### PR TITLE
limitador-server: release 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.0.0-beta.18"
+version = "3.0.0-beta.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b95871724d27ac9a23d6db3246b23e4e42cd44a23145e1c6b04b78fb5271da"
+checksum = "ae58d21721388ea9b2cd0d4c11756b0f34424cdcd6e5cc74c3ce37b4641c8af0"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -32,7 +32,7 @@ dependencies = [
  "ahash",
  "base64",
  "bitflags",
- "brotli2",
+ "brotli",
  "bytes",
  "bytestring",
  "derive_more",
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "actix-router"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bdca166b1041184e2108ef05bd9909ec18cc6abc41152d31d30224cebfaac75"
+checksum = "5e0b59ad08167ffbb686ddb495846707231e96908b829b1fc218198ec581e2ad"
 dependencies = [
  "bytestring",
  "firestorm",
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.0.0-beta.20"
+version = "4.0.0-beta.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8ba5081e9f8d0016cf34df516c699198158fd8c77990aa284115b055ead61b"
+checksum = "606fc29a9bde2907243086ceb93ce56df7584276c2c46abc64a524f645c63c5e"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -218,10 +218,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.52"
+name = "alloc-no-stdlib"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+checksum = "35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "arc-swap"
@@ -300,23 +315,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli-sys"
-version = "0.3.2"
+name = "brotli"
+version = "3.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
+checksum = "f838e47a451d5a8fa552371f80024dd6ace9b7acdf25c4c3d0f9bc6816fb1c39"
 dependencies = [
- "cc",
- "libc",
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
 ]
 
 [[package]]
-name = "brotli2"
-version = "0.3.2"
+name = "brotli-decompressor"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
+checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
 dependencies = [
- "brotli-sys",
- "libc",
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -623,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
@@ -797,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
 dependencies = [
  "bytes",
  "fnv",
@@ -1037,9 +1053,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "limitador"
@@ -1112,9 +1128,9 @@ checksum = "902eb695eb0591864543cbfbf6d742510642a605a61fc5e97fe6ceb5a30ac4fb"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
  "serde",
@@ -1255,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a1eb3a36534514077c1e079ada2fb170ef30c47d203aa6916138cf882ecd52"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
 dependencies = [
  "libc",
 ]
@@ -1310,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "paperclip"
 version = "0.6.1"
-source = "git+https://github.com/sfisol/paperclip?rev=99db92949e95287fbeb8f3ea844291f1810cccee#99db92949e95287fbeb8f3ea844291f1810cccee"
+source = "git+https://github.com/sfisol/paperclip?rev=2522f12ecbc78055ab5bcfc5b7f033d21be2f794#2522f12ecbc78055ab5bcfc5b7f033d21be2f794"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1331,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "paperclip-actix"
 version = "0.4.2"
-source = "git+https://github.com/sfisol/paperclip?rev=99db92949e95287fbeb8f3ea844291f1810cccee#99db92949e95287fbeb8f3ea844291f1810cccee"
+source = "git+https://github.com/sfisol/paperclip?rev=2522f12ecbc78055ab5bcfc5b7f033d21be2f794#2522f12ecbc78055ab5bcfc5b7f033d21be2f794"
 dependencies = [
  "actix-service 1.0.6",
  "actix-service 2.0.2",
@@ -1347,7 +1363,7 @@ dependencies = [
 [[package]]
 name = "paperclip-core"
 version = "0.4.1"
-source = "git+https://github.com/sfisol/paperclip?rev=99db92949e95287fbeb8f3ea844291f1810cccee#99db92949e95287fbeb8f3ea844291f1810cccee"
+source = "git+https://github.com/sfisol/paperclip?rev=2522f12ecbc78055ab5bcfc5b7f033d21be2f794#2522f12ecbc78055ab5bcfc5b7f033d21be2f794"
 dependencies = [
  "actix-web",
  "mime",
@@ -1365,7 +1381,7 @@ dependencies = [
 [[package]]
 name = "paperclip-macros"
 version = "0.5.1"
-source = "git+https://github.com/sfisol/paperclip?rev=99db92949e95287fbeb8f3ea844291f1810cccee#99db92949e95287fbeb8f3ea844291f1810cccee"
+source = "git+https://github.com/sfisol/paperclip?rev=2522f12ecbc78055ab5bcfc5b7f033d21be2f794#2522f12ecbc78055ab5bcfc5b7f033d21be2f794"
 dependencies = [
  "heck",
  "http",
@@ -1630,15 +1646,15 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.25.2"
+version = "2.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c327e191621a2158159df97cdbc2e7074bb4e940275e35abf38eb3d2595754"
+checksum = "9d613b4fd96c0182e187734b4f8fc5cbc8c940bbf781819f7a52d42dc5922d25"
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -1828,6 +1844,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1869,9 +1891,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09d3c15d814eda1d6a836f2f2b56a6abc1446c8a34351cb3180d3db92ffe4ce"
+checksum = "3fed7948b6c68acbb6e20c334f55ad635dc0f75506963de4464289fbd3b051ac"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1882,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90dd10c41c6bfc633da6e0c659bd25d31e0791e5974ac42970267d59eba87f7"
+checksum = "a57321bf8bc2362081b2599912d2961fe899c0efadf1b4b2f8d48b3e253bb96c"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1916,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.134"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b3c34c1690edf8174f5b289a336ab03f568a4460d8c6df75f2f3a692b3bc6a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -1935,9 +1957,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.134"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784ed1fbfa13fe191077537b0d70ec8ad1e903cfe04831da608aa36457cb653d"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1946,9 +1968,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.75"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -2050,9 +2072,9 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "socket2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f82496b90c36d70af5fcd482edaa2e0bd16fade569de1330405fecbbdac736b"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
@@ -2060,19 +2082,20 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
+checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
 
 [[package]]
 name = "strum_macros"
-version = "0.22.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
+checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn",
 ]
 
@@ -2141,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d54b9298e05179c335de2b9645d061255bcd5155f843b3e328d2cfe0a5b413"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
 dependencies = [
  "itoa 1.0.1",
  "libc",
@@ -2184,9 +2207,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
  "bytes",
  "libc",
@@ -2571,9 +2594,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.2"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
 dependencies = [
  "either",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "limitador-server"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/limitador-server/CHANGELOG.md
+++ b/limitador-server/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Notable changes to the Limitador server will be tracked in this document.
 
+## 0.5.0 - 2022-01-31
+
+### Added
+
+- Support for Infinispan (tested with 11.0.9.Final). You can enable it via the
+`INFINISPAN_URL` env variable. [#38](https://github.com/kuadrant/limitador/pull/38),
+[#40](https://github.com/kuadrant/limitador/pull/40), [#44](https://github.com/kuadrant/limitador/pull/44),
+[#45](https://github.com/kuadrant/limitador/pull/45).
+
+### Changed
+
+- Moved to the Tokio 1 async reactor. [#54](https://github.com/kuadrant/limitador/pull/54).
+
 ## 0.4.0 - 2021-03-08
 
 ### Added

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -25,9 +25,9 @@ serde_yaml = "0.8"
 log = "0.4"
 env_logger = "0.9"
 url = "2"
-actix-web = "= 4.0.0-beta.20"
+actix-web = "4.0.0-beta.20"
 actix-rt = "2"
-paperclip = { git = "https://github.com/sfisol/paperclip", rev = "99db92949e95287fbeb8f3ea844291f1810cccee", features = ["actix"] }
+paperclip = { git = "https://github.com/sfisol/paperclip", rev = "2522f12ecbc78055ab5bcfc5b7f033d21be2f794", features = ["actix"] }
 serde = { version = "1", features = ["derive"] }
 
 [build-dependencies]

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limitador-server"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["David Ortiz <z.david.ortiz@gmail.com>"]
 license = "Apache-2.0"
 keywords = ["rate-limiting", "rate", "limiter", "envoy", "rls"]

--- a/limitador-server/kubernetes/limitador-deployment.yaml
+++ b/limitador-server/kubernetes/limitador-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: limitador
-          image: quay.io/3scale/limitador:0.4.0
+          image: quay.io/3scale/limitador:0.5.0
           imagePullPolicy: IfNotPresent
           env:
             - name: RUST_LOG

--- a/limitador-server/src/envoy_rls/server.rs
+++ b/limitador-server/src/envoy_rls/server.rs
@@ -17,8 +17,8 @@ pub struct MyRateLimiter {
 }
 
 impl MyRateLimiter {
-    pub fn new(limiter: Arc<Limiter>) -> MyRateLimiter {
-        MyRateLimiter { limiter }
+    pub fn new(limiter: Arc<Limiter>) -> Self {
+        Self { limiter }
     }
 }
 

--- a/limitador-server/src/envoy_rls/server.rs
+++ b/limitador-server/src/envoy_rls/server.rs
@@ -257,7 +257,7 @@ mod tests {
             Limit::new(namespace, 0, 60, vec!["x == 1", "y == 2"], vec!["z"]),
         ]
         .iter()
-        .for_each(|limit| limiter.add_limit(&limit).unwrap());
+        .for_each(|limit| limiter.add_limit(limit).unwrap());
 
         let rate_limiter = MyRateLimiter::new(Arc::new(Limiter::Blocking(limiter)));
 

--- a/limitador-server/src/http_api/request_types.rs
+++ b/limitador-server/src/http_api/request_types.rs
@@ -40,7 +40,7 @@ impl From<&LimitadorLimit> for Limit {
 
 impl From<Limit> for LimitadorLimit {
     fn from(limit: Limit) -> Self {
-        let mut limitador_limit = LimitadorLimit::new(
+        let mut limitador_limit = Self::new(
             limit.namespace.as_str(),
             limit.max_value,
             limit.seconds,

--- a/limitador-server/src/http_api/server.rs
+++ b/limitador-server/src/http_api/server.rs
@@ -269,10 +269,10 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_status() {
-        let mut app = test::init_service(App::new().route("/status", web::get().to(status))).await;
+        let app = test::init_service(App::new().route("/status", web::get().to(status))).await;
 
         let req = test::TestRequest::with_uri("/status").to_request();
-        let resp = test::call_service(&mut app, req).await;
+        let resp = test::call_service(&app, req).await;
 
         assert!(resp.status().is_success());
     }
@@ -281,7 +281,7 @@ mod tests {
     async fn test_metrics() {
         let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await.unwrap());
         let data = web::Data::new(rate_limiter);
-        let mut app = test::init_service(
+        let app = test::init_service(
             App::new()
                 .app_data(data.clone())
                 .route("/metrics", web::get().to(metrics)),
@@ -289,7 +289,7 @@ mod tests {
         .await;
 
         let req = test::TestRequest::get().uri("/metrics").to_request();
-        let resp = test::call_and_read_body(&mut app, req).await;
+        let resp = test::call_and_read_body(&app, req).await;
         let resp_string = String::from_utf8(resp.to_vec()).unwrap();
 
         // No need to check the whole output. We just want to make sure that it
@@ -301,7 +301,7 @@ mod tests {
     async fn test_limits_create_read_delete() {
         let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await.unwrap());
         let data = web::Data::new(rate_limiter);
-        let mut app = test::init_service(
+        let app = test::init_service(
             App::new()
                 .app_data(data.clone())
                 .route("/limits", web::post().to(create_limit))
@@ -325,7 +325,7 @@ mod tests {
             .data(data.clone())
             .set_json(&limit)
             .to_request();
-        let resp = test::call_service(&mut app, req).await;
+        let resp = test::call_service(&app, req).await;
         assert!(resp.status().is_success());
 
         // Read limit created
@@ -333,7 +333,7 @@ mod tests {
             .uri(&format!("/limits/{}", namespace))
             .data(data.clone())
             .to_request();
-        let resp_limits: Vec<Limit> = test::call_and_read_body_json(&mut app, req).await;
+        let resp_limits: Vec<Limit> = test::call_and_read_body_json(&app, req).await;
         assert_eq!(resp_limits.len(), 1);
         assert_eq!(*resp_limits.get(0).unwrap(), limit);
 
@@ -343,7 +343,7 @@ mod tests {
             .data(data.clone())
             .set_json(&limit)
             .to_request();
-        let resp = test::call_service(&mut app, req).await;
+        let resp = test::call_service(&app, req).await;
         assert!(resp.status().is_success());
 
         // Check that the list is now empty
@@ -351,7 +351,7 @@ mod tests {
             .uri(&format!("/limits/{}", namespace))
             .data(data.clone())
             .to_request();
-        let resp_limits: Vec<Limit> = test::call_and_read_body_json(&mut app, req).await;
+        let resp_limits: Vec<Limit> = test::call_and_read_body_json(&app, req).await;
         assert!(resp_limits.is_empty());
     }
 
@@ -359,7 +359,7 @@ mod tests {
     async fn test_create_limit_with_name() {
         let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await.unwrap());
         let data = web::Data::new(rate_limiter);
-        let mut app = test::init_service(
+        let app = test::init_service(
             App::new()
                 .app_data(data.clone())
                 .route("/limits", web::post().to(create_limit))
@@ -381,7 +381,7 @@ mod tests {
             .data(data.clone())
             .set_json(&limit)
             .to_request();
-        let resp = test::call_service(&mut app, req).await;
+        let resp = test::call_service(&app, req).await;
         assert!(resp.status().is_success());
 
         // Read limit created
@@ -389,7 +389,7 @@ mod tests {
             .uri(&format!("/limits/{}", namespace))
             .data(data.clone())
             .to_request();
-        let resp_limits: Vec<Limit> = test::call_and_read_body_json(&mut app, req).await;
+        let resp_limits: Vec<Limit> = test::call_and_read_body_json(&app, req).await;
         assert_eq!(resp_limits.len(), 1);
         assert_eq!(*resp_limits.get(0).unwrap(), limit);
     }
@@ -398,7 +398,7 @@ mod tests {
     async fn test_delete_all_limits_of_namespace() {
         let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await.unwrap());
         let data = web::Data::new(rate_limiter);
-        let mut app = test::init_service(
+        let app = test::init_service(
             App::new()
                 .app_data(data.clone())
                 .route("/limits", web::post().to(create_limit))
@@ -433,7 +433,7 @@ mod tests {
                 .data(data.clone())
                 .set_json(&limit)
                 .to_request();
-            let resp = test::call_service(&mut app, req).await;
+            let resp = test::call_service(&app, req).await;
             assert!(resp.status().is_success());
         }
 
@@ -442,7 +442,7 @@ mod tests {
             .uri(&format!("/limits/{}", namespace))
             .data(data.clone())
             .to_request();
-        let resp = test::call_service(&mut app, req).await;
+        let resp = test::call_service(&app, req).await;
         assert!(resp.status().is_success());
 
         // Check that the list is now empty
@@ -450,7 +450,7 @@ mod tests {
             .uri(&format!("/limits/{}", namespace))
             .data(data.clone())
             .to_request();
-        let resp_limits: Vec<Limit> = test::call_and_read_body_json(&mut app, req).await;
+        let resp_limits: Vec<Limit> = test::call_and_read_body_json(&app, req).await;
         assert!(resp_limits.is_empty());
     }
 
@@ -458,7 +458,7 @@ mod tests {
     async fn test_check_and_report() {
         let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await.unwrap());
         let data = web::Data::new(rate_limiter);
-        let mut app = test::init_service(
+        let app = test::init_service(
             App::new()
                 .app_data(data.clone())
                 .route("/limits", web::post().to(create_limit))
@@ -483,7 +483,7 @@ mod tests {
             .data(data.clone())
             .set_json(&limit)
             .to_request();
-        let resp = test::call_service(&mut app, req).await;
+        let resp = test::call_service(&app, req).await;
         assert!(resp.status().is_success());
 
         // Prepare values to check
@@ -502,7 +502,7 @@ mod tests {
             .data(data.clone())
             .set_json(&info)
             .to_request();
-        let resp = test::call_service(&mut app, req).await;
+        let resp = test::call_service(&app, req).await;
         assert!(resp.status().is_success());
 
         // The second request should be rate-limited
@@ -511,7 +511,7 @@ mod tests {
             .data(data.clone())
             .set_json(&info)
             .to_request();
-        let resp = test::call_service(&mut app, req).await;
+        let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
     }
 
@@ -519,7 +519,7 @@ mod tests {
     async fn test_check_and_report_endpoints_separately() {
         let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await.unwrap());
         let data = web::Data::new(rate_limiter);
-        let mut app = test::init_service(
+        let app = test::init_service(
             App::new()
                 .app_data(data.clone())
                 .route("/limits", web::post().to(create_limit))
@@ -545,7 +545,7 @@ mod tests {
             .data(data.clone())
             .set_json(&limit)
             .to_request();
-        let resp = test::call_service(&mut app, req).await;
+        let resp = test::call_service(&app, req).await;
         assert!(resp.status().is_success());
 
         // Prepare values to check
@@ -564,7 +564,7 @@ mod tests {
             .data(data.clone())
             .set_json(&info)
             .to_request();
-        let resp = test::call_service(&mut app, req).await;
+        let resp = test::call_service(&app, req).await;
         assert!(resp.status().is_success());
 
         // Do the first report
@@ -573,7 +573,7 @@ mod tests {
             .data(data.clone())
             .set_json(&info)
             .to_request();
-        let resp = test::call_service(&mut app, req).await;
+        let resp = test::call_service(&app, req).await;
         assert!(resp.status().is_success());
 
         // Should be rate-limited now
@@ -582,7 +582,7 @@ mod tests {
             .data(data.clone())
             .set_json(&info)
             .to_request();
-        let resp = test::call_service(&mut app, req).await;
+        let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
     }
 }

--- a/limitador/src/counter.rs
+++ b/limitador/src/counter.rs
@@ -26,13 +26,13 @@ where
 }
 
 impl Counter {
-    pub fn new(limit: Limit, set_variables: HashMap<String, String>) -> Counter {
+    pub fn new(limit: Limit, set_variables: HashMap<String, String>) -> Self {
         // TODO: check that all the variables defined in the limit are set.
 
         let mut vars = set_variables;
         vars.retain(|var, _| limit.has_variable(var));
 
-        Counter {
+        Self {
             limit,
             set_variables: vars,
             remaining: None,

--- a/limitador/src/errors.rs
+++ b/limitador/src/errors.rs
@@ -9,6 +9,6 @@ pub enum LimitadorError {
 
 impl From<StorageErr> for LimitadorError {
     fn from(e: StorageErr) -> Self {
-        LimitadorError::Storage(e.msg().to_owned())
+        Self::Storage(e.msg().to_owned())
     }
 }

--- a/limitador/src/limit.rs
+++ b/limitador/src/limit.rs
@@ -215,7 +215,7 @@ mod tests {
         values.insert("x".into(), "1".into());
         values.insert("y".into(), "1".into());
 
-        assert_eq!(false, limit.applies(&values))
+        assert!(!limit.applies(&values))
     }
 
     #[test]
@@ -227,7 +227,7 @@ mod tests {
         values.insert("a".into(), "1".into());
         values.insert("y".into(), "1".into());
 
-        assert_eq!(false, limit.applies(&values))
+        assert!(!limit.applies(&values))
     }
 
     #[test]
@@ -238,7 +238,7 @@ mod tests {
         let mut values: HashMap<String, String> = HashMap::new();
         values.insert("x".into(), "5".into());
 
-        assert_eq!(false, limit.applies(&values))
+        assert!(!limit.applies(&values))
     }
 
     #[test]
@@ -274,6 +274,6 @@ mod tests {
         values.insert("y".into(), "2".into());
         values.insert("z".into(), "1".into());
 
-        assert_eq!(false, limit.applies(&values))
+        assert!(!limit.applies(&values))
     }
 }

--- a/limitador/src/prometheus_metrics.rs
+++ b/limitador/src/prometheus_metrics.rs
@@ -140,8 +140,8 @@ mod tests {
         let prometheus_metrics = PrometheusMetrics::new();
 
         let namespaces_with_auth_counts = [
-            (Namespace::from("some_namespace"), 2),
-            (Namespace::from("another_namespace"), 3),
+            ("some_namespace".parse().unwrap(), 2),
+            ("another_namespace".parse().unwrap(), 3),
         ];
 
         namespaces_with_auth_counts
@@ -170,8 +170,8 @@ mod tests {
         let prometheus_metrics = PrometheusMetrics::new();
 
         let namespaces_with_limited_counts = [
-            (Namespace::from("some_namespace"), 2),
-            (Namespace::from("another_namespace"), 3),
+            ("some_namespace".parse().unwrap(), 2),
+            ("another_namespace".parse().unwrap(), 3),
         ];
 
         namespaces_with_limited_counts
@@ -200,8 +200,8 @@ mod tests {
         let prometheus_metrics = PrometheusMetrics::new_with_counters_by_limit_name();
 
         let limits_with_counts = [
-            (Namespace::from("some_namespace"), "Some limit", 2),
-            (Namespace::from("some_namespace"), "Another limit", 3),
+            ("some_namespace".parse().unwrap(), "Some limit", 2),
+            ("some_namespace".parse().unwrap(), "Another limit", 3),
         ];
 
         limits_with_counts
@@ -231,7 +231,7 @@ mod tests {
     #[test]
     fn incr_limited_calls_uses_empty_string_when_no_name() {
         let prometheus_metrics = PrometheusMetrics::new_with_counters_by_limit_name();
-        let namespace = Namespace::from("some namespace");
+        let namespace = "some namespace".parse().unwrap();
         prometheus_metrics.incr_limited_calls(&namespace, None);
 
         let metrics_output = prometheus_metrics.gather_metrics();

--- a/limitador/src/storage/in_memory.rs
+++ b/limitador/src/storage/in_memory.rs
@@ -132,8 +132,8 @@ impl Storage for InMemoryStorage {
 }
 
 impl InMemoryStorage {
-    pub fn new(capacity: usize) -> InMemoryStorage {
-        InMemoryStorage {
+    pub fn new(capacity: usize) -> Self {
+        Self {
             limits_for_namespace: RwLock::new(HashMap::new()),
             counters: RwLock::new(TtlCache::new(capacity)),
         }

--- a/limitador/src/storage/infinispan/counters.rs
+++ b/limitador/src/storage/infinispan/counters.rs
@@ -40,8 +40,8 @@ impl TryFrom<String> for Consistency {
         value.make_ascii_lowercase();
 
         match value.as_str() {
-            "weak" => Ok(Consistency::Weak),
-            "strong" => Ok(Consistency::Strong),
+            "weak" => Ok(Self::Weak),
+            "strong" => Ok(Self::Strong),
             _ => Err(InvalidConsistencyErr { mode: value }),
         }
     }
@@ -55,7 +55,7 @@ pub struct CounterOpts {
 
 impl CounterOpts {
     pub fn new(initial_value: i64, ttl: Duration, consistency: Consistency) -> Self {
-        CounterOpts {
+        Self {
             initial_value,
             ttl,
             consistency,

--- a/limitador/src/storage/infinispan/infinispan_storage.rs
+++ b/limitador/src/storage/infinispan/infinispan_storage.rs
@@ -35,7 +35,7 @@ impl AsyncStorage for InfinispanStorage {
             .get_set(key_for_namespaces_set())
             .await?
             .iter()
-            .map(|ns| Namespace::from(ns.as_ref()))
+            .map(|ns| ns.parse().unwrap())
             .collect())
     }
 
@@ -222,11 +222,11 @@ impl InfinispanStorage {
         password: &str,
         cache_name: Option<String>,
         counters_consistency: Consistency,
-    ) -> InfinispanStorage {
+    ) -> Self {
         let infinispan = Infinispan::new(url, username, password);
 
         match cache_name {
-            Some(cache_name) => InfinispanStorage {
+            Some(cache_name) => Self {
                 infinispan,
                 cache_name,
                 counters_consistency,
@@ -239,7 +239,7 @@ impl InfinispanStorage {
                     .await
                     .unwrap();
 
-                InfinispanStorage {
+                Self {
                     infinispan,
                     cache_name: cache_name.into(),
                     counters_consistency,

--- a/limitador/src/storage/infinispan/mod.rs
+++ b/limitador/src/storage/infinispan/mod.rs
@@ -12,12 +12,12 @@ pub use infinispan_storage::InfinispanStorageBuilder;
 
 impl From<reqwest::Error> for StorageErr {
     fn from(e: reqwest::Error) -> Self {
-        StorageErr { msg: e.to_string() }
+        Self { msg: e.to_string() }
     }
 }
 
 impl From<InfinispanError> for StorageErr {
     fn from(e: InfinispanError) -> Self {
-        StorageErr { msg: e.to_string() }
+        Self { msg: e.to_string() }
     }
 }

--- a/limitador/src/storage/redis/batcher.rs
+++ b/limitador/src/storage/redis/batcher.rs
@@ -10,8 +10,8 @@ pub struct Batcher {
 }
 
 impl Batcher {
-    pub fn new(redis_storage: AsyncRedisStorage) -> Batcher {
-        Batcher {
+    pub fn new(redis_storage: AsyncRedisStorage) -> Self {
+        Self {
             accumulated_counter_updates: Mutex::new(HashMap::new()),
             redis_storage,
         }

--- a/limitador/src/storage/redis/counters_cache.rs
+++ b/limitador/src/storage/redis/counters_cache.rs
@@ -19,31 +19,25 @@ pub struct CountersCacheBuilder {
 }
 
 impl CountersCacheBuilder {
-    pub fn new() -> CountersCacheBuilder {
-        CountersCacheBuilder {
+    pub fn new() -> Self {
+        Self {
             max_cached_counters: DEFAULT_MAX_CACHED_COUNTERS,
             max_ttl_cached_counters: DEFAULT_MAX_TTL_CACHED_COUNTERS,
             ttl_ratio_cached_counters: DEFAULT_TTL_RATIO_CACHED_COUNTERS,
         }
     }
 
-    pub fn max_cached_counters(mut self, max_cached_counters: usize) -> CountersCacheBuilder {
+    pub fn max_cached_counters(mut self, max_cached_counters: usize) -> Self {
         self.max_cached_counters = max_cached_counters;
         self
     }
 
-    pub fn max_ttl_cached_counter(
-        mut self,
-        max_ttl_cached_counter: Duration,
-    ) -> CountersCacheBuilder {
+    pub fn max_ttl_cached_counter(mut self, max_ttl_cached_counter: Duration) -> Self {
         self.max_ttl_cached_counters = max_ttl_cached_counter;
         self
     }
 
-    pub fn ttl_ratio_cached_counter(
-        mut self,
-        ttl_ratio_cached_counter: u64,
-    ) -> CountersCacheBuilder {
+    pub fn ttl_ratio_cached_counter(mut self, ttl_ratio_cached_counter: u64) -> Self {
         self.ttl_ratio_cached_counters = ttl_ratio_cached_counter;
         self
     }

--- a/limitador/src/storage/redis/mod.rs
+++ b/limitador/src/storage/redis/mod.rs
@@ -15,12 +15,12 @@ pub use redis_sync::RedisStorage;
 
 impl From<RedisError> for StorageErr {
     fn from(e: RedisError) -> Self {
-        StorageErr { msg: e.to_string() }
+        Self { msg: e.to_string() }
     }
 }
 
 impl From<::r2d2::Error> for StorageErr {
     fn from(e: ::r2d2::Error) -> Self {
-        StorageErr { msg: e.to_string() }
+        Self { msg: e.to_string() }
     }
 }

--- a/limitador/src/storage/redis/redis_async.rs
+++ b/limitador/src/storage/redis/redis_async.rs
@@ -36,10 +36,7 @@ impl AsyncStorage for AsyncRedisStorage {
             .smembers::<String, HashSet<String>>(key_for_namespaces_set())
             .await?;
 
-        Ok(namespaces
-            .iter()
-            .map(|ns| Namespace::from(ns.as_ref()))
-            .collect())
+        Ok(namespaces.iter().map(|ns| ns.parse().unwrap()).collect())
     }
 
     async fn add_limit(&self, limit: &Limit) -> Result<(), StorageErr> {
@@ -215,8 +212,8 @@ impl AsyncStorage for AsyncRedisStorage {
 }
 
 impl AsyncRedisStorage {
-    pub async fn new(redis_url: &str) -> AsyncRedisStorage {
-        AsyncRedisStorage {
+    pub async fn new(redis_url: &str) -> Self {
+        Self {
             conn_manager: ConnectionManager::new(
                 redis::Client::open(ConnectionInfo::from_str(redis_url).unwrap()).unwrap(),
             )
@@ -225,8 +222,8 @@ impl AsyncRedisStorage {
         }
     }
 
-    pub fn new_with_conn_manager(conn_manager: ConnectionManager) -> AsyncRedisStorage {
-        AsyncRedisStorage { conn_manager }
+    pub fn new_with_conn_manager(conn_manager: ConnectionManager) -> Self {
+        Self { conn_manager }
     }
 
     async fn delete_counters_of_namespace(&self, namespace: &Namespace) -> Result<(), StorageErr> {

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -199,7 +199,7 @@ impl AsyncStorage for CachedRedisStorage {
 }
 
 impl CachedRedisStorage {
-    pub async fn new(redis_url: &str) -> CachedRedisStorage {
+    pub async fn new(redis_url: &str) -> Self {
         Self::new_with_options(
             redis_url,
             DEFAULT_MAX_CACHED_NAMESPACES,
@@ -220,7 +220,7 @@ impl CachedRedisStorage {
         max_cached_counters: usize,
         ttl_cached_counters: Duration,
         ttl_ratio_cached_counters: u64,
-    ) -> CachedRedisStorage {
+    ) -> Self {
         let redis_conn_manager = ConnectionManager::new(
             redis::Client::open(ConnectionInfo::from_str(redis_url).unwrap()).unwrap(),
         )
@@ -251,7 +251,7 @@ impl CachedRedisStorage {
             .ttl_ratio_cached_counter(ttl_ratio_cached_counters)
             .build();
 
-        CachedRedisStorage {
+        Self {
             cached_limits_by_namespace: Mutex::new(TtlCache::new(max_cached_namespaces)),
             ttl_cached_limits,
             cached_counters: Mutex::new(cached_counters),
@@ -305,8 +305,8 @@ pub struct CachedRedisStorageBuilder {
 }
 
 impl CachedRedisStorageBuilder {
-    pub fn new(redis_url: &str) -> CachedRedisStorageBuilder {
-        CachedRedisStorageBuilder {
+    pub fn new(redis_url: &str) -> Self {
+        Self {
             redis_url: redis_url.to_string(),
             max_cached_namespaces: DEFAULT_MAX_CACHED_NAMESPACES,
             ttl_cached_limits: DEFAULT_TTL_CACHED_LIMITS,
@@ -317,44 +317,32 @@ impl CachedRedisStorageBuilder {
         }
     }
 
-    pub fn max_cached_namespaces(
-        mut self,
-        max_cached_namespaces: usize,
-    ) -> CachedRedisStorageBuilder {
+    pub fn max_cached_namespaces(mut self, max_cached_namespaces: usize) -> Self {
         self.max_cached_namespaces = max_cached_namespaces;
         self
     }
 
-    pub fn ttl_cached_limits(mut self, ttl_cached_limits: Duration) -> CachedRedisStorageBuilder {
+    pub fn ttl_cached_limits(mut self, ttl_cached_limits: Duration) -> Self {
         self.ttl_cached_limits = ttl_cached_limits;
         self
     }
 
-    pub fn flushing_period(
-        mut self,
-        flushing_period: Option<Duration>,
-    ) -> CachedRedisStorageBuilder {
+    pub fn flushing_period(mut self, flushing_period: Option<Duration>) -> Self {
         self.flushing_period = flushing_period;
         self
     }
 
-    pub fn max_cached_counters(mut self, max_cached_counters: usize) -> CachedRedisStorageBuilder {
+    pub fn max_cached_counters(mut self, max_cached_counters: usize) -> Self {
         self.max_cached_counters = max_cached_counters;
         self
     }
 
-    pub fn max_ttl_cached_counters(
-        mut self,
-        max_ttl_cached_counters: Duration,
-    ) -> CachedRedisStorageBuilder {
+    pub fn max_ttl_cached_counters(mut self, max_ttl_cached_counters: Duration) -> Self {
         self.max_ttl_cached_counters = max_ttl_cached_counters;
         self
     }
 
-    pub fn ttl_ratio_cached_counters(
-        mut self,
-        ttl_ratio_cached_counters: u64,
-    ) -> CachedRedisStorageBuilder {
+    pub fn ttl_ratio_cached_counters(mut self, ttl_ratio_cached_counters: u64) -> Self {
         self.ttl_ratio_cached_counters = ttl_ratio_cached_counters;
         self
     }

--- a/limitador/src/storage/redis/redis_sync.rs
+++ b/limitador/src/storage/redis/redis_sync.rs
@@ -27,10 +27,7 @@ impl Storage for RedisStorage {
 
         let namespaces = con.smembers::<String, HashSet<String>>(key_for_namespaces_set())?;
 
-        Ok(namespaces
-            .iter()
-            .map(|ns| Namespace::from(ns.as_ref()))
-            .collect())
+        Ok(namespaces.iter().map(|ns| ns.parse().unwrap()).collect())
     }
 
     fn add_limit(&self, limit: &Limit) -> Result<(), StorageErr> {
@@ -196,7 +193,7 @@ impl Storage for RedisStorage {
 }
 
 impl RedisStorage {
-    pub fn new(redis_url: &str) -> RedisStorage {
+    pub fn new(redis_url: &str) -> Self {
         let conn_manager = RedisConnectionManager::new(redis_url).unwrap();
         let conn_pool = Pool::builder()
             .connection_timeout(Duration::from_secs(3))
@@ -204,7 +201,7 @@ impl RedisStorage {
             .build(conn_manager)
             .unwrap();
 
-        RedisStorage { conn_pool }
+        Self { conn_pool }
     }
 
     fn delete_counters_of_namespace(&self, namespace: &Namespace) -> Result<(), StorageErr> {
@@ -239,8 +236,8 @@ pub struct RedisConnectionManager {
 }
 
 impl RedisConnectionManager {
-    pub fn new<T: IntoConnectionInfo>(params: T) -> Result<RedisConnectionManager, RedisError> {
-        Ok(RedisConnectionManager {
+    pub fn new<T: IntoConnectionInfo>(params: T) -> Result<Self, RedisError> {
+        Ok(Self {
             connection_info: params.into_connection_info()?,
         })
     }
@@ -268,7 +265,7 @@ impl ManageConnection for RedisConnectionManager {
 
 impl Default for RedisStorage {
     fn default() -> Self {
-        RedisStorage::new(DEFAULT_REDIS_URL)
+        Self::new(DEFAULT_REDIS_URL)
     }
 }
 

--- a/limitador/tests/helpers/tests_limiter.rs
+++ b/limitador/tests/helpers/tests_limiter.rs
@@ -55,15 +55,27 @@ impl TestsLimiter {
 
     pub async fn get_limits(&self, namespace: &str) -> Result<HashSet<Limit>, LimitadorError> {
         match &self.limiter_impl {
-            LimiterImpl::Blocking(limiter) => limiter.get_limits(namespace),
-            LimiterImpl::Async(limiter) => limiter.get_limits(namespace).await,
+            LimiterImpl::Blocking(limiter) => {
+                limiter.get_limits(namespace.parse::<Namespace>().unwrap())
+            }
+            LimiterImpl::Async(limiter) => {
+                limiter
+                    .get_limits(namespace.parse::<Namespace>().unwrap())
+                    .await
+            }
         }
     }
 
     pub async fn delete_limits(&self, namespace: &str) -> Result<(), LimitadorError> {
         match &self.limiter_impl {
-            LimiterImpl::Blocking(limiter) => limiter.delete_limits(namespace),
-            LimiterImpl::Async(limiter) => limiter.delete_limits(namespace).await,
+            LimiterImpl::Blocking(limiter) => {
+                limiter.delete_limits(namespace.parse::<Namespace>().unwrap())
+            }
+            LimiterImpl::Async(limiter) => {
+                limiter
+                    .delete_limits(namespace.parse::<Namespace>().unwrap())
+                    .await
+            }
         }
     }
 
@@ -74,8 +86,14 @@ impl TestsLimiter {
         delta: i64,
     ) -> Result<bool, LimitadorError> {
         match &self.limiter_impl {
-            LimiterImpl::Blocking(limiter) => limiter.is_rate_limited(namespace, values, delta),
-            LimiterImpl::Async(limiter) => limiter.is_rate_limited(namespace, values, delta).await,
+            LimiterImpl::Blocking(limiter) => {
+                limiter.is_rate_limited(namespace.parse::<Namespace>().unwrap(), values, delta)
+            }
+            LimiterImpl::Async(limiter) => {
+                limiter
+                    .is_rate_limited(namespace.parse::<Namespace>().unwrap(), values, delta)
+                    .await
+            }
         }
     }
 
@@ -86,8 +104,14 @@ impl TestsLimiter {
         delta: i64,
     ) -> Result<(), LimitadorError> {
         match &self.limiter_impl {
-            LimiterImpl::Blocking(limiter) => limiter.update_counters(namespace, values, delta),
-            LimiterImpl::Async(limiter) => limiter.update_counters(namespace, values, delta).await,
+            LimiterImpl::Blocking(limiter) => {
+                limiter.update_counters(namespace.parse::<Namespace>().unwrap(), values, delta)
+            }
+            LimiterImpl::Async(limiter) => {
+                limiter
+                    .update_counters(namespace.parse::<Namespace>().unwrap(), values, delta)
+                    .await
+            }
         }
     }
 
@@ -98,12 +122,18 @@ impl TestsLimiter {
         delta: i64,
     ) -> Result<bool, LimitadorError> {
         match &self.limiter_impl {
-            LimiterImpl::Blocking(limiter) => {
-                limiter.check_rate_limited_and_update(namespace, values, delta)
-            }
+            LimiterImpl::Blocking(limiter) => limiter.check_rate_limited_and_update(
+                namespace.parse::<Namespace>().unwrap(),
+                values,
+                delta,
+            ),
             LimiterImpl::Async(limiter) => {
                 limiter
-                    .check_rate_limited_and_update(namespace, values, delta)
+                    .check_rate_limited_and_update(
+                        namespace.parse::<Namespace>().unwrap(),
+                        values,
+                        delta,
+                    )
                     .await
             }
         }
@@ -111,8 +141,14 @@ impl TestsLimiter {
 
     pub async fn get_counters(&self, namespace: &str) -> Result<HashSet<Counter>, LimitadorError> {
         match &self.limiter_impl {
-            LimiterImpl::Blocking(limiter) => limiter.get_counters(namespace),
-            LimiterImpl::Async(limiter) => limiter.get_counters(namespace).await,
+            LimiterImpl::Blocking(limiter) => {
+                limiter.get_counters(namespace.parse::<Namespace>().unwrap())
+            }
+            LimiterImpl::Async(limiter) => {
+                limiter
+                    .get_counters(namespace.parse::<Namespace>().unwrap())
+                    .await
+            }
         }
     }
 

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -94,7 +94,6 @@ mod test {
     use self::limitador::RateLimiter;
     use crate::helpers::tests_limiter::*;
     use limitador::limit::Limit;
-    use limitador::limit::Namespace;
     use limitador::storage::in_memory::InMemoryStorage;
     use limitador::storage::wasm::WasmStorage;
     use std::collections::{HashMap, HashSet};
@@ -170,7 +169,7 @@ mod test {
                 .get_namespaces()
                 .await
                 .unwrap()
-                .contains(&Namespace::from(ns)));
+                .contains(&ns.parse().unwrap()));
         }
     }
 
@@ -206,12 +205,12 @@ mod test {
             .get_namespaces()
             .await
             .unwrap()
-            .contains(&Namespace::from("first_namespace")));
+            .contains(&"first_namespace".parse().unwrap()));
         assert!(!rate_limiter
             .get_namespaces()
             .await
             .unwrap()
-            .contains(&Namespace::from("second_namespace")));
+            .contains(&"second_namespace".parse().unwrap()));
     }
 
     async fn add_a_limit(rate_limiter: &mut TestsLimiter) {

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::all)]
+
 macro_rules! test_with_all_storage_impls {
     // This macro uses the "paste" crate to define the names of the functions.
     // Also, the Redis tests cannot be run in parallel. The "serial" tag from
@@ -163,12 +165,12 @@ mod test {
             rate_limiter.add_limit(&limit).await.unwrap();
         }
 
-        for ns in ["first_namespace", "second_namespace"].iter() {
+        for &ns in ["first_namespace", "second_namespace"].iter() {
             assert!(rate_limiter
                 .get_namespaces()
                 .await
                 .unwrap()
-                .contains(&Namespace::from(ns.as_ref())));
+                .contains(&Namespace::from(ns)));
         }
     }
 
@@ -344,7 +346,7 @@ mod test {
         ];
 
         for limit in limits.iter() {
-            rate_limiter.add_limit(&limit).await.unwrap()
+            rate_limiter.add_limit(limit).await.unwrap()
         }
 
         rate_limiter.delete_limits(namespace).await.unwrap();
@@ -422,25 +424,19 @@ mod test {
         values.insert("app_id".to_string(), "test_app_id".to_string());
 
         for _ in 0..max_hits {
-            assert_eq!(
-                false,
-                rate_limiter
-                    .is_rate_limited(namespace, &values, 1)
-                    .await
-                    .unwrap()
-            );
+            assert!(!rate_limiter
+                .is_rate_limited(namespace, &values, 1)
+                .await
+                .unwrap());
             rate_limiter
                 .update_counters(namespace, &values, 1)
                 .await
                 .unwrap();
         }
-        assert_eq!(
-            true,
-            rate_limiter
-                .is_rate_limited(namespace, &values, 1)
-                .await
-                .unwrap()
-        );
+        assert!(rate_limiter
+            .is_rate_limited(namespace, &values, 1)
+            .await
+            .unwrap());
     }
 
     async fn rate_limited_with_delta_higher_than_one(rate_limiter: &mut TestsLimiter) {
@@ -456,25 +452,19 @@ mod test {
         // Report 5 hits twice. The limit is 10, so the first limited call should be
         // the third one.
         for _ in 0..2 {
-            assert_eq!(
-                false,
-                rate_limiter
-                    .is_rate_limited(namespace, &values, 5)
-                    .await
-                    .unwrap()
-            );
+            assert!(!rate_limiter
+                .is_rate_limited(namespace, &values, 5)
+                .await
+                .unwrap());
             rate_limiter
                 .update_counters(namespace, &values, 5)
                 .await
                 .unwrap();
         }
-        assert_eq!(
-            true,
-            rate_limiter
-                .is_rate_limited(namespace, &values, 1)
-                .await
-                .unwrap()
-        );
+        assert!(rate_limiter
+            .is_rate_limited(namespace, &values, 1)
+            .await
+            .unwrap());
     }
 
     async fn rate_limited_with_delta_higher_than_max(rate_limiter: &mut TestsLimiter) {
@@ -522,25 +512,19 @@ mod test {
             // iteration. It should not affect.
             values.insert("does_not_apply".to_string(), i.to_string());
 
-            assert_eq!(
-                false,
-                rate_limiter
-                    .is_rate_limited(namespace, &values, 1)
-                    .await
-                    .unwrap()
-            );
+            assert!(!rate_limiter
+                .is_rate_limited(namespace, &values, 1)
+                .await
+                .unwrap());
             rate_limiter
                 .update_counters(namespace, &values, 1)
                 .await
                 .unwrap();
         }
-        assert_eq!(
-            true,
-            rate_limiter
-                .is_rate_limited(namespace, &values, 1)
-                .await
-                .unwrap()
-        );
+        assert!(rate_limiter
+            .is_rate_limited(namespace, &values, 1)
+            .await
+            .unwrap());
     }
 
     async fn is_rate_limited_returns_false_when_no_limits_in_namespace(
@@ -549,13 +533,10 @@ mod test {
         let mut values: HashMap<String, String> = HashMap::new();
         values.insert("req.method".to_string(), "GET".to_string());
 
-        assert_eq!(
-            rate_limiter
-                .is_rate_limited("test_namespace", &values, 1)
-                .await
-                .unwrap(),
-            false
-        );
+        assert!(!rate_limiter
+            .is_rate_limited("test_namespace", &values, 1)
+            .await
+            .unwrap());
     }
 
     async fn is_rate_limited_returns_false_when_no_matching_limits(
@@ -578,13 +559,10 @@ mod test {
         values.insert("req.method".to_string(), "POST".to_string());
         values.insert("app_id".to_string(), "test_app_id".to_string());
 
-        assert_eq!(
-            rate_limiter
-                .is_rate_limited(namespace, &values, 1)
-                .await
-                .unwrap(),
-            false
-        );
+        assert!(!rate_limiter
+            .is_rate_limited(namespace, &values, 1)
+            .await
+            .unwrap());
     }
 
     async fn is_rate_limited_applies_limit_if_its_unconditional(rate_limiter: &mut TestsLimiter) {
@@ -628,22 +606,16 @@ mod test {
         values.insert("app_id".to_string(), "test_app_id".to_string());
 
         for _ in 0..max_hits {
-            assert_eq!(
-                false,
-                rate_limiter
-                    .check_rate_limited_and_update(namespace, &values, 1)
-                    .await
-                    .unwrap()
-            );
-        }
-
-        assert_eq!(
-            true,
-            rate_limiter
+            assert!(!rate_limiter
                 .check_rate_limited_and_update(namespace, &values, 1)
                 .await
-                .unwrap()
-        );
+                .unwrap());
+        }
+
+        assert!(rate_limiter
+            .check_rate_limited_and_update(namespace, &values, 1)
+            .await
+            .unwrap());
     }
 
     async fn check_rate_limited_and_update_returns_true_if_no_limits_apply(
@@ -660,13 +632,10 @@ mod test {
         // Does not match the limit defined
         values.insert("req.method".to_string(), "POST".to_string());
 
-        assert_eq!(
-            false,
-            rate_limiter
-                .check_rate_limited_and_update(namespace, &values, 1)
-                .await
-                .unwrap()
-        );
+        assert!(!rate_limiter
+            .check_rate_limited_and_update(namespace, &values, 1)
+            .await
+            .unwrap());
     }
 
     async fn check_rate_limited_and_update_applies_limit_if_its_unconditional(


### PR DESCRIPTION
This is a 0.4 backwards-compatible release, but bumped because internals have changed quite a bit regarding the async reactor and performance characteristics _might_ differ. Thoroughly testing with heavy workloads is recommended before placing in production.

CHANGELOG excerpt:

> ## 0.5.0 - 2022-01-31
> 
> ### Added
> 
> - Support for Infinispan (tested with 11.0.9.Final). You can enable it via the `INFINISPAN_URL` env variable.
> 
> ### Changed
> 
> - Moved to the Tokio 1 async reactor.

There are other internal changes that don't impact users, namely updating the RLS protocol definition and some refactorings to explicitly expose fallible operations for future development.