### PR TITLE
Fix container image by using the same build environment as the runtime one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
 [workspace]
 
 members = ["limitador", "limitador-server"]
+
+[profile.release]
+lto = true
+codegen-units = 1


### PR DESCRIPTION
This is way simpler and more reliable. The problem at this point in time is that we are pulling in OpenSSL as a dependency, and this requires a build of this library with musl. Rather than rebuilding OpenSSL manually, let's just compile the project in a musl-based distro... and why not use Alpine, which we already use for running the service!

In addition, we just added a release profile to use fat LTO and a single codegen-unit.