### PR TITLE
Only use key utility functions when needed

### DIFF
--- a/limitador/src/storage/mod.rs
+++ b/limitador/src/storage/mod.rs
@@ -13,6 +13,7 @@ pub mod redis;
 #[cfg(feature = "infinispan_storage")]
 pub mod infinispan;
 
+#[cfg(any(feature = "redis_storage", feature = "infinispan_storage"))]
 mod keys;
 
 pub enum Authorization<'c> {


### PR DESCRIPTION
The utility functions for key manipulation are only used with an
external storage is used. This removes warning when using only in memory
storage, e.g. when building targeting wasm32

Minor thing, but removes warnings... which is always nice 😃 