### PR TITLE
Ignore authority header check when it contains `|` char

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,8 +831,7 @@ dependencies = [
 [[package]]
 name = "h2"
 version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
+source = "git+https://github.com/rahulanand16nov/h2?branch=v0.3.11-pipe#d956cec4ac9dc1ee94aac416f5d338d5b296f902"
 dependencies = [
  "bytes",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ lto = true
 codegen-units = 1
 
 [patch.crates-io]
-h2 = { git = "https://github.com/rahulanand16nov/h2", branch = "v0.3.11-pipe" }
+h2 = { git = "https://github.com/rahulanand16nov/h2", branch = "v0.3.11-pipe" } # This patch can be removed once hyperium/h2#619 is closed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ members = ["limitador", "limitador-server"]
 [profile.release]
 lto = true
 codegen-units = 1
+
+[patch.crates-io]
+h2 = { git = "https://github.com/rahulanand16nov/h2", branch = "v0.3.11-pipe" }


### PR DESCRIPTION
This PR fixes #53 by forking https://github.com/hyperium/h2 and allowing requests with authority header containing pipe `|` characters.

The fix is present at: https://github.com/rahulanand16nov/h2/commit/d956cec4ac9dc1ee94aac416f5d338d5b296f902

It's not a security risk since the authority header is used nowhere in the logic of limitador (correct me if I am wrong). A similar issue will be created in the dependencies repo to fix it.

An image that contains this fix and works: `quay.io/rahanand/limitador:test`