### PR TITLE
Impl `From<&str> for Namespace` instead of `FromStr` as it can't fail

### DIFF
--- a/limitador-server/src/http_api/request_types.rs
+++ b/limitador-server/src/http_api/request_types.rs
@@ -41,7 +41,7 @@ impl From<&LimitadorLimit> for Limit {
 impl From<Limit> for LimitadorLimit {
     fn from(limit: Limit) -> Self {
         let mut limitador_limit = Self::new(
-            limit.namespace.as_str(),
+            limit.namespace,
             limit.max_value,
             limit.seconds,
             limit.conditions,

--- a/limitador-server/src/http_api/server.rs
+++ b/limitador-server/src/http_api/server.rs
@@ -2,7 +2,6 @@ use crate::http_api::request_types::{CheckAndReportInfo, Counter, Limit};
 use crate::Limiter;
 use actix_web::{http::StatusCode, ResponseError};
 use actix_web::{App, HttpServer};
-use limitador::limit::Namespace;
 use paperclip::actix::{
     api_v2_errors,
     api_v2_operation,
@@ -75,14 +74,8 @@ async fn get_limits(
     namespace: web::Path<String>,
 ) -> Result<web::Json<Vec<Limit>>, ErrorResponse> {
     let get_limits_result = match data.get_ref().as_ref() {
-        Limiter::Blocking(limiter) => {
-            let namespace: Namespace = namespace.into_inner().into();
-            limiter.get_limits(namespace)
-        }
-        Limiter::Async(limiter) => {
-            let namespace: Namespace = namespace.into_inner().into();
-            limiter.get_limits(namespace).await
-        }
+        Limiter::Blocking(limiter) => limiter.get_limits(namespace.into_inner()),
+        Limiter::Async(limiter) => limiter.get_limits(namespace.into_inner()).await,
     };
 
     match get_limits_result {
@@ -116,14 +109,8 @@ async fn delete_limits(
     namespace: web::Path<String>,
 ) -> Result<web::Json<()>, ErrorResponse> {
     let delete_limits_result = match data.get_ref().as_ref() {
-        Limiter::Blocking(limiter) => {
-            let namespace: Namespace = namespace.into_inner().into();
-            limiter.delete_limits(namespace)
-        }
-        Limiter::Async(limiter) => {
-            let namespace: Namespace = namespace.into_inner().into();
-            limiter.delete_limits(namespace).await
-        }
+        Limiter::Blocking(limiter) => limiter.delete_limits(namespace.into_inner()),
+        Limiter::Async(limiter) => limiter.delete_limits(namespace.into_inner()).await,
     };
 
     match delete_limits_result {
@@ -138,14 +125,8 @@ async fn get_counters(
     namespace: web::Path<String>,
 ) -> Result<web::Json<Vec<Counter>>, ErrorResponse> {
     let get_counters_result = match data.get_ref().as_ref() {
-        Limiter::Blocking(limiter) => {
-            let namespace: Namespace = namespace.into_inner().into();
-            limiter.get_counters(namespace)
-        }
-        Limiter::Async(limiter) => {
-            let namespace: Namespace = namespace.into_inner().into();
-            limiter.get_counters(namespace).await
-        }
+        Limiter::Blocking(limiter) => limiter.get_counters(namespace.into_inner()),
+        Limiter::Async(limiter) => limiter.get_counters(namespace.into_inner()).await,
     };
 
     match get_counters_result {

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -319,7 +319,7 @@ impl RateLimiter {
         self.storage.delete_limit(limit).map_err(|err| err.into())
     }
 
-    pub fn get_limits<N: TryInto<Namespace>>(
+    pub fn get_limits<N: Into<Namespace>>(
         &self,
         namespace: N,
     ) -> Result<HashSet<Limit>, LimitadorError>
@@ -327,20 +327,20 @@ impl RateLimiter {
         <N as TryInto<Namespace>>::Error: Debug,
     {
         self.storage
-            .get_limits(&namespace.try_into().unwrap())
+            .get_limits(&namespace.into())
             .map_err(|err| err.into())
     }
 
-    pub fn delete_limits<N: TryInto<Namespace>>(&self, namespace: N) -> Result<(), LimitadorError>
+    pub fn delete_limits<N: Into<Namespace>>(&self, namespace: N) -> Result<(), LimitadorError>
     where
         <N as TryInto<Namespace>>::Error: Debug,
     {
         self.storage
-            .delete_limits(&namespace.try_into().unwrap())
+            .delete_limits(&namespace.into())
             .map_err(|err| err.into())
     }
 
-    pub fn is_rate_limited<N: TryInto<Namespace>>(
+    pub fn is_rate_limited<N: Into<Namespace>>(
         &self,
         namespace: N,
         values: &HashMap<String, String>,
@@ -349,7 +349,7 @@ impl RateLimiter {
     where
         <N as TryInto<Namespace>>::Error: Debug,
     {
-        let namespace = namespace.try_into().unwrap();
+        let namespace = namespace.into();
         let counters = self.counters_that_apply(namespace.clone(), values)?;
 
         for counter in counters {
@@ -369,7 +369,7 @@ impl RateLimiter {
         Ok(false)
     }
 
-    pub fn update_counters<N: TryInto<Namespace>>(
+    pub fn update_counters<N: Into<Namespace>>(
         &self,
         namespace: N,
         values: &HashMap<String, String>,
@@ -386,7 +386,7 @@ impl RateLimiter {
             .map_err(|err| err.into())
     }
 
-    pub fn check_rate_limited_and_update<N: TryInto<Namespace>>(
+    pub fn check_rate_limited_and_update<N: Into<Namespace>>(
         &self,
         namespace: N,
         values: &HashMap<String, String>,
@@ -395,7 +395,7 @@ impl RateLimiter {
     where
         <N as TryInto<Namespace>>::Error: Debug,
     {
-        let namespace = namespace.try_into().unwrap();
+        let namespace = namespace.into();
         let counters = self.counters_that_apply(namespace.clone(), values)?;
 
         if counters.is_empty() {
@@ -467,7 +467,7 @@ impl RateLimiter {
         self.prometheus_metrics.gather_metrics()
     }
 
-    fn counters_that_apply<N: TryInto<Namespace>>(
+    fn counters_that_apply<N: Into<Namespace>>(
         &self,
         namespace: N,
         values: &HashMap<String, String>,
@@ -588,7 +588,7 @@ impl AsyncRateLimiter {
         Ok(())
     }
 
-    pub async fn check_rate_limited_and_update<N: TryInto<Namespace>>(
+    pub async fn check_rate_limited_and_update<N: Into<Namespace>>(
         &self,
         namespace: N,
         values: &HashMap<String, String>,
@@ -598,7 +598,7 @@ impl AsyncRateLimiter {
         <N as TryInto<Namespace>>::Error: Debug,
     {
         // the above where-clause is needed in order to call unwrap().
-        let namespace = namespace.try_into().unwrap();
+        let namespace = namespace.into();
         let counters = self.counters_that_apply(namespace.clone(), values).await?;
 
         if counters.is_empty() {

--- a/limitador/src/limit.rs
+++ b/limitador/src/limit.rs
@@ -1,24 +1,13 @@
 use serde::{Deserialize, Serialize, Serializer};
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::hash::{Hash, Hasher};
-use std::str::FromStr;
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Namespace(String);
 
-impl FromStr for Namespace {
-    type Err = core::convert::Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(s.into()))
-    }
-}
-
-impl TryFrom<&str> for Namespace {
-    type Error = <Self as FromStr>::Err;
-
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        s.parse()
+impl From<&str> for Namespace {
+    fn from(s: &str) -> Namespace {
+        Self(s.into())
     }
 }
 
@@ -58,7 +47,7 @@ where
 }
 
 impl Limit {
-    pub fn new<N: TryInto<Namespace>>(
+    pub fn new<N: Into<Namespace>>(
         namespace: N,
         max_value: i64,
         seconds: u64,
@@ -70,7 +59,7 @@ impl Limit {
     {
         // the above where-clause is needed in order to call unwrap().
         Self {
-            namespace: namespace.try_into().unwrap(),
+            namespace: namespace.into(),
             max_value,
             seconds,
             name: None,
@@ -181,13 +170,7 @@ mod tests {
 
     #[test]
     fn limit_can_have_an_optional_name() {
-        let mut limit = Limit::new(
-            "test_namespace".parse::<Namespace>().unwrap(),
-            10,
-            60,
-            vec!["x == 5"],
-            vec!["y"],
-        );
+        let mut limit = Limit::new("test_namespace", 10, 60, vec!["x == 5"], vec!["y"]);
         assert!(limit.name.is_none());
 
         let name = "Test Limit";
@@ -197,13 +180,7 @@ mod tests {
 
     #[test]
     fn limit_applies() {
-        let limit = Limit::new(
-            "test_namespace".parse::<Namespace>().unwrap(),
-            10,
-            60,
-            vec!["x == 5"],
-            vec!["y"],
-        );
+        let limit = Limit::new("test_namespace", 10, 60, vec!["x == 5"], vec!["y"]);
 
         let mut values: HashMap<String, String> = HashMap::new();
         values.insert("x".into(), "5".into());

--- a/limitador/src/prometheus_metrics.rs
+++ b/limitador/src/prometheus_metrics.rs
@@ -140,8 +140,8 @@ mod tests {
         let prometheus_metrics = PrometheusMetrics::new();
 
         let namespaces_with_auth_counts = [
-            ("some_namespace".parse().unwrap(), 2),
-            ("another_namespace".parse().unwrap(), 3),
+            ("some_namespace".into(), 2),
+            ("another_namespace".into(), 3),
         ];
 
         namespaces_with_auth_counts
@@ -170,8 +170,8 @@ mod tests {
         let prometheus_metrics = PrometheusMetrics::new();
 
         let namespaces_with_limited_counts = [
-            ("some_namespace".parse().unwrap(), 2),
-            ("another_namespace".parse().unwrap(), 3),
+            ("some_namespace".into(), 2),
+            ("another_namespace".into(), 3),
         ];
 
         namespaces_with_limited_counts
@@ -200,8 +200,8 @@ mod tests {
         let prometheus_metrics = PrometheusMetrics::new_with_counters_by_limit_name();
 
         let limits_with_counts = [
-            ("some_namespace".parse().unwrap(), "Some limit", 2),
-            ("some_namespace".parse().unwrap(), "Another limit", 3),
+            ("some_namespace".into(), "Some limit", 2),
+            ("some_namespace".into(), "Another limit", 3),
         ];
 
         limits_with_counts
@@ -231,7 +231,7 @@ mod tests {
     #[test]
     fn incr_limited_calls_uses_empty_string_when_no_name() {
         let prometheus_metrics = PrometheusMetrics::new_with_counters_by_limit_name();
-        let namespace = "some namespace".parse().unwrap();
+        let namespace = "some namespace".into();
         prometheus_metrics.incr_limited_calls(&namespace, None);
 
         let metrics_output = prometheus_metrics.gather_metrics();

--- a/limitador/src/storage/infinispan/infinispan_storage.rs
+++ b/limitador/src/storage/infinispan/infinispan_storage.rs
@@ -35,7 +35,7 @@ impl AsyncStorage for InfinispanStorage {
             .get_set(key_for_namespaces_set())
             .await?
             .iter()
-            .map(|ns| ns.parse().unwrap())
+            .map(|ns| ns.as_str().into())
             .collect())
     }
 

--- a/limitador/src/storage/redis/redis_async.rs
+++ b/limitador/src/storage/redis/redis_async.rs
@@ -36,7 +36,7 @@ impl AsyncStorage for AsyncRedisStorage {
             .smembers::<String, HashSet<String>>(key_for_namespaces_set())
             .await?;
 
-        Ok(namespaces.iter().map(|ns| ns.parse().unwrap()).collect())
+        Ok(namespaces.iter().map(|ns| ns.as_str().into()).collect())
     }
 
     async fn add_limit(&self, limit: &Limit) -> Result<(), StorageErr> {

--- a/limitador/src/storage/redis/redis_sync.rs
+++ b/limitador/src/storage/redis/redis_sync.rs
@@ -27,7 +27,7 @@ impl Storage for RedisStorage {
 
         let namespaces = con.smembers::<String, HashSet<String>>(key_for_namespaces_set())?;
 
-        Ok(namespaces.iter().map(|ns| ns.parse().unwrap()).collect())
+        Ok(namespaces.iter().map(|ns| ns.as_str().into()).collect())
     }
 
     fn add_limit(&self, limit: &Limit) -> Result<(), StorageErr> {

--- a/limitador/tests/helpers/tests_limiter.rs
+++ b/limitador/tests/helpers/tests_limiter.rs
@@ -55,27 +55,15 @@ impl TestsLimiter {
 
     pub async fn get_limits(&self, namespace: &str) -> Result<HashSet<Limit>, LimitadorError> {
         match &self.limiter_impl {
-            LimiterImpl::Blocking(limiter) => {
-                limiter.get_limits(namespace.parse::<Namespace>().unwrap())
-            }
-            LimiterImpl::Async(limiter) => {
-                limiter
-                    .get_limits(namespace.parse::<Namespace>().unwrap())
-                    .await
-            }
+            LimiterImpl::Blocking(limiter) => limiter.get_limits(namespace),
+            LimiterImpl::Async(limiter) => limiter.get_limits(namespace).await,
         }
     }
 
     pub async fn delete_limits(&self, namespace: &str) -> Result<(), LimitadorError> {
         match &self.limiter_impl {
-            LimiterImpl::Blocking(limiter) => {
-                limiter.delete_limits(namespace.parse::<Namespace>().unwrap())
-            }
-            LimiterImpl::Async(limiter) => {
-                limiter
-                    .delete_limits(namespace.parse::<Namespace>().unwrap())
-                    .await
-            }
+            LimiterImpl::Blocking(limiter) => limiter.delete_limits(namespace),
+            LimiterImpl::Async(limiter) => limiter.delete_limits(namespace).await,
         }
     }
 
@@ -86,14 +74,8 @@ impl TestsLimiter {
         delta: i64,
     ) -> Result<bool, LimitadorError> {
         match &self.limiter_impl {
-            LimiterImpl::Blocking(limiter) => {
-                limiter.is_rate_limited(namespace.parse::<Namespace>().unwrap(), values, delta)
-            }
-            LimiterImpl::Async(limiter) => {
-                limiter
-                    .is_rate_limited(namespace.parse::<Namespace>().unwrap(), values, delta)
-                    .await
-            }
+            LimiterImpl::Blocking(limiter) => limiter.is_rate_limited(namespace, values, delta),
+            LimiterImpl::Async(limiter) => limiter.is_rate_limited(namespace, values, delta).await,
         }
     }
 
@@ -104,14 +86,8 @@ impl TestsLimiter {
         delta: i64,
     ) -> Result<(), LimitadorError> {
         match &self.limiter_impl {
-            LimiterImpl::Blocking(limiter) => {
-                limiter.update_counters(namespace.parse::<Namespace>().unwrap(), values, delta)
-            }
-            LimiterImpl::Async(limiter) => {
-                limiter
-                    .update_counters(namespace.parse::<Namespace>().unwrap(), values, delta)
-                    .await
-            }
+            LimiterImpl::Blocking(limiter) => limiter.update_counters(namespace, values, delta),
+            LimiterImpl::Async(limiter) => limiter.update_counters(namespace, values, delta).await,
         }
     }
 
@@ -122,18 +98,12 @@ impl TestsLimiter {
         delta: i64,
     ) -> Result<bool, LimitadorError> {
         match &self.limiter_impl {
-            LimiterImpl::Blocking(limiter) => limiter.check_rate_limited_and_update(
-                namespace.parse::<Namespace>().unwrap(),
-                values,
-                delta,
-            ),
+            LimiterImpl::Blocking(limiter) => {
+                limiter.check_rate_limited_and_update(namespace, values, delta)
+            }
             LimiterImpl::Async(limiter) => {
                 limiter
-                    .check_rate_limited_and_update(
-                        namespace.parse::<Namespace>().unwrap(),
-                        values,
-                        delta,
-                    )
+                    .check_rate_limited_and_update(namespace, values, delta)
                     .await
             }
         }
@@ -141,14 +111,8 @@ impl TestsLimiter {
 
     pub async fn get_counters(&self, namespace: &str) -> Result<HashSet<Counter>, LimitadorError> {
         match &self.limiter_impl {
-            LimiterImpl::Blocking(limiter) => {
-                limiter.get_counters(namespace.parse::<Namespace>().unwrap())
-            }
-            LimiterImpl::Async(limiter) => {
-                limiter
-                    .get_counters(namespace.parse::<Namespace>().unwrap())
-                    .await
-            }
+            LimiterImpl::Blocking(limiter) => limiter.get_counters(namespace),
+            LimiterImpl::Async(limiter) => limiter.get_counters(namespace).await,
         }
     }
 

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -169,7 +169,7 @@ mod test {
                 .get_namespaces()
                 .await
                 .unwrap()
-                .contains(&ns.parse().unwrap()));
+                .contains(&ns.into()));
         }
     }
 
@@ -205,12 +205,12 @@ mod test {
             .get_namespaces()
             .await
             .unwrap()
-            .contains(&"first_namespace".parse().unwrap()));
+            .contains(&"first_namespace".into()));
         assert!(!rate_limiter
             .get_namespaces()
             .await
             .unwrap()
-            .contains(&"second_namespace".parse().unwrap()));
+            .contains(&"second_namespace".into()));
     }
 
     async fn add_a_limit(rate_limiter: &mut TestsLimiter) {


### PR DESCRIPTION
`Namespace` implements `FromStr` from the [stdlib](https://doc.rust-lang.org/std/str/trait.FromStr.html). But afaict `Namespace` _is_ a `String`, as such any `String` represents a valid `Namespace`. `FromStr` can fail tho. Even if our implementation had `type Err = core::convert::Infallible` it still means you have to call `unwrap()` on the `Result` from the the `try_into()` call.

There might have been a reason for this, but given the existing infallible `From<String>` implementation, I can't see it.

This changes this to `impl From<&str> for Namespace`, just as it already did for `From<String>` and makes the `.into() -> Namespace` removing the intermediary `Result` that was always a success anyways. As such it removes a bunch of `.unwrap()` from the code base. 

Part one of more to come...