### PR TITLE
`RaterLimiter` to take a `&Namespace` 

### DIFF
--- a/limitador-server/src/envoy_rls/server.rs
+++ b/limitador-server/src/envoy_rls/server.rs
@@ -46,6 +46,8 @@ impl RateLimitService for MyRateLimiter {
             }));
         }
 
+        let namespace = namespace.into();
+
         for descriptor in &req.descriptors {
             for entry in &descriptor.entries {
                 values.insert(entry.key.clone(), entry.value.clone());
@@ -62,11 +64,11 @@ impl RateLimitService for MyRateLimiter {
 
         let is_rate_limited_res = match &*self.limiter {
             Limiter::Blocking(limiter) => {
-                limiter.check_rate_limited_and_update(namespace, &values, i64::from(hits_addend))
+                limiter.check_rate_limited_and_update(&namespace, &values, i64::from(hits_addend))
             }
             Limiter::Async(limiter) => {
                 limiter
-                    .check_rate_limited_and_update(namespace, &values, i64::from(hits_addend))
+                    .check_rate_limited_and_update(&namespace, &values, i64::from(hits_addend))
                     .await
             }
         };

--- a/limitador-server/src/http_api/server.rs
+++ b/limitador-server/src/http_api/server.rs
@@ -73,9 +73,10 @@ async fn get_limits(
     data: web::Data<Arc<Limiter>>,
     namespace: web::Path<String>,
 ) -> Result<web::Json<Vec<Limit>>, ErrorResponse> {
+    let namespace = &namespace.into_inner().into();
     let get_limits_result = match data.get_ref().as_ref() {
-        Limiter::Blocking(limiter) => limiter.get_limits(namespace.into_inner()),
-        Limiter::Async(limiter) => limiter.get_limits(namespace.into_inner()).await,
+        Limiter::Blocking(limiter) => limiter.get_limits(namespace),
+        Limiter::Async(limiter) => limiter.get_limits(namespace).await,
     };
 
     match get_limits_result {
@@ -108,9 +109,10 @@ async fn delete_limits(
     data: web::Data<Arc<Limiter>>,
     namespace: web::Path<String>,
 ) -> Result<web::Json<()>, ErrorResponse> {
+    let namespace = namespace.into_inner().into();
     let delete_limits_result = match data.get_ref().as_ref() {
-        Limiter::Blocking(limiter) => limiter.delete_limits(namespace.into_inner()),
-        Limiter::Async(limiter) => limiter.delete_limits(namespace.into_inner()).await,
+        Limiter::Blocking(limiter) => limiter.delete_limits(&namespace),
+        Limiter::Async(limiter) => limiter.delete_limits(&namespace).await,
     };
 
     match delete_limits_result {
@@ -124,9 +126,10 @@ async fn get_counters(
     data: web::Data<Arc<Limiter>>,
     namespace: web::Path<String>,
 ) -> Result<web::Json<Vec<Counter>>, ErrorResponse> {
+    let namespace = namespace.into_inner().into();
     let get_counters_result = match data.get_ref().as_ref() {
-        Limiter::Blocking(limiter) => limiter.get_counters(namespace.into_inner()),
-        Limiter::Async(limiter) => limiter.get_counters(namespace.into_inner()).await,
+        Limiter::Blocking(limiter) => limiter.get_counters(&namespace),
+        Limiter::Async(limiter) => limiter.get_counters(&namespace).await,
     };
 
     match get_counters_result {
@@ -151,9 +154,10 @@ async fn check(
         values,
         delta,
     } = request.into_inner();
+    let namespace = namespace.into();
     let is_rate_limited_result = match state.get_ref().as_ref() {
-        Limiter::Blocking(limiter) => limiter.is_rate_limited(namespace, &values, delta),
-        Limiter::Async(limiter) => limiter.is_rate_limited(namespace, &values, delta).await,
+        Limiter::Blocking(limiter) => limiter.is_rate_limited(&namespace, &values, delta),
+        Limiter::Async(limiter) => limiter.is_rate_limited(&namespace, &values, delta).await,
     };
 
     match is_rate_limited_result {
@@ -178,9 +182,10 @@ async fn report(
         values,
         delta,
     } = request.into_inner();
+    let namespace = namespace.into();
     let update_counters_result = match data.get_ref().as_ref() {
-        Limiter::Blocking(limiter) => limiter.update_counters(namespace, &values, delta),
-        Limiter::Async(limiter) => limiter.update_counters(namespace, &values, delta).await,
+        Limiter::Blocking(limiter) => limiter.update_counters(&namespace, &values, delta),
+        Limiter::Async(limiter) => limiter.update_counters(&namespace, &values, delta).await,
     };
 
     match update_counters_result {
@@ -199,13 +204,14 @@ async fn check_and_report(
         values,
         delta,
     } = request.into_inner();
+    let namespace = namespace.into();
     let rate_limited_and_update_result = match data.get_ref().as_ref() {
         Limiter::Blocking(limiter) => {
-            limiter.check_rate_limited_and_update(namespace, &values, delta)
+            limiter.check_rate_limited_and_update(&namespace, &values, delta)
         }
         Limiter::Async(limiter) => {
             limiter
-                .check_rate_limited_and_update(namespace, &values, delta)
+                .check_rate_limited_and_update(&namespace, &values, delta)
                 .await
         }
     };

--- a/limitador/benches/bench.rs
+++ b/limitador/benches/bench.rs
@@ -130,7 +130,11 @@ fn bench_is_rate_limited(b: &mut Bencher, test_scenario: &TestScenario, storage:
 
         black_box(
             rate_limiter
-                .is_rate_limited(params.namespace.as_ref(), &params.values, params.delta)
+                .is_rate_limited(
+                    &params.namespace.to_owned().into(),
+                    &params.values,
+                    params.delta,
+                )
                 .unwrap(),
         )
     })
@@ -145,7 +149,11 @@ fn bench_update_counters(b: &mut Bencher, test_scenario: &TestScenario, storage:
 
         black_box(
             rate_limiter
-                .update_counters(params.namespace.as_ref(), &params.values, params.delta)
+                .update_counters(
+                    &params.namespace.to_owned().into(),
+                    &params.values,
+                    params.delta,
+                )
                 .unwrap(),
         )
     })
@@ -165,7 +173,7 @@ fn bench_check_rate_limited_and_update(
         black_box(
             rate_limiter
                 .check_rate_limited_and_update(
-                    params.namespace.as_ref(),
+                    &params.namespace.to_owned().into(),
                     &params.values,
                     params.delta,
                 )

--- a/limitador/tests/helpers/tests_limiter.rs
+++ b/limitador/tests/helpers/tests_limiter.rs
@@ -55,15 +55,15 @@ impl TestsLimiter {
 
     pub async fn get_limits(&self, namespace: &str) -> Result<HashSet<Limit>, LimitadorError> {
         match &self.limiter_impl {
-            LimiterImpl::Blocking(limiter) => limiter.get_limits(namespace),
-            LimiterImpl::Async(limiter) => limiter.get_limits(namespace).await,
+            LimiterImpl::Blocking(limiter) => limiter.get_limits(&namespace.into()),
+            LimiterImpl::Async(limiter) => limiter.get_limits(&namespace.into()).await,
         }
     }
 
     pub async fn delete_limits(&self, namespace: &str) -> Result<(), LimitadorError> {
         match &self.limiter_impl {
-            LimiterImpl::Blocking(limiter) => limiter.delete_limits(namespace),
-            LimiterImpl::Async(limiter) => limiter.delete_limits(namespace).await,
+            LimiterImpl::Blocking(limiter) => limiter.delete_limits(&namespace.into()),
+            LimiterImpl::Async(limiter) => limiter.delete_limits(&namespace.into()).await,
         }
     }
 
@@ -74,8 +74,14 @@ impl TestsLimiter {
         delta: i64,
     ) -> Result<bool, LimitadorError> {
         match &self.limiter_impl {
-            LimiterImpl::Blocking(limiter) => limiter.is_rate_limited(namespace, values, delta),
-            LimiterImpl::Async(limiter) => limiter.is_rate_limited(namespace, values, delta).await,
+            LimiterImpl::Blocking(limiter) => {
+                limiter.is_rate_limited(&namespace.into(), values, delta)
+            }
+            LimiterImpl::Async(limiter) => {
+                limiter
+                    .is_rate_limited(&namespace.into(), values, delta)
+                    .await
+            }
         }
     }
 
@@ -86,8 +92,14 @@ impl TestsLimiter {
         delta: i64,
     ) -> Result<(), LimitadorError> {
         match &self.limiter_impl {
-            LimiterImpl::Blocking(limiter) => limiter.update_counters(namespace, values, delta),
-            LimiterImpl::Async(limiter) => limiter.update_counters(namespace, values, delta).await,
+            LimiterImpl::Blocking(limiter) => {
+                limiter.update_counters(&namespace.into(), values, delta)
+            }
+            LimiterImpl::Async(limiter) => {
+                limiter
+                    .update_counters(&namespace.into(), values, delta)
+                    .await
+            }
         }
     }
 
@@ -99,11 +111,11 @@ impl TestsLimiter {
     ) -> Result<bool, LimitadorError> {
         match &self.limiter_impl {
             LimiterImpl::Blocking(limiter) => {
-                limiter.check_rate_limited_and_update(namespace, values, delta)
+                limiter.check_rate_limited_and_update(&namespace.into(), values, delta)
             }
             LimiterImpl::Async(limiter) => {
                 limiter
-                    .check_rate_limited_and_update(namespace, values, delta)
+                    .check_rate_limited_and_update(&namespace.into(), values, delta)
                     .await
             }
         }
@@ -111,8 +123,8 @@ impl TestsLimiter {
 
     pub async fn get_counters(&self, namespace: &str) -> Result<HashSet<Counter>, LimitadorError> {
         match &self.limiter_impl {
-            LimiterImpl::Blocking(limiter) => limiter.get_counters(namespace),
-            LimiterImpl::Async(limiter) => limiter.get_counters(namespace).await,
+            LimiterImpl::Blocking(limiter) => limiter.get_counters(&namespace.into()),
+            LimiterImpl::Async(limiter) => limiter.get_counters(&namespace.into()).await,
         }
     }
 


### PR DESCRIPTION
This is based of #76 
I think this is cleaner (and avoids a couple `.clone()`s along the way). If we all agree, this could be merged.