### PR TITLE
Monitor config file for changes and reload when needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
 name = "firestorm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,6 +728,15 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1009,6 +1030,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1104,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6112e8f37b59803ac47a42d14f1f3a59bbf72fc6857ffc5be455e28a691f8e"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,6 +1174,7 @@ dependencies = [
  "env_logger",
  "limitador",
  "log",
+ "notify",
  "paperclip",
  "prost",
  "prost-types",
@@ -1262,6 +1324,24 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "notify"
+version = "5.0.0-pre.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "553f9844ad0b0824605c20fb55a661679782680410abfb1a8144c2e7e437e7a7"
+dependencies = [
+ "bitflags",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "mio 0.8.0",
+ "walkdir",
+ "winapi",
 ]
 
 [[package]]

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -29,6 +29,7 @@ actix-web = "4.0.0-rc.3"
 actix-rt = "2"
 paperclip = { git = "https://github.com/sfisol/paperclip", rev = "6359742625d599c76f27492e497776df795bdcaa", features = ["actix"] }
 serde = { version = "1", features = ["derive"] }
+notify = "5.0.0-pre.15"
 
 [build-dependencies]
 tonic-build = "0.6"


### PR DESCRIPTION
See issue #74 

### What has changed

 - bafcb99 Adds the behavior to reload the limit file off disk when it changed and do the changes
 - 4394736 Returns proper errors when handling the limit file off disk

### Testing it locally

1. Build locally
`$ cargo build`
2. Start limitador server, using the example config
`$ LIMITS_FILE=limitador-server/examples/limits.yaml RUST_LOG=info ./target/debug/limitador-server`
3. Hit the HTTP end point to list limits at:
http://localhost:8080/limits/test_namespace
4. Change a value in the config file at `limitador-server/examples/limits.yaml` and save
5. Reload the URL and the changes should be visible
6. An invalid config file would trigger an error to be logged and be ignored (i.e. the old config remains active)
