### PR TITLE
Simpler trait

### DIFF
--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -384,16 +384,16 @@ impl RateLimiter {
 
         let check_result = self
             .storage
-            .check_and_update(&counters.iter().collect(), delta)?;
+            .check_and_update(counters.into_iter().collect(), delta)?;
 
         match check_result {
             Authorization::Ok => {
                 self.prometheus_metrics.incr_authorized_calls(namespace);
                 Ok(false)
             }
-            Authorization::Limited(c) => {
+            Authorization::Limited(name) => {
                 self.prometheus_metrics
-                    .incr_limited_calls(namespace, c.limit().name());
+                    .incr_limited_calls(namespace, name.as_deref());
                 Ok(true)
             }
         }
@@ -557,7 +557,7 @@ impl AsyncRateLimiter {
 
         let check_result = self
             .storage
-            .check_and_update(&counters.iter().collect(), delta)
+            .check_and_update(counters.into_iter().collect(), delta)
             .await?;
 
         match check_result {
@@ -565,9 +565,9 @@ impl AsyncRateLimiter {
                 self.prometheus_metrics.incr_authorized_calls(namespace);
                 Ok(false)
             }
-            Authorization::Limited(c) => {
+            Authorization::Limited(name) => {
                 self.prometheus_metrics
-                    .incr_limited_calls(namespace, c.limit().name());
+                    .incr_limited_calls(namespace, name.as_deref());
                 Ok(true)
             }
         }

--- a/limitador/src/storage/in_memory.rs
+++ b/limitador/src/storage/in_memory.rs
@@ -52,7 +52,7 @@ impl CounterStorage for InMemoryStorage {
         Ok(Authorization::Ok)
     }
 
-    fn get_counters(&self, limits: HashSet<Limit>) -> Result<HashSet<Counter>, StorageErr> {
+    fn get_counters(&self, limits: &HashSet<Limit>) -> Result<HashSet<Counter>, StorageErr> {
         let mut res = HashSet::new();
 
         let namespaces: HashSet<&Namespace> = limits.iter().map(Limit::namespace).collect();

--- a/limitador/src/storage/in_memory.rs
+++ b/limitador/src/storage/in_memory.rs
@@ -37,19 +37,15 @@ impl CounterStorage for InMemoryStorage {
         // This makes the operator of check + update atomic
         let mut stored_counters = self.counters.write().unwrap();
 
-        let mut counters_to_update = Vec::with_capacity(counters.len());
-
-        for counter in counters {
-            if !Self::counter_is_within_limits(&counter, stored_counters.get(&counter), delta) {
+        for counter in counters.iter() {
+            if !Self::counter_is_within_limits(counter, stored_counters.get(counter), delta) {
                 return Ok(Authorization::Limited(
                     counter.limit().name().map(|n| n.to_owned()),
                 ));
-            } else {
-                counters_to_update.push(counter);
             }
         }
 
-        for counter in counters_to_update {
+        for counter in counters {
             self.insert_or_update_counter(&mut stored_counters, &counter, delta)
         }
 

--- a/limitador/src/storage/infinispan/infinispan_storage.rs
+++ b/limitador/src/storage/infinispan/infinispan_storage.rs
@@ -65,20 +65,26 @@ impl AsyncCounterStorage for InfinispanStorage {
         Ok(())
     }
 
-    async fn check_and_update<'c>(
+    async fn check_and_update(
         &self,
-        counters: &HashSet<&'c Counter>,
+        counters: HashSet<Counter>,
         delta: i64,
-    ) -> Result<Authorization<'c>, StorageErr> {
+    ) -> Result<Authorization, StorageErr> {
+        let mut counters_to_update = Vec::with_capacity(counters.len());
+
         for counter in counters {
-            if !self.is_within_limits(counter, delta).await? {
-                return Ok(Authorization::Limited(counter));
+            if !self.is_within_limits(&counter, delta).await? {
+                return Ok(Authorization::Limited(
+                    counter.limit().name().map(|n| n.to_owned()),
+                ));
+            } else {
+                counters_to_update.push(counter);
             }
         }
 
         // Update only if all are withing limits
-        for counter in counters {
-            self.update_counter(counter, delta).await?
+        for counter in counters_to_update {
+            self.update_counter(&counter, delta).await?
         }
 
         Ok(Authorization::Ok)

--- a/limitador/src/storage/infinispan/infinispan_storage.rs
+++ b/limitador/src/storage/infinispan/infinispan_storage.rs
@@ -70,20 +70,16 @@ impl AsyncCounterStorage for InfinispanStorage {
         counters: HashSet<Counter>,
         delta: i64,
     ) -> Result<Authorization, StorageErr> {
-        let mut counters_to_update = Vec::with_capacity(counters.len());
-
-        for counter in counters {
-            if !self.is_within_limits(&counter, delta).await? {
+        for counter in counters.iter() {
+            if !self.is_within_limits(counter, delta).await? {
                 return Ok(Authorization::Limited(
                     counter.limit().name().map(|n| n.to_owned()),
                 ));
-            } else {
-                counters_to_update.push(counter);
             }
         }
 
         // Update only if all are withing limits
-        for counter in counters_to_update {
+        for counter in counters {
             self.update_counter(&counter, delta).await?
         }
 

--- a/limitador/src/storage/mod.rs
+++ b/limitador/src/storage/mod.rs
@@ -18,9 +18,9 @@ pub mod infinispan;
 #[cfg(any(feature = "redis_storage", feature = "infinispan_storage"))]
 mod keys;
 
-pub enum Authorization<'c> {
+pub enum Authorization {
     Ok,
-    Limited(&'c Counter), // First counter found over the limits
+    Limited(Option<String>), // First counter found over the limits
 }
 
 pub struct Storage {
@@ -102,11 +102,11 @@ impl Storage {
         self.counters.update_counter(counter, delta)
     }
 
-    pub fn check_and_update<'c>(
+    pub fn check_and_update(
         &self,
-        counters: &HashSet<&'c Counter>,
+        counters: HashSet<Counter>,
         delta: i64,
-    ) -> Result<Authorization<'c>, StorageErr> {
+    ) -> Result<Authorization, StorageErr> {
         self.counters.check_and_update(counters, delta)
     }
 
@@ -201,11 +201,11 @@ impl AsyncStorage {
         self.counters.update_counter(counter, delta).await
     }
 
-    pub async fn check_and_update<'c>(
+    pub async fn check_and_update(
         &self,
-        counters: &HashSet<&'c Counter>,
+        counters: HashSet<Counter>,
         delta: i64,
-    ) -> Result<Authorization<'c>, StorageErr> {
+    ) -> Result<Authorization, StorageErr> {
         self.counters.check_and_update(counters, delta).await
     }
 
@@ -226,11 +226,11 @@ impl AsyncStorage {
 pub trait CounterStorage: Sync + Send {
     fn is_within_limits(&self, counter: &Counter, delta: i64) -> Result<bool, StorageErr>;
     fn update_counter(&self, counter: &Counter, delta: i64) -> Result<(), StorageErr>;
-    fn check_and_update<'c>(
+    fn check_and_update(
         &self,
-        counters: &HashSet<&'c Counter>,
+        counters: HashSet<Counter>,
         delta: i64,
-    ) -> Result<Authorization<'c>, StorageErr>;
+    ) -> Result<Authorization, StorageErr>;
     fn get_counters(&self, limits: HashSet<Limit>) -> Result<HashSet<Counter>, StorageErr>;
     fn delete_counters(&self, limits: HashSet<Limit>) -> Result<(), StorageErr>;
     fn clear(&self) -> Result<(), StorageErr>;
@@ -240,11 +240,11 @@ pub trait CounterStorage: Sync + Send {
 pub trait AsyncCounterStorage: Sync + Send {
     async fn is_within_limits(&self, counter: &Counter, delta: i64) -> Result<bool, StorageErr>;
     async fn update_counter(&self, counter: &Counter, delta: i64) -> Result<(), StorageErr>;
-    async fn check_and_update<'c>(
+    async fn check_and_update(
         &self,
-        counters: &HashSet<&'c Counter>,
+        counters: HashSet<Counter>,
         delta: i64,
-    ) -> Result<Authorization<'c>, StorageErr>;
+    ) -> Result<Authorization, StorageErr>;
     async fn get_counters(&self, limits: HashSet<Limit>) -> Result<HashSet<Counter>, StorageErr>;
     async fn delete_counters(&self, limits: HashSet<Limit>) -> Result<(), StorageErr>;
     async fn clear(&self) -> Result<(), StorageErr>;

--- a/limitador/src/storage/redis/redis_async.rs
+++ b/limitador/src/storage/redis/redis_async.rs
@@ -70,17 +70,13 @@ impl AsyncCounterStorage for AsyncRedisStorage {
             .query_async(&mut con)
             .await?;
 
-        let mut counters_to_update = Vec::with_capacity(counters.len());
-
-        for (i, counter) in counters.into_iter().enumerate() {
+        for (i, counter) in counters.iter().enumerate() {
             match counter_vals[i] {
                 Some(val) => {
                     if val - delta < 0 {
                         return Ok(Authorization::Limited(
                             counter.limit().name().map(|n| n.to_owned()),
                         ));
-                    } else {
-                        counters_to_update.push(counter);
                     }
                 }
                 None => {
@@ -88,15 +84,13 @@ impl AsyncCounterStorage for AsyncRedisStorage {
                         return Ok(Authorization::Limited(
                             counter.limit().name().map(|n| n.to_owned()),
                         ));
-                    } else {
-                        counters_to_update.push(counter);
                     }
                 }
             }
         }
 
         // TODO: this can be optimized by using pipelines with multiple updates
-        for counter in counters_to_update {
+        for counter in counters {
             self.update_counter(&counter, delta).await?
         }
 

--- a/limitador/src/storage/redis/redis_async.rs
+++ b/limitador/src/storage/redis/redis_async.rs
@@ -56,41 +56,48 @@ impl AsyncCounterStorage for AsyncRedisStorage {
         Ok(())
     }
 
-    async fn check_and_update<'c>(
+    async fn check_and_update(
         &self,
-        counters: &HashSet<&'c Counter>,
+        counters: HashSet<Counter>,
         delta: i64,
-    ) -> Result<Authorization<'c>, StorageErr> {
+    ) -> Result<Authorization, StorageErr> {
         let mut con = self.conn_manager.clone();
 
-        let counter_keys: Vec<String> = counters
-            .iter()
-            .map(|counter| key_for_counter(counter))
-            .collect();
+        let counter_keys: Vec<String> = counters.iter().map(key_for_counter).collect();
 
         let counter_vals: Vec<Option<i64>> = redis::cmd("MGET")
             .arg(counter_keys)
             .query_async(&mut con)
             .await?;
 
-        for (i, counter) in counters.iter().enumerate() {
+        let mut counters_to_update = Vec::with_capacity(counters.len());
+
+        for (i, counter) in counters.into_iter().enumerate() {
             match counter_vals[i] {
                 Some(val) => {
                     if val - delta < 0 {
-                        return Ok(Authorization::Limited(counter));
+                        return Ok(Authorization::Limited(
+                            counter.limit().name().map(|n| n.to_owned()),
+                        ));
+                    } else {
+                        counters_to_update.push(counter);
                     }
                 }
                 None => {
                     if counter.max_value() - delta < 0 {
-                        return Ok(Authorization::Limited(counter));
+                        return Ok(Authorization::Limited(
+                            counter.limit().name().map(|n| n.to_owned()),
+                        ));
+                    } else {
+                        counters_to_update.push(counter);
                     }
                 }
             }
         }
 
         // TODO: this can be optimized by using pipelines with multiple updates
-        for counter in counters {
-            self.update_counter(counter, delta).await?
+        for counter in counters_to_update {
+            self.update_counter(&counter, delta).await?
         }
 
         Ok(Authorization::Ok)

--- a/limitador/src/storage/redis/redis_sync.rs
+++ b/limitador/src/storage/redis/redis_sync.rs
@@ -52,10 +52,7 @@ impl CounterStorage for RedisStorage {
     ) -> Result<Authorization, StorageErr> {
         let mut con = self.conn_pool.get()?;
 
-        let counter_keys: Vec<String> = counters
-            .iter()
-            .map(key_for_counter)
-            .collect();
+        let counter_keys: Vec<String> = counters.iter().map(key_for_counter).collect();
 
         let counter_vals: Vec<Option<i64>> =
             redis::cmd("MGET").arg(counter_keys).query(&mut *con)?;
@@ -87,14 +84,14 @@ impl CounterStorage for RedisStorage {
         Ok(Authorization::Ok)
     }
 
-    fn get_counters(&self, limits: HashSet<Limit>) -> Result<HashSet<Counter>, StorageErr> {
+    fn get_counters(&self, limits: &HashSet<Limit>) -> Result<HashSet<Counter>, StorageErr> {
         let mut res = HashSet::new();
 
         let mut con = self.conn_pool.get()?;
 
         for limit in limits {
             let counter_keys =
-                con.smembers::<String, HashSet<String>>(key_for_counters_of_limit(&limit))?;
+                con.smembers::<String, HashSet<String>>(key_for_counters_of_limit(limit))?;
 
             for counter_key in counter_keys {
                 let mut counter: Counter = counter_from_counter_key(&counter_key);

--- a/limitador/src/storage/wasm.rs
+++ b/limitador/src/storage/wasm.rs
@@ -91,22 +91,28 @@ impl CounterStorage for WasmStorage {
         Ok(())
     }
 
-    fn check_and_update<'c>(
+    fn check_and_update(
         &self,
-        counters: &HashSet<&'c Counter>,
+        counters: HashSet<Counter>,
         delta: i64,
-    ) -> Result<Authorization<'c>, StorageErr> {
+    ) -> Result<Authorization, StorageErr> {
         // This makes the operator of check + update atomic
         let mut stored_counters = self.counters.write().unwrap();
 
+        let mut counters_to_update = Vec::with_capacity(counters.len());
+
         for counter in counters {
-            if !self.counter_is_within_limits(counter, stored_counters.get(counter), delta) {
-                return Ok(Authorization::Limited(counter));
+            if !self.counter_is_within_limits(&counter, stored_counters.get(&counter), delta) {
+                return Ok(Authorization::Limited(
+                    counter.limit().name().map(|n| n.to_owned()),
+                ));
+            } else {
+                counters_to_update.push(counter);
             }
         }
 
-        for &counter in counters {
-            self.insert_or_update_counter(&mut stored_counters, counter, delta)
+        for counter in counters_to_update {
+            self.insert_or_update_counter(&mut stored_counters, &counter, delta)
         }
 
         Ok(Authorization::Ok)

--- a/limitador/src/storage/wasm.rs
+++ b/limitador/src/storage/wasm.rs
@@ -99,19 +99,15 @@ impl CounterStorage for WasmStorage {
         // This makes the operator of check + update atomic
         let mut stored_counters = self.counters.write().unwrap();
 
-        let mut counters_to_update = Vec::with_capacity(counters.len());
-
-        for counter in counters {
-            if !self.counter_is_within_limits(&counter, stored_counters.get(&counter), delta) {
+        for counter in counters.iter() {
+            if !self.counter_is_within_limits(counter, stored_counters.get(counter), delta) {
                 return Ok(Authorization::Limited(
                     counter.limit().name().map(|n| n.to_owned()),
                 ));
-            } else {
-                counters_to_update.push(counter);
             }
         }
 
-        for counter in counters_to_update {
+        for counter in counters {
             self.insert_or_update_counter(&mut stored_counters, &counter, delta)
         }
 

--- a/limitador/src/storage/wasm.rs
+++ b/limitador/src/storage/wasm.rs
@@ -114,7 +114,7 @@ impl CounterStorage for WasmStorage {
         Ok(Authorization::Ok)
     }
 
-    fn get_counters(&self, limits: HashSet<Limit>) -> Result<HashSet<Counter>, StorageErr> {
+    fn get_counters(&self, limits: &HashSet<Limit>) -> Result<HashSet<Counter>, StorageErr> {
         // TODO: optimize to avoid iterating over all of them.
 
         let counters_with_vals: Vec<Counter> = self


### PR DESCRIPTION
### Some background 

When you look at the lifecycle of the data (i.e. how the data "flows" within limitador) there aren't much reasons to use references much. By moving ownership down into the lib, in many cases we can get close to no copy (and there is still room for improvement, e.g. the `Map<String, String>` for conditions & vars, but that's a topic for another day).

 - 8b6ca3e make the previous change somewhat "lighter". Initially within 692ff34, I was keeping a (Boxed, to keep the enum small) `Counter` in the `Authorization::Limited`. But then seeing that we don't need it, I changed it to only have the name of the limit that tripped. We _could_ still keep the whole `Counter` in there (I sort of like the API of `Authorization::Limited` having the counter that tripped). In which case the flow in the first change (692ff34) would be iterate while taking ownership of all the counters [as here](https://github.com/Kuadrant/limitador/pull/80/commits/692ff34c63b2d4ea2d95328d9ef13421c68e4b54#diff-ebd607498f8416f1e94e7592efd8580d8dd6798df308dee8f7f7f7f78fe73c18R40-R53), unless we trip a counter in which case we early return by passing ownership of said `Counter` to `Authorization::Limited`. 
 - d078d85 Uses a reference to a `HashSet<Limit>` which avoid having to clone all the `Limit` of one `HashSet` to merely build the same container. This addresses [a comment made on previous PR](https://github.com/Kuadrant/limitador/pull/78#discussion_r898977195) by @rahulanand16nov that rightfully highlighted that we could do better (and avoiding `clone()`ing that much). 

I hope this makes "some" sense. 