### PR TITLE
Bench improvements

### DIFF
--- a/limitador-server/src/http_api/server.rs
+++ b/limitador-server/src/http_api/server.rs
@@ -272,9 +272,8 @@ mod tests {
         let limiter = Limiter::new().await.unwrap();
 
         // Create a limit with max == 1
-
         let namespace = "test_namespace";
-        let limit = create_test_limit(&limiter, namespace, 1).await;
+        let _limit = create_test_limit(&limiter, namespace, 1).await;
         let rate_limiter: Arc<Limiter> = Arc::new(limiter);
         let data = web::Data::new(rate_limiter);
         let app = test::init_service(
@@ -317,7 +316,7 @@ mod tests {
     async fn test_check_and_report_endpoints_separately() {
         let namespace = "test_namespace";
         let limiter = Limiter::new().await.unwrap();
-        let limit = create_test_limit(&limiter, namespace, 1).await;
+        let _limit = create_test_limit(&limiter, namespace, 1).await;
 
         let rate_limiter: Arc<Limiter> = Arc::new(limiter);
         let data = web::Data::new(rate_limiter);

--- a/limitador/benches/bench.rs
+++ b/limitador/benches/bench.rs
@@ -3,13 +3,18 @@ use rand::seq::SliceRandom;
 
 use limitador::limit::Limit;
 use limitador::storage::in_memory::InMemoryStorage;
+#[cfg(feature = "redis")]
 use limitador::storage::redis::RedisStorage;
 use limitador::storage::CounterStorage;
 use limitador::RateLimiter;
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
-criterion_group!(benches, bench_in_mem, bench_redis,);
+#[cfg(not(feature = "redis"))]
+criterion_group!(benches, bench_in_mem);
+#[cfg(feature = "redis")]
+criterion_group!(benches, bench_in_mem, bench_redis);
+
 criterion_main!(benches);
 
 #[derive(Debug, Clone)]
@@ -88,6 +93,7 @@ fn bench_in_mem(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(feature = "redis")]
 fn bench_redis(c: &mut Criterion) {
     let mut group = c.benchmark_group("Redis");
     for scenario in TEST_SCENARIOS {

--- a/limitador/benches/bench.rs
+++ b/limitador/benches/bench.rs
@@ -232,7 +232,7 @@ fn generate_test_data(
         for _ in 0..scenario.n_limits_per_ns {
             test_limits.push(Limit::new(
                 namespace.clone(),
-                100_000_000_000,
+                i64::MAX,
                 10,
                 conditions.clone(),
                 variables.clone(),


### PR DESCRIPTION
I changed 3 things really:

 - e2dda39 removes use of deprecated Criterion APIs
 - b267e26 enables running bench with --no-default-features (i.e. only with in-memory counter storage)
 - 034adf1 since we don't want to hit limits, changed them to use `i64::MAX` (why is this a `i64`?!)
