### PR TITLE
Moved all env var configuration into one place

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff1f980957787286a554052d03c7aee98d99cc32e09f6d45f0a814133c87978"
+checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1132,7 +1132,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serial_test",
+ "serial_test 0.5.1",
  "thiserror",
  "tokio",
  "ttl_cache",
@@ -1153,6 +1153,7 @@ dependencies = [
  "prost-types",
  "serde",
  "serde_yaml",
+ "serial_test 0.7.0",
  "thiserror",
  "tokio",
  "tonic",
@@ -1162,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "local-channel"
@@ -1413,7 +1414,7 @@ dependencies = [
  "once_cell",
  "paperclip-core",
  "paperclip-macros",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
  "serde_json",
 ]
 
@@ -2061,7 +2062,19 @@ checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static",
  "parking_lot 0.11.2",
- "serial_test_derive",
+ "serial_test_derive 0.5.1",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19dbfb999a147cedbfe82f042eb9555f5b0fa4ef95ee4570b74349103d9c9f4"
+dependencies = [
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.1",
+ "serial_test_derive 0.7.0",
 ]
 
 [[package]]
@@ -2072,6 +2085,19 @@ checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9e2050b2be1d681f8f1c1a528bcfe4e00afa2d8995f713974f5333288659f2"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn",
 ]
 
@@ -2118,9 +2144,9 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "cc88c725d61fc6c3132893370cac4a0200e3fedf5da8331c570664b1987f5ca2"
 
 [[package]]
 name = "socket2"
@@ -2140,9 +2166,9 @@ checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum_macros"
-version = "0.24.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+checksum = "4faebde00e8ff94316c01800f9054fd2ba77d30d9e922541913051d1d978918b"
 dependencies = [
  "heck 0.4.0",
  "proc-macro2",
@@ -2448,9 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
  "once_cell",
 ]
@@ -2506,9 +2532,9 @@ checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "81dee68f85cab8cf68dec42158baf3a79a1cdc065a8b103025965d6ccb7f6cbd"
 dependencies = [
  "tinyvec",
 ]

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -30,6 +30,7 @@ actix-rt = "2"
 paperclip = { version = "0.7", features = ["actix4"] }
 serde = { version = "1", features = ["derive"] }
 notify = "5.0.0-pre.15"
+serial_test = "0.7.0"
 
 [build-dependencies]
 tonic-build = "0.6"

--- a/limitador-server/src/config.rs
+++ b/limitador-server/src/config.rs
@@ -1,0 +1,200 @@
+// LIMITS_FILE: Path
+//
+// LIMIT_NAME_IN_PROMETHEUS_LABELS: bool
+//
+// REDIS_URL: StorageType { String }
+// └ REDIS_LOCAL_CACHE_ENABLED: bool
+//   └ REDIS_LOCAL_CACHE_FLUSHING_PERIOD_MS: i64 ?!
+//   └ REDIS_LOCAL_CACHE_MAX_TTL_CACHED_COUNTERS_MS: u64 -> Duration
+//   └ REDIS_LOCAL_CACHE_TTL_RATIO_CACHED_COUNTERS: u64
+//
+// INFINISPAN_URL: StorageType { String }
+//  └ INFINISPAN_CACHE_NAME: String
+//  └ INFINISPAN_COUNTERS_CONSISTENCY: enum Consistency { Weak, Strong }
+//
+// ENVOY_RLS_HOST: host // just to become ENVOY_RLS_HOST:ENVOY_RLS_PORT as String
+// ENVOY_RLS_PORT: port
+//
+// HTTP_API_HOST: host // just to become HTTP_API_HOST:HTTP_API_PORT as &str
+// HTTP_API_PORT: port
+
+use std::env;
+
+pub struct Configuration {
+    pub limits_file: Option<String>,
+    pub storage: StorageConfiguration,
+    rls_host: String,
+    rls_port: u16,
+    http_host: String,
+    http_port: u16,
+    pub limit_name_in_labels: bool,
+}
+
+impl Configuration {
+    pub fn from_env() -> Result<Self, ()> {
+        let rls_port = env::var("ENVOY_RLS_PORT").unwrap_or_else(|_| "8081".to_string());
+        let http_port = env::var("HTTP_API_PORT").unwrap_or_else(|_| "8080".to_string());
+        Ok(Self {
+            limits_file: env::var("LIMITS_FILE").ok(),
+            storage: storage_config_from_env()?,
+            rls_host: env::var("ENVOY_RLS_HOST").unwrap_or_else(|_| "0.0.0.0".to_string()),
+            rls_port: rls_port.parse().expect("Expected a port number!"),
+            http_host: env::var("HTTP_API_HOST").unwrap_or_else(|_| "0.0.0.0".to_string()),
+            http_port: http_port.parse().expect("Expected a port number!"),
+            limit_name_in_labels: env_option_is_enabled("LIMIT_NAME_IN_PROMETHEUS_LABELS"),
+        })
+    }
+
+    pub fn rlp_address(&self) -> String {
+        format!("{}:{}", self.rls_host, self.rls_port)
+    }
+
+    pub fn http_address(&self) -> String {
+        format!("{}:{}", self.http_host, self.http_port)
+    }
+}
+
+fn storage_config_from_env() -> Result<StorageConfiguration, ()> {
+    let redis_url = env::var("REDIS_URL");
+    let infinispan_url = env::var("INFINISPAN_URL");
+
+    match (redis_url, infinispan_url) {
+        (Ok(_), Ok(_)) => Err(()),
+        (Ok(url), Err(_)) => Ok(StorageConfiguration::Redis(RedisStorageConfiguration {
+            url,
+            cache: if env_option_is_enabled("REDIS_LOCAL_CACHE_ENABLED") {
+                Some(RedisStorageCacheConfiguration {
+                    flushing_period: env::var("REDIS_LOCAL_CACHE_FLUSHING_PERIOD_MS")
+                        .unwrap_or_else(|_| "1".to_string())
+                        .parse()
+                        .expect("Expected an i64"),
+                    max_ttl: env::var("REDIS_LOCAL_CACHE_MAX_TTL_CACHED_COUNTERS_MS")
+                        .unwrap_or_else(|_| "5000".to_string())
+                        .parse()
+                        .expect("Expected an u64"),
+                    ttl_ratio: env::var("REDIS_LOCAL_CACHE_TTL_RATIO_CACHED_COUNTERS")
+                        .unwrap_or_else(|_| "10".to_string())
+                        .parse()
+                        .expect("Expected an u64"),
+                })
+            } else {
+                None
+            },
+        })),
+        (Err(_), Ok(url)) => Ok(StorageConfiguration::Infinispan(
+            InfinispanStorageConfiguration {
+                url,
+                cache: env::var("INFINISPAN_CACHE_NAME").ok(),
+                consistency: env::var("INFINISPAN_COUNTERS_CONSISTENCY").ok(),
+            },
+        )),
+        _ => Ok(StorageConfiguration::InMemory),
+    }
+}
+
+fn env_option_is_enabled(env_name: &str) -> bool {
+    match env::var(env_name) {
+        Ok(value) => value == "1",
+        Err(_) => false,
+    }
+}
+
+#[derive(PartialEq, Debug)]
+pub enum StorageConfiguration {
+    InMemory,
+    Redis(RedisStorageConfiguration),
+    Infinispan(InfinispanStorageConfiguration),
+}
+
+#[derive(PartialEq, Debug)]
+pub struct RedisStorageConfiguration {
+    pub url: String,
+    pub cache: Option<RedisStorageCacheConfiguration>,
+}
+
+#[derive(PartialEq, Debug)]
+pub struct RedisStorageCacheConfiguration {
+    pub flushing_period: i64,
+    pub max_ttl: u64,
+    pub ttl_ratio: u64,
+}
+
+#[derive(PartialEq, Debug)]
+pub struct InfinispanStorageConfiguration {
+    pub url: String,
+    pub cache: Option<String>,
+    pub consistency: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::{Configuration, StorageConfiguration};
+    use serial_test::serial;
+    use std::env;
+
+    #[test]
+    #[serial]
+    fn test_config_defaults() {
+        env::remove_var("REDIS_URL");
+        env::remove_var("INFINISPAN_URL");
+
+        println!("{:?}", env::var("REDIS_URL"));
+        println!("{:?}", env::var("INFINISPAN_URL"));
+
+        let config = Configuration::from_env().unwrap();
+        assert_eq!(config.limits_file, None);
+        assert_eq!(config.storage, StorageConfiguration::InMemory);
+        assert_eq!(config.http_address(), "0.0.0.0:8080".to_string());
+        assert_eq!(config.rlp_address(), "0.0.0.0:8081".to_string());
+        assert_eq!(config.limit_name_in_labels, false);
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_redis_defaults() {
+        env::remove_var("REDIS_URL");
+        env::remove_var("INFINISPAN_URL");
+
+        println!("{:?}", env::var("REDIS_URL"));
+        println!("{:?}", env::var("INFINISPAN_URL"));
+
+        let url = "127.0.1.1:7654";
+        env::set_var("REDIS_URL", url);
+        let config = Configuration::from_env().unwrap();
+        assert_eq!(config.limits_file, None);
+        if let StorageConfiguration::Redis(ref redis_config) = config.storage {
+            assert_eq!(redis_config.url, url);
+            assert_eq!(redis_config.cache, None);
+        } else {
+            panic!("Should be a Redis config!");
+        }
+        assert_eq!(config.http_address(), "0.0.0.0:8080".to_string());
+        assert_eq!(config.rlp_address(), "0.0.0.0:8081".to_string());
+        assert_eq!(config.limit_name_in_labels, false);
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_infinispan_defaults() {
+        env::remove_var("REDIS_URL");
+        env::remove_var("INFINISPAN_URL");
+
+        println!("{:?}", env::var("REDIS_URL"));
+        println!("{:?}", env::var("INFINISPAN_URL"));
+
+        let url = "127.0.2.2:9876";
+        env::set_var("INFINISPAN_URL", url);
+        let config = Configuration::from_env().unwrap();
+        assert_eq!(config.limits_file, None);
+        if let StorageConfiguration::Infinispan(ref infinispan_config) = config.storage {
+            assert_eq!(infinispan_config.url, url);
+            assert_eq!(infinispan_config.cache, None);
+            assert_eq!(infinispan_config.consistency, None);
+        } else {
+            panic!("Should be an Infinispan config!");
+        }
+        assert_eq!(config.http_address(), "0.0.0.0:8080".to_string());
+        assert_eq!(config.rlp_address(), "0.0.0.0:8081".to_string());
+        assert_eq!(config.limit_name_in_labels, false);
+    }
+}

--- a/limitador-server/src/envoy_rls/server.rs
+++ b/limitador-server/src/envoy_rls/server.rs
@@ -128,6 +128,7 @@ mod tests {
     use super::*;
     use crate::envoy_rls::server::envoy::extensions::common::ratelimit::v3::rate_limit_descriptor::Entry;
     use crate::envoy_rls::server::envoy::extensions::common::ratelimit::v3::RateLimitDescriptor;
+    use crate::Configuration;
     use limitador::limit::Limit;
     use limitador::RateLimiter;
     use tonic::IntoRequest;
@@ -194,7 +195,11 @@ mod tests {
     #[tokio::test]
     async fn test_returns_ok_when_no_limits_apply() {
         // No limits saved
-        let rate_limiter = MyRateLimiter::new(Arc::new(Limiter::new().await.unwrap()));
+        let rate_limiter = MyRateLimiter::new(Arc::new(
+            Limiter::new(Configuration::from_env().unwrap())
+                .await
+                .unwrap(),
+        ));
 
         let req = RateLimitRequest {
             domain: "test_namespace".to_string(),
@@ -222,7 +227,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_returns_unknown_when_domain_is_empty() {
-        let rate_limiter = MyRateLimiter::new(Arc::new(Limiter::new().await.unwrap()));
+        let rate_limiter = MyRateLimiter::new(Arc::new(
+            Limiter::new(Configuration::from_env().unwrap())
+                .await
+                .unwrap(),
+        ));
 
         let req = RateLimitRequest {
             domain: "".to_string(),

--- a/limitador-server/src/http_api/server.rs
+++ b/limitador-server/src/http_api/server.rs
@@ -201,6 +201,7 @@ pub async fn run_http_server(address: &str, rate_limiter: Arc<Limiter>) -> std::
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Configuration;
     use actix_web::{test, web};
     use limitador::limit::Limit as LimitadorLimit;
     use std::collections::HashMap;
@@ -224,7 +225,11 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_metrics() {
-        let rate_limiter: Arc<Limiter> = Arc::new(Limiter::new().await.unwrap());
+        let rate_limiter: Arc<Limiter> = Arc::new(
+            Limiter::new(Configuration::from_env().unwrap())
+                .await
+                .unwrap(),
+        );
         let data = web::Data::new(rate_limiter);
         let app = test::init_service(
             App::new()
@@ -244,7 +249,9 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_limits_read() {
-        let limiter = Limiter::new().await.unwrap();
+        let limiter = Limiter::new(Configuration::from_env().unwrap())
+            .await
+            .unwrap();
         let namespace = "test_namespace";
 
         let limit = create_test_limit(&limiter, namespace, 10).await;
@@ -269,7 +276,9 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_check_and_report() {
-        let limiter = Limiter::new().await.unwrap();
+        let limiter = Limiter::new(Configuration::from_env().unwrap())
+            .await
+            .unwrap();
 
         // Create a limit with max == 1
         let namespace = "test_namespace";
@@ -315,7 +324,9 @@ mod tests {
     #[actix_rt::test]
     async fn test_check_and_report_endpoints_separately() {
         let namespace = "test_namespace";
-        let limiter = Limiter::new().await.unwrap();
+        let limiter = Limiter::new(Configuration::from_env().unwrap())
+            .await
+            .unwrap();
         let _limit = create_test_limit(&limiter, namespace, 1).await;
 
         let rate_limiter: Arc<Limiter> = Arc::new(limiter);


### PR DESCRIPTION
Moves all environment variable parsing into one location, the `Configuration` struct, for now only initialized from `from_env()` variables, but opens the seam for more options (e.g. command line args and/or config file)

Prep work for #81 and adding cmd line args?