### PR TITLE
Revert "`Limit`s `max_value` and `name` field play no role in their identity…"

### DIFF
--- a/limitador-server/src/envoy_rls/server.rs
+++ b/limitador-server/src/envoy_rls/server.rs
@@ -268,9 +268,7 @@ mod tests {
             Limit::new(namespace, 0, 60, vec!["x == 1", "y == 2"], vec!["z"]),
         ]
         .into_iter()
-        .for_each(|limit| {
-            limiter.add_limit(limit);
-        });
+        .for_each(|limit| limiter.add_limit(limit));
 
         let rate_limiter = MyRateLimiter::new(Arc::new(Limiter::Blocking(limiter)));
 

--- a/limitador-server/src/http_api/server.rs
+++ b/limitador-server/src/http_api/server.rs
@@ -390,7 +390,7 @@ mod tests {
         match &limiter {
             Limiter::Blocking(limiter) => limiter.add_limit(limit.clone()),
             Limiter::Async(limiter) => limiter.add_limit(limit.clone()),
-        };
+        }
         limit
     }
 }

--- a/limitador/src/counter.rs
+++ b/limitador/src/counter.rs
@@ -48,17 +48,6 @@ impl Counter {
         self.limit.max_value()
     }
 
-    pub fn update_to_limit(&mut self, limit: &Limit) -> bool {
-        if limit == &self.limit {
-            self.limit.set_max_value(limit.max_value());
-            if let Some(name) = limit.name() {
-                self.limit.set_name(name.to_string());
-            }
-            return true;
-        }
-        false
-    }
-
     pub fn seconds(&self) -> u64 {
         self.limit.seconds()
     }

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -201,7 +201,6 @@ use crate::storage::{AsyncCounterStorage, AsyncStorage, Authorization, CounterSt
 
 #[macro_use]
 extern crate lazy_static;
-extern crate core;
 
 pub mod counter;
 pub mod errors;
@@ -313,7 +312,7 @@ impl RateLimiter {
         self.storage.get_namespaces()
     }
 
-    pub fn add_limit(&self, limit: Limit) -> bool {
+    pub fn add_limit(&self, limit: Limit) {
         self.storage.add_limit(limit)
     }
 
@@ -484,7 +483,7 @@ impl AsyncRateLimiter {
         self.storage.get_namespaces()
     }
 
-    pub fn add_limit(&self, limit: Limit) -> bool {
+    pub fn add_limit(&self, limit: Limit) {
         self.storage.add_limit(limit)
     }
 

--- a/limitador/src/limit.rs
+++ b/limitador/src/limit.rs
@@ -26,10 +26,8 @@ impl From<String> for Namespace {
 #[derive(Eq, Debug, Clone, Serialize, Deserialize)]
 pub struct Limit {
     namespace: Namespace,
-    #[serde(skip)]
     max_value: i64,
     seconds: u64,
-    #[serde(skip)]
     name: Option<String>,
 
     // Need to sort to generate the same object when using the JSON as a key or
@@ -90,10 +88,6 @@ impl Limit {
         self.name = Some(name)
     }
 
-    pub fn set_max_value(&mut self, value: i64) {
-        self.max_value = value;
-    }
-
     pub fn conditions(&self) -> HashSet<String> {
         self.conditions.iter().map(|cond| cond.into()).collect()
     }
@@ -135,7 +129,9 @@ impl Limit {
 impl Hash for Limit {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.namespace.hash(state);
+        self.max_value.hash(state);
         self.seconds.hash(state);
+        self.name.hash(state);
 
         let mut encoded_conditions = self
             .conditions
@@ -160,7 +156,9 @@ impl Hash for Limit {
 impl PartialEq for Limit {
     fn eq(&self, other: &Self) -> bool {
         self.namespace == other.namespace
+            && self.max_value == other.max_value
             && self.seconds == other.seconds
+            && self.name == other.name
             && self.conditions == other.conditions
             && self.variables == other.variables
     }

--- a/limitador/src/storage/infinispan/infinispan_storage.rs
+++ b/limitador/src/storage/infinispan/infinispan_storage.rs
@@ -102,7 +102,7 @@ impl AsyncCounterStorage for InfinispanStorage {
                 // unnecessarily.
 
                 if let Some(val) = counter_val {
-                    let mut counter: Counter = counter_from_counter_key(&counter_key, &limit);
+                    let mut counter: Counter = counter_from_counter_key(&counter_key);
                     let ttl = 0; // TODO: calculate TTL from response headers.
                     counter.set_remaining(val);
                     counter.set_expires_in(Duration::from_secs(ttl));

--- a/limitador/src/storage/keys.rs
+++ b/limitador/src/storage/keys.rs
@@ -31,39 +31,9 @@ pub fn key_for_counters_of_limit(limit: &Limit) -> String {
     )
 }
 
-pub fn counter_from_counter_key(key: &str, limit: &Limit) -> Counter {
+pub fn counter_from_counter_key(key: &str) -> Counter {
     let counter_prefix = "counter:";
     let start_pos_counter = key.find(counter_prefix).unwrap() + counter_prefix.len();
 
-    let mut counter: Counter = serde_json::from_str(&key[start_pos_counter..]).unwrap();
-    if !counter.update_to_limit(limit) {
-        // this means some kind of data corruption _or_ most probably
-        // an out of sync `impl PartialEq for Limit` vs `pub fn key_for_counter(counter: &Counter) -> String`
-        panic!(
-            "Failed to rebuild Counter's Limit from the provided Limit: {:?} vs {:?}",
-            counter.limit(),
-            limit
-        )
-    }
-    counter
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::storage::keys::key_for_counters_of_limit;
-    use crate::Limit;
-
-    #[test]
-    fn key_for_limit_format() {
-        let limit = Limit::new(
-            "example.com",
-            10,
-            60,
-            vec!["req.method == GET"],
-            vec!["app_id"],
-        );
-        assert_eq!(
-            "namespace:{example.com},counters_of_limit:{\"namespace\":\"example.com\",\"seconds\":60,\"conditions\":[\"req.method == GET\"],\"variables\":[\"app_id\"]}",
-            key_for_counters_of_limit(&limit))
-    }
+    serde_json::from_str(&key[start_pos_counter..]).unwrap()
 }

--- a/limitador/src/storage/mod.rs
+++ b/limitador/src/storage/mod.rs
@@ -52,14 +52,14 @@ impl Storage {
         self.limits.read().unwrap().keys().cloned().collect()
     }
 
-    pub fn add_limit(&self, limit: Limit) -> bool {
+    pub fn add_limit(&self, limit: Limit) {
         let namespace = limit.namespace().clone();
         self.limits
             .write()
             .unwrap()
             .entry(namespace)
             .or_default()
-            .insert(limit)
+            .insert(limit);
     }
 
     pub fn get_limits(&self, namespace: &Namespace) -> HashSet<Limit> {
@@ -140,18 +140,19 @@ impl AsyncStorage {
         self.limits.read().unwrap().keys().cloned().collect()
     }
 
-    pub fn add_limit(&self, limit: Limit) -> bool {
+    pub fn add_limit(&self, limit: Limit) {
         let namespace = limit.namespace().clone();
 
         let mut limits_for_namespace = self.limits.write().unwrap();
 
         match limits_for_namespace.get_mut(&namespace) {
-            Some(limits) => limits.insert(limit),
+            Some(limits) => {
+                limits.insert(limit);
+            }
             None => {
                 let mut limits = HashSet::new();
                 limits.insert(limit);
                 limits_for_namespace.insert(namespace, limits);
-                true
             }
         }
     }

--- a/limitador/src/storage/redis/redis_async.rs
+++ b/limitador/src/storage/redis/redis_async.rs
@@ -108,7 +108,7 @@ impl AsyncCounterStorage for AsyncRedisStorage {
                 .await?;
 
             for counter_key in counter_keys {
-                let mut counter: Counter = counter_from_counter_key(&counter_key, &limit);
+                let mut counter: Counter = counter_from_counter_key(&counter_key);
 
                 // If the key does not exist, it means that the counter expired,
                 // so we don't have to return it.

--- a/limitador/src/storage/redis/redis_sync.rs
+++ b/limitador/src/storage/redis/redis_sync.rs
@@ -94,7 +94,7 @@ impl CounterStorage for RedisStorage {
                 con.smembers::<String, HashSet<String>>(key_for_counters_of_limit(limit))?;
 
             for counter_key in counter_keys {
-                let mut counter: Counter = counter_from_counter_key(&counter_key, limit);
+                let mut counter: Counter = counter_from_counter_key(&counter_key);
 
                 // If the key does not exist, it means that the counter expired,
                 // so we don't have to return it.

--- a/limitador/tests/helpers/tests_limiter.rs
+++ b/limitador/tests/helpers/tests_limiter.rs
@@ -39,7 +39,7 @@ impl TestsLimiter {
         }
     }
 
-    pub async fn add_limit(&self, limit: &Limit) -> bool {
+    pub async fn add_limit(&self, limit: &Limit) {
         match &self.limiter_impl {
             LimiterImpl::Blocking(limiter) => limiter.add_limit(limit.clone()),
             LimiterImpl::Async(limiter) => limiter.add_limit(limit.clone()),


### PR DESCRIPTION
Reverts Kuadrant/limitador#87

Looks like I missed a place where this was used… 
