### PR TITLE
limits file watcher supports k8s envs

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,81 @@
+---
+name: e2e tests
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+jobs:
+  limits_file_watcher:
+    name: Limits File Watcher in k8s environment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Build Limitador Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: limitador-testing
+          tags: latest
+          dockerfiles: |
+            ./Dockerfile
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1.1.0
+        with:
+          version: v0.11.1
+          config: limitador-server/script/kind-cluster.yaml
+          cluster_name: limitador-local
+          wait: 120s
+      - name: Check cluster info
+        run: |
+          kubectl cluster-info dump
+      - name: Load limitador docker image
+        run: |
+          podman save -o image.tar ${{ steps.build-image.outputs.image }}:${{ steps.build-image.outputs.tags }}
+          kind load image-archive --name limitador-local image.tar
+      - name: Deploy limitador
+        run: |
+          kubectl apply -f limitador-server/e2e/file-watcher/configmap.yaml
+          kubectl apply -f limitador-server/e2e/file-watcher/deployment.yaml
+          kubectl apply -f limitador-server/e2e/file-watcher/service.yaml
+      - name: Watch limitador pod resource (background)
+        timeout-minutes: 5
+        run: |
+          limitador-server/e2e/file-watcher/watch-pod-resource.sh </dev/null 2>/dev/null &
+      - name: Wait for limitador deployment availability
+        run: |
+          # use 'wait' to check for Available status in .status.conditions[]
+          kubectl wait deployment limitador --for condition=Available=True --timeout=300s
+      - name: Read limits from HTTP endpoint
+        uses: nick-fields/retry@v2
+        with:
+          timeout_seconds: 10
+          max_attempts: 10
+          command: |
+            ip=$(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+            port=$(kubectl get service limitador -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
+            curl "http://${ip}:${port}/limits/test" -o output-limits.json 2>/dev/null
+            jq --exit-status '.[] | select(.max_value == 1000)' output-limits.json
+      - name: Update limit in the configmap
+        run: |
+          kubectl apply -f limitador-server/e2e/file-watcher/configmap_updated.yaml
+          # Little tric to force kubelet to update local file
+          kubectl annotate $(kubectl get pods -l app=limitador -o name) bla=bla1
+      - name: Watch limitador pod resource (background)
+        timeout-minutes: 5
+        run: |
+          limitador-server/e2e/file-watcher/watch-pod-env.sh </dev/null 2>/dev/null &
+      - name: Read new limits from HTTP endpoint
+        uses: nick-fields/retry@v2
+        with:
+          timeout_seconds: 10
+          max_attempts: 10
+          retry_wait_seconds: 30
+          command: |
+            ip=$(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+            port=$(kubectl get service limitador -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
+            curl "http://${ip}:${port}/limits/test" -o output-limits-new.json 2>/dev/null
+            jq --exit-status '.[] | select(.max_value == 2000)' output-limits-new.json

--- a/limitador-server/e2e/file-watcher/configmap.yaml
+++ b/limitador-server/e2e/file-watcher/configmap.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: limitador-config
+data:
+  limits.yaml: |
+    ---
+    - namespace: test
+      max_value: 1000
+      seconds: 1
+      conditions: []
+      variables: ["user_id"]

--- a/limitador-server/e2e/file-watcher/configmap_updated.yaml
+++ b/limitador-server/e2e/file-watcher/configmap_updated.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: limitador-config
+data:
+  limits.yaml: |
+    ---
+    - namespace: test
+      max_value: 2000
+      seconds: 1
+      conditions: []
+      variables: ["user_id"]

--- a/limitador-server/e2e/file-watcher/deployment.yaml
+++ b/limitador-server/e2e/file-watcher/deployment.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: limitador
+  labels:
+    app: limitador
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: limitador
+  template:
+    metadata:
+      labels:
+        app: limitador
+    spec:
+      containers:
+        - name: limitador
+          image: localhost/limitador-testing:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: RUST_LOG
+              value: debug
+            - name: LIMITS_FILE
+              value: /tmp/limitador/limits.yaml
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 8081
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 5
+            timeoutSeconds: 2
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          volumeMounts:
+            - mountPath: /tmp/limitador
+              name: runtime-config
+      volumes:
+        - name: runtime-config
+          configMap:
+            name: limitador-config

--- a/limitador-server/e2e/file-watcher/service.yaml
+++ b/limitador-server/e2e/file-watcher/service.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: limitador
+  labels:
+    app: limitador
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: http
+    - name: grpc
+      protocol: TCP
+      port: 8081
+      targetPort: grpc
+  selector:
+    app: limitador
+  type: NodePort

--- a/limitador-server/e2e/file-watcher/watch-env.sh
+++ b/limitador-server/e2e/file-watcher/watch-env.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+ip=$(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+port=$(kubectl get service limitador -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
+POD_TYPE_NAME=`kubectl get pods -l app=limitador -o name`
+while true
+do
+    echo "#######################################################"
+    echo "##########Configmap content ###########################"
+    kubectl get configmap limitador-config -o yaml | yq e -
+    echo "##########limits.yaml content inside the pod ##########"
+    kubectl exec $(kubectl get pods -l app=limitador -o name) -- cat /tmp/limitador/limits.yaml
+    echo "##########HTTP endpoints limits ##########"
+    curl "http://${ip}:${port}/limits/test" 2>/dev/null | yq e -
+    sleep 5
+done

--- a/limitador-server/e2e/file-watcher/watch-pod-resource.sh
+++ b/limitador-server/e2e/file-watcher/watch-pod-resource.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+POD_TYPE_NAME=`kubectl get pods -l app=limitador -o name`
+while true
+do
+    echo "#######################################################"
+    echo "#######################################################"
+    echo "## POD: ${POD_TYPE_NAME} ########"
+    kubectl describe ${POD_TYPE_NAME}
+    sleep 5
+done

--- a/limitador-server/script/kind-cluster.yaml
+++ b/limitador-server/script/kind-cluster.yaml
@@ -3,4 +3,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+  image: kindest/node:v1.23.1

--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -15,10 +15,11 @@ use limitador::storage::infinispan::{Consistency, InfinispanStorageBuilder};
 use limitador::storage::redis::{AsyncRedisStorage, CachedRedisStorage, CachedRedisStorageBuilder};
 use limitador::storage::{AsyncCounterStorage, AsyncStorage};
 use limitador::{AsyncRateLimiter, AsyncRateLimiterBuilder, RateLimiter, RateLimiterBuilder};
-use notify::event::ModifyKind;
+use notify::event::{ModifyKind, RenameMode};
 use notify::{Error, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::convert::TryInto;
-use std::path::Path;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::Arc;
 use std::time::Duration;
@@ -203,6 +204,10 @@ impl Limiter {
     }
 }
 
+struct LimitsPath {
+    x: PathBuf,
+}
+
 #[actix_rt::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
@@ -228,6 +233,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let _watcher = if let Some(limits_file_path) = limit_file {
+        info!("limits file path: {}", limits_file_path);
         if let Err(e) = rate_limiter.load_limits_from_file(&limits_file_path).await {
             eprintln!("Failed to load limit file: {}", e);
             process::exit(1)
@@ -235,27 +241,83 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let limiter = Arc::clone(&rate_limiter);
         let handle = Handle::current();
+        // it should not fail because the limits file has already been read
+        let limits_file_dir = Path::new(&limits_file_path).parent().unwrap();
+        let limits_file_path_cloned = limits_file_path.to_owned();
+        // structure needed to keep state of the last known canonical limits file path
+        let mut last_known_canonical_path = LimitsPath {
+            x: fs::canonicalize(&limits_file_path).unwrap(),
+        };
 
-        let mut watcher =
-            RecommendedWatcher::new(move |result: Result<Event, Error>| match result {
+        let mut watcher = RecommendedWatcher::new(
+            move |result: Result<Event, Error>| match result {
                 Ok(ref event) => {
-                    if let EventKind::Modify(ModifyKind::Data(_)) = event.kind {
-                        let limiter = limiter.clone();
-                        let location = event.paths.first().unwrap().clone();
-                        handle.spawn(async move {
-                            match limiter.load_limits_from_file(&location).await {
-                                Ok(_) => info!("Reloaded limit file"),
-                                Err(e) => error!("Failed reloading limit file: {}", e),
+                    debug!("Event!!! {:?}", event);
+                    match event.kind {
+                        EventKind::Modify(ModifyKind::Data(_)) => {
+                            // Content has been changed
+                            // Usually happens in local or dockerized envs
+                            let location = event.paths.first().unwrap().clone();
+
+                            // Sometimes this event happens in k8s envs when
+                            // content source is a configmap and it is replaced
+                            // As the move event always occurrs,
+                            // skip reloading limit file in this event.
+
+                            // the parent dir is being watched
+                            // only reload when the limits file content changed
+                            if location == last_known_canonical_path.x {
+                                let limiter = limiter.clone();
+                                handle.spawn(async move {
+                                    match limiter.load_limits_from_file(&location).await {
+                                        Ok(_) => info!("data modified; reloaded limit file"),
+                                        Err(e) => error!("Failed reloading limit file: {}", e),
+                                    }
+                                });
+                            } else {
+                                debug!("data modification event not related to the limits file; skipped");
                             }
-                        });
+                        }
+                        EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => {
+                            // Move operation occurred
+                            // Usually happens in k8s envs when content source is a configmap
+
+                            // symbolic links resolved.
+                            let canonical_limit_file =
+                                fs::canonicalize(&limits_file_path_cloned).unwrap();
+                            info!("current canonical file path !!! {:?}", canonical_limit_file);
+                            info!(
+                                "last known canonical file path !!! {:?}",
+                                last_known_canonical_path.x
+                            );
+                            // check if the real path to the config file changed (eg: k8s ConfigMap replacement)
+                            if canonical_limit_file != last_known_canonical_path.x {
+                                last_known_canonical_path.x = canonical_limit_file.clone();
+                                info!(
+                                    "new canonical file path !!! {:?}",
+                                    last_known_canonical_path.x
+                                );
+                                let limiter = limiter.clone();
+                                handle.spawn(async move {
+                                    match limiter.load_limits_from_file(&canonical_limit_file).await
+                                    {
+                                        Ok(_) => info!("file moved; reloaded limit file"),
+                                        Err(e) => error!("Failed reloading limit file: {}", e),
+                                    }
+                                });
+                            }
+                        }
+                        _ => (), // /dev/null
                     }
+
+                    if let EventKind::Modify(ModifyKind::Data(_)) = event.kind {};
                 }
                 Err(ref e) => {
                     warn!("Something went wrong while watching limit file: {}", e);
                 }
-            })?;
-
-        watcher.watch(Path::new(&limits_file_path), RecursiveMode::Recursive)?;
+            },
+        )?;
+        watcher.watch(limits_file_dir, RecursiveMode::Recursive)?;
         Some(watcher)
     } else {
         None


### PR DESCRIPTION
#### what

Currently, the limits file watcher reloads limits when there is a file change on local and dockerized environments when the file is mounted from host local filesystem. However, when the limits file source is a populated volume with data stored in a k8s configmap, the watcher does not reload limits when the content is changed. 

This PR adds support to limits stored in k8s config map and reloads limits when the configmap's limits change.

Additionally, End2End integration test implemented. It is called `Limits File Watcher in k8s environment`

#### why 
Unfortunately (or fortunately), things in k8s env are not what they look like. When k8s (kubelet agent) populates a volume with data stored in a ConfigMap, the resulting file is a symbolic link. And when there is a configmap replacement, the file is not "simply" updated. In few words, it is moved. 

With the current configuration, the inotify watcher was totally unaware of the configmap replacements.

```rust
 let mut watcher = RecommendedWatcher::new(move |result: Result<Event, Error>| match result {      
         Ok(ref event) => {                                                          
             if let EventKind::Modify(ModifyKind::Data(_)) = event.kind { ... }                                                                
         }                                                                                                                              
 })?;                                                                                                                                                          
 watcher.watch(Path::new(&limits_file_path), RecursiveMode::Recursive)?;             
```
The `EventHandler` implemented with the closure never gets called. It's not an issue with the filtering of the event. The event simply did not happen. 

What does a volume populated with data stored in a configmap look like? It is the result of a double symlink indirection

```
/home/limitador/bin $ ls -al /home/limitador/etc                                                     
total 0                                                                                              
drwxrwsrwx    3 root     10007600       100 Jul 20 22:25 .                                           
drwxr-sr-x    1 limitado limitado        17 Jul 20 22:25 ..                                          
drwxr-sr-x    2 root     10007600        47 Jul 20 22:25 ..2022_07_20_22_25_07.358335008             
lrwxrwxrwx    1 root     10007600        31 Jul 20 22:25 ..data -> ..2022_07_20_22_25_07.358335008                    
lrwxrwxrwx    1 root     10007600        28 Jul 20 22:25 limitador-config.yaml -> ..data/limitador-config.yaml
```

And what happens when there is a configmap replacement? A new directory is created, new file is created in it with the new content of the configmap. Then, k8s updates the `..data` , removing the existing symlink and creating a new one targeting the newly created directory. Then removes the old base directory with the old data file. After a configmap replacement, the resulting `/home/limitador/etc` folder looks like this:

```
/home/limitador/bin $ ls -al /home/limitador/etc                                                     
total 0                                                                                              
drwxrwsrwx    3 root     10007600       100 Jul 20 22:32 .                                           
drwxr-sr-x    1 limitado limitado        17 Jul 20 22:25 ..                                          
drwxr-sr-x    2 root     10007600        47 Jul 20 22:32 ..2022_07_20_22_32_00.023471129             
lrwxrwxrwx    1 root     10007600        31 Jul 20 22:32 ..data -> ..2022_07_20_22_32_00.023471129                        
lrwxrwxrwx    1 root     10007600        28 Jul 20 22:25 limitador-config.yaml -> ..data/limitador-config.yaml
```

Note that `/home/limitador/etc/limitador-config.yaml` symlink targets the new content and effectively has changed the content. However, only because the underlying symlink pointers have changed. There was not a real OS file content "Write" operation. The operation would be something like this

```bash
ln -sfn ..2022_07_20_22_32_00.023471129 data
```

Logging events generated when actually the content of a file has changed
<details>

```
2022-07-21T15:18:15Z INFO  limitador_server] Event!!! Event { kind: Modify(Data(Any)), paths: ["/home/eguzki/testing/1/limits.yaml"], attr:tracker: None, attr:flag: None, attr:info: None, attr:source: None }
[2022-07-21T15:18:15Z INFO  limitador_server] Event!!! Event { kind: Modify(Metadata(Any)), paths: ["/home/eguzki/testing/1/limits.yaml"], attr:tracker: None, attr:flag: None, attr:info: None, attr:source: None }
[2022-07-21T15:18:15Z INFO  limitador_server] Event!!! Event { kind: Access(Close(Write)), paths: ["/home/eguzki/testing/1/limits.yaml"], attr:tracker: None, attr:flag: None, attr:info: None, attr:source: None }
```

</details>

Logging events generated when imitating k8s behavior locally with `ln -sfn ..2022_07_20_22_32_00.023471129 data'' (watching the parent directory instead of the file)
<details>

```
2022-07-21T16:35:35Z INFO  limitador_server] Event!!! Event { kind: Create(File), paths: ["/home/eguzki/testing/CuRqFcEx"], attr:tracker: None, attr:flag: None, attr:info: None, attr:source: None }
[2022-07-21T16:35:35Z INFO  limitador_server] Event!!! Event { kind: Modify(Name(From)), paths: ["/home/eguzki/testing/CuRqFcEx"], attr:tracker: Some(13913), attr:flag: None, attr:info: None, attr:source: None }
[2022-07-21T16:35:35Z INFO  limitador_server] Event!!! Event { kind: Modify(Name(To)), paths: ["/home/eguzki/testing/data"], attr:tracker: Some(13913), attr:flag: None, attr:info: None, attr:source: None }
[2022-07-21T16:35:35Z INFO  limitador_server] Event!!! Event { kind: Modify(Name(Both)), paths: ["/home/eguzki/testing/CuRqFcEx", "/home/eguzki/testing/data"], attr:tracker: Some(13913), attr:flag: None, attr:info: None, attr:source: None }
```

</details>

Logging events generated when in k8s when there is a configmap replacement (watching the parent directory instead of the file)
<details>

```
[2022-07-21T22:43:27Z INFO  limitador_server] Event!!! Event { kind: Create(Folder), paths: ["/home/limitador/etc/..2022_07_21_22_43_27.287303002"], attr:tracker: None, attr:flag: None, attr:info: None, attr:source: None }
[2022-07-21T22:43:27Z INFO  limitador_server] Event!!! Event { kind: Modify(Metadata(Any)), paths: ["/home/limitador/etc/..2022_07_21_22_43_27.287303002"], attr:tracker: None, attr:flag: None, attr:info: None, attr:source: None }
[2022-07-21T22:43:27Z INFO  limitador_server] Event!!! Event { kind: Create(File), paths: ["/home/limitador/etc/..data_tmp"], attr:tracker: None, attr:flag: None, attr:info: None, attr:source: None }
[2022-07-21T22:43:27Z INFO  limitador_server] Event!!! Event { kind: Modify(Name(From)), paths: ["/home/limitador/etc/..data_tmp"], attr:tracker: Some(4021), attr:flag: None, attr:info: None, attr:source: None }
[2022-07-21T22:43:27Z INFO  limitador_server] Event!!! Event { kind: Modify(Name(To)), paths: ["/home/limitador/etc/..data"], attr:tracker: Some(4021), attr:flag: None, attr:info: None, attr:source: None }
[2022-07-21T22:43:27Z INFO  limitador_server] Event!!! Event { kind: Modify(Name(Both)), paths: ["/home/limitador/etc/..data_tmp", "/home/limitador/etc/..data"], attr:tracker: Some(4021), attr:flag: None, attr:info: None, attr:source: None }
[2022-07-21T22:43:27Z INFO  limitador_server] Event!!! Event { kind: Remove(File), paths: ["/home/limitador/etc/..data/hash"], attr:tracker: None, attr:flag: None, attr:info: None, attr:source: None }
[2022-07-21T22:43:27Z INFO  limitador_server] Event!!! Event { kind: Remove(File), paths: ["/home/limitador/etc/..data/limitador-config.yaml"], attr:tracker: None, attr:flag: None, attr:info: None, attr:source: None }
[2022-07-21T22:43:27Z INFO  limitador_server] Event!!! Event { kind: Remove(Folder), paths: ["/home/limitador/etc/..2022_07_21_22_36_55.967227880"], attr:tracker: None, attr:flag: None, attr:info: None, attr:source: None }
```

</details>

#### how

Basic ideas "taken" from [Kubernetes ConfigMap hot-reload in action with Viper](https://medium.com/@xcoulon/kubernetes-configmap-hot-reload-in-action-with-viper-d413128a1c9a) and linked [PR](https://github.com/spf13/viper/pull/415) to support "watchConfig" in k8s.

First relevant change: watch the parent directory instead of the limits file. This will enable reading events.

Then, limits will be reloaded when either of the following happens
* actual limits file content has been changed
* Keep state of the last known real (no symlinks) limits file path and the limits real file path has changed. 

An enhancement for the second case would be to use the hash and only reload limits when the hash changes.

This implementation should cover Limitador running in both bare metal and k8s envs.

#### verification steps locally

Create first limits file path dir `limitDir1` under some path (in my case `/home/eguzki/testing`)
```
mkdir /home/eguzki/testing/limitDir1
```

Add content to the first limits file

```yaml
cat <<EOF >/home/eguzki/testing/limitDir1/limits.yaml
---
- namespace: test_namespace
  max_value: 20
  seconds: 60
  conditions:
    - "req.method == GET"
  variables:
    - user_id
EOF
```
First directory symlink
```bash
cd /home/eguzki/testing
ln -s limitDir1 data
```
Second file symlink
```bash
cd /home/eguzki/testing
ln -s data/limits.yaml limits.yaml
```
Run limitador with `LIMITS_FILE=/home/eguzki/testing/limits.yaml`. Note that no `limitDir1` or `data` references.
```
RUST_LOG=debug LIMITS_FILE=/home/eguzki/testing/limits.yaml cargo run
```
Read limits from admin HTTP endpoint
```
curl http://127.0.0.1:8080/limits/test_namespace 2>/dev/null | yq e -P 
- namespace: test_namespace
  max_value: 20
  seconds: 60
  name: null
  conditions:
    - req.method == GET
  variables:
    - user_id
```
Create a second configuration in `limitDir2`. Limitador must be up&running.

```
mkdir /home/eguzki/testing/limitDir2
```

Add content to the second limits file. Same as the first limits file, but limit's condition changes to `POST`.

```yaml
cat <<EOF >/home/eguzki/testing/limitDir2/limits.yaml
---
- namespace: test_namespace
  max_value: 20
  seconds: 60
  conditions:
    - "req.method == POST"
  variables:
    - user_id
EOF
```
Update `data` symlink to target second limit file
```bash
cd /home/eguzki/testing
ln -sfn limitDir2 data
```
Verify limits have been reloaded reading the admin HTTP endpoint
```
curl http://127.0.0.1:8080/limits/test_namespace 2>/dev/null | yq e -P 
- namespace: test_namespace
  max_value: 20
  seconds: 60
  name: null
  conditions:
    - req.method == POST
  variables:
    - user_id
```

#### verification steps in k8s

We will be using Limitador Operator to easily manage limits from the Limitador CR.

First, push limitador image with the current PR changes
```
docker build -t quay.io/3scale/limitador:support-k8s .
docker push quay.io/3scale/limitador:support-k8s
```
Clone limitador operator and run local k8s env
```
git clone https://github.com/Kuadrant/limitador-operator.git
cd limitador-operator
make local-setup
```
Deploy limitador with our custom image one and one limit configured
```yaml
k apply -f - <<EOF
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador-sample
spec:
  replicas: 1
  version: support-k8s
  listener:
    http:
      port: 8080
    grpc:
      port: 8081
  limits:
    - conditions: ["get-toy == yes"]
      max_value: 2
      namespace: toystore-app
      seconds: 30
      variables: []
EOF
```
When up&running, read limits from admin HTTP endpoint
```
kubectl port-forward deployment/limitador-sample 8080
```
```yaml
curl http://127.0.0.1:8080/limits/toystore-app 2>/dev/null | yq e -P 
- namespace: toystore-app
  max_value: 2
  seconds: 30
  name: null
  conditions:
    - get-toy == yes
  variables: []
```
Modify limits from the Limit CR. This will trigger a change in the configmap, which in turn will trigger change in mounted path of the limitador's deployment. The change is simple, just update limit's `seconds` to `60`.
```
k patch limitador limitador-sample --type json --patch='[{"op": "replace", "path": "/spec/limits/0/seconds", "value": 60}]'
```

Wait few secs, eventually, the admin HTTP endpoint should return the new limit verifying it has been reloaded. 

```yaml
curl http://127.0.0.1:8080/limits/toystore-app 2>/dev/null | yq e -P 
- namespace: toystore-app
  max_value: 2
  seconds: 60
  name: null
  conditions:
    - get-toy == yes
  variables: []
```

