### PR TITLE
sandbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ COPY ./Cargo.toml ./Cargo.toml
 COPY limitador/Cargo.toml ./limitador/Cargo.toml
 COPY limitador-server/Cargo.toml ./limitador-server/Cargo.toml
 
+ENV RUSTFLAGS="-C target-feature=-crt-static"
+
 RUN mkdir -p limitador/src limitador-server/src
 
 RUN echo "fn main() {println!(\"if you see this, the build broke\")}" > limitador/src/main.rs \
@@ -40,6 +42,8 @@ RUN source $HOME/.cargo/env \
 # ------------------------------------------------------------------------------
 
 FROM alpine:3.16
+
+RUN apk add libssl3 libgcc
 
 RUN addgroup -g 1000 limitador \
     && adduser -D -s /bin/sh -u 1000 -G limitador limitador

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ port, that implements the Envoy Rate Limit protocol (v3).
 - [**How it works**](/doc/how-it-works.md)
 - [**Limits storage**](#limits-storage)
 - [**Development**](#development)
+- [**Testing Environment**](limitador-server/docs/sandbox.md)
 - [**Kubernetes**](limitador-server/kubernetes/)
 - [**License**](#license)
 

--- a/limitador-server/docs/sandbox.md
+++ b/limitador-server/docs/sandbox.md
@@ -1,0 +1,68 @@
+## Testing Environment
+
+### Requirements
+
+* *docker*
+* *docker-compose*
+
+### Setup
+
+Clone the project
+
+```bash
+git clone https://github.com/Kuadrant/limitador.git
+cd limitador/limitador-server/sandbox
+```
+
+Check out `make help` for all the targets.
+
+### Deployment options
+
+| Limitador's configuration | Command | Info |
+| ------------- | ----- | ----- |
+| In-memory configuration | `make deploy-in-memory` | Counters are held in Limitador (ephemeral) |
+| Redis | `make deploy-redis` | Uses Redis to store counters |
+| Redis Cached | `make deploy-redis-cached` | Uses Redis to store counters, with an in-memory cache |
+| Infinispan | `make deploy-infinispan` | Uses Infinispan to store counters |
+
+### Limitador's admin HTTP endpoint
+
+```bash
+curl -i http://127.0.0.1:18080/limits/test_namespace
+```
+
+### Downstream traffic
+
+**Upstream** service implemented by [httpbin.org](https://httpbin.org/)
+
+```bash
+curl -i -H "Host: example.com" http://127.0.0.1:18000/get
+```
+
+### Limitador Image
+
+By default, the sandbox will run Limitador's `limitador-testing:latest` image.
+
+**Building `limitador-testing:latest` image**
+
+You can easily build the limitador's image from the current workspace code base with:
+
+```bash
+make build
+```
+
+The image will be tagged with `limitador-testing:latest`
+
+**Using custom Limitador's image**
+
+The `LIMITADOR_IMAGE` environment variable overrides the default image. For example:
+
+```bash
+make deploy-in-memory LIMITADOR_IMAGE=quay.io/3scale/limitador:latest
+```
+
+### Tear Down
+
+```bash
+make tear-down
+```

--- a/limitador-server/sandbox/Makefile
+++ b/limitador-server/sandbox/Makefile
@@ -1,0 +1,50 @@
+SHELL := /bin/bash
+
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
+
+DOCKER_COMPOSE ?= $(shell which docker-compose 2>/dev/null)
+DOCKER ?= $(shell which docker 2>/dev/null || echo "docker")
+
+all: help
+
+##@ General
+
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk commands is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# http://linuxcommand.org/lc3_adv_awk.php
+
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Deployment Options
+
+deploy-in-memory: clean ## Counters are held in Limitador (ephemeral)
+	$(DOCKER_COMPOSE) -f docker-compose-envoy.yaml -f docker-compose-limitador-memory.yaml up
+
+deploy-redis: clean ## Uses Redis to store counters
+	$(DOCKER_COMPOSE) -f docker-compose-envoy.yaml -f docker-compose-limitador-redis.yaml up
+
+deploy-redis-cached: clean ## Uses Redis to store counters, with an in-memory cache
+	$(DOCKER_COMPOSE) -f docker-compose-envoy.yaml -f docker-compose-limitador-redis-cached.yaml up
+
+deploy-infinispan: clean ## Uses Infinispan to store counters
+	$(DOCKER_COMPOSE) -f docker-compose-envoy.yaml -f docker-compose-limitador-infinispan.yaml up
+
+##@ Helper targets
+
+build: ## Build "limitador-testing" image
+	$(DOCKER) build -t limitador-testing -f ../../Dockerfile ../../
+
+clean: ## clean all containers
+	- $(DOCKER_COMPOSE) -f docker-compose-envoy.yaml -f docker-compose-limitador-memory.yaml down --volumes --remove-orphans
+	- $(DOCKER_COMPOSE) -f docker-compose-envoy.yaml -f docker-compose-limitador-redis.yaml down --volumes --remove-orphans
+	- $(DOCKER_COMPOSE) -f docker-compose-envoy.yaml -f docker-compose-limitador-redis-cached.yaml down --volumes --remove-orphans
+	- $(DOCKER_COMPOSE) -f docker-compose-envoy.yaml -f docker-compose-limitador-infinispan.yaml down --volumes --remove-orphans

--- a/limitador-server/sandbox/docker-compose-envoy.yaml
+++ b/limitador-server/sandbox/docker-compose-envoy.yaml
@@ -1,0 +1,27 @@
+---
+version: '2.2'
+services:
+  envoy:
+    image: envoyproxy/envoy:v1.20-latest
+    depends_on:
+      - upstream
+    command:
+      - /usr/local/bin/envoy
+      - --config-path
+      - /etc/envoy.yaml
+      - --log-level
+      - info
+      - --component-log-level
+      - http:debug,router:debug
+      - --service-cluster
+      - proxy
+    expose:
+      - "80"
+      - "8001"
+    ports:
+      - "18000:80"
+      - "18001:8001"
+    volumes:
+      - ./envoy.yaml:/etc/envoy.yaml
+  upstream:
+    image: kennethreitz/httpbin

--- a/limitador-server/sandbox/docker-compose-limitador-infinispan.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-infinispan.yaml
@@ -16,7 +16,7 @@ services:
       - 0.0.0.0
       - --http-port
       - "8080"
-      - -vvv
+      - -vvvv
       - /opt/kuadrant/limits/limits.yaml
       - infinispan
       - --cache-name

--- a/limitador-server/sandbox/docker-compose-limitador-infinispan.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-infinispan.yaml
@@ -1,0 +1,45 @@
+---
+version: '2.2'
+services:
+  limitador:
+    image: ${LIMITADOR_IMAGE:-limitador-testing}
+    depends_on:
+      infinispan:
+        condition: service_healthy
+    command:
+      - limitador-server
+      - --rls-ip
+      - 0.0.0.0
+      - --rls-port
+      - "8081"
+      - --http-ip
+      - 0.0.0.0
+      - --http-port
+      - "8080"
+      - -vvv
+      - /opt/kuadrant/limits/limits.yaml
+      - infinispan
+      - --cache-name
+      - "limitador-sandbox"
+      - --consistency
+      - "Strong"
+      - http://username:password@infinispan:11222
+    expose:
+      - "8080"
+      - "8081"
+    ports:
+      - "18080:8080"
+    volumes:
+      - ./limits.yaml:/opt/kuadrant/limits/limits.yaml
+  infinispan:
+    image: infinispan/server:13.0.10.Final
+    environment:
+      USER: username
+      PASS: password
+    expose:
+      - "11222"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11222/rest/v2/cache-managers/default/health/status"]
+      interval: 30s
+      timeout: 10s
+      retries: 5

--- a/limitador-server/sandbox/docker-compose-limitador-memory.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-memory.yaml
@@ -1,0 +1,27 @@
+---
+version: '2.2'
+services:
+  limitador:
+    image: ${LIMITADOR_IMAGE:-limitador-testing}
+    depends_on:
+      - envoy
+    command:
+      - limitador-server
+      - --rls-ip
+      - 0.0.0.0
+      - --rls-port
+      - "8081"
+      - --http-ip
+      - 0.0.0.0
+      - --http-port
+      - "8080"
+      - -vvv
+      - /opt/kuadrant/limits/limits.yaml
+      - memory
+    expose:
+      - "8080"
+      - "8081"
+    ports:
+      - "18080:8080"
+    volumes:
+      - ./limits.yaml:/opt/kuadrant/limits/limits.yaml

--- a/limitador-server/sandbox/docker-compose-limitador-redis-cached.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-redis-cached.yaml
@@ -1,0 +1,39 @@
+---
+version: '2.2'
+services:
+  limitador:
+    image: ${LIMITADOR_IMAGE:-limitador-testing}
+    depends_on:
+      - envoy
+      - redis
+    command:
+      - limitador-server
+      - --rls-ip
+      - 0.0.0.0
+      - --rls-port
+      - "8081"
+      - --http-ip
+      - 0.0.0.0
+      - --http-port
+      - "8080"
+      - -vvv
+      - /opt/kuadrant/limits/limits.yaml
+      - redis_cached
+      - --ttl
+      - "3"
+      - --ratio
+      - "11"
+      - --flush-period
+      - "2"
+      - --max-cached
+      - "5000"
+      - redis://redis:6379
+    expose:
+      - "8080"
+      - "8081"
+    ports:
+      - "18080:8080"
+    volumes:
+      - ./limits.yaml:/opt/kuadrant/limits/limits.yaml
+  redis:
+    image: redis:5

--- a/limitador-server/sandbox/docker-compose-limitador-redis.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-redis.yaml
@@ -1,0 +1,31 @@
+---
+version: '2.2'
+services:
+  limitador:
+    image: ${LIMITADOR_IMAGE:-limitador-testing}
+    depends_on:
+      - envoy
+      - redis
+    command:
+      - limitador-server
+      - --rls-ip
+      - 0.0.0.0
+      - --rls-port
+      - "8081"
+      - --http-ip
+      - 0.0.0.0
+      - --http-port
+      - "8080"
+      - -vvv
+      - /opt/kuadrant/limits/limits.yaml
+      - redis
+      - redis://redis:6379
+    expose:
+      - "8080"
+      - "8081"
+    ports:
+      - "18080:8080"
+    volumes:
+      - ./limits.yaml:/opt/kuadrant/limits/limits.yaml
+  redis:
+    image: redis:5

--- a/limitador-server/sandbox/envoy.yaml
+++ b/limitador-server/sandbox/envoy.yaml
@@ -1,0 +1,84 @@
+---
+static_resources:
+  listeners:
+  - name: main
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    filter_chains:
+      - filters:
+        - name: envoy.filters.network.http_connection_manager
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+            stat_prefix: ingress_http
+            route_config:
+              name: local_route
+              virtual_hosts:
+                - name: local_service
+                  domains:
+                    - "*"
+                  routes:
+                    - match:
+                        prefix: "/"
+                      route:
+                        cluster: upstream
+                        rate_limits:
+                          - actions:
+                            - request_headers:
+                                header_name: :method
+                                descriptor_key: req.method
+                            - request_headers:
+                                header_name: :path
+                                descriptor_key: req.path
+            http_filters:
+            - name: envoy.filters.http.ratelimit
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
+                domain: "test_namespace"
+                failure_mode_deny: true
+                timeout: 3s
+                rate_limit_service:
+                  transport_api_version: "v3"
+                  grpc_service:
+                    envoy_grpc:
+                      cluster_name: limitador
+            - name: envoy.filters.http.router
+  clusters:
+    - name: upstream
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      lb_policy: round_robin
+      load_assignment:
+        cluster_name: upstream
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: upstream
+                  port_value: 80
+    - name: limitador
+      connect_timeout: 1s
+      type: STRICT_DNS
+      lb_policy: round_robin
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: limitador
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: limitador
+                  port_value: 8081
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/limitador-server/sandbox/limits.yaml
+++ b/limitador-server/sandbox/limits.yaml
@@ -1,0 +1,13 @@
+---
+- namespace: test_namespace
+  max_value: 10
+  seconds: 60
+  conditions:
+    - "req.method == GET"
+  variables: []
+- namespace: test_namespace
+  max_value: 5
+  seconds: 60
+  conditions:
+    - "req.method == POST"
+  variables: []


### PR DESCRIPTION
## Testing Environment

### Requirements

* *docker*
* *docker-compose*

### Setup

Clone the project

```bash
git clone https://github.com/Kuadrant/limitador.git
cd limitador/limitador-server/sandbox
```

Check out `make help` for all the targets.

### Deployment options

| Limitador's configuration | Command | Info |
| ------------- | ----- | ----- |
| In-memory configuration | `make deploy-in-memory` | Counters are held in Limitador (ephemeral) |
| Redis | `make deploy-redis` | Uses Redis to store counters |
| Redis Cached | `make deploy-redis-cached` | Uses Redis to store counters, with an in-memory cache |
| Infinispan | `make deploy-infinispan` | Uses Infinispan to store counters |

### Limitador's admin HTTP endpoint

```bash
curl -i http://127.0.0.1:18080/limits/test_namespace
```

### Downstream traffic

**Upstream** service implemented by [httpbin.org](https://httpbin.org/)

```bash
curl -i -H "Host: example.com" http://127.0.0.1:18000/get
```

### Limitador Image

By default, the sandbox will run Limitador's `limitador-testing:latest` image.

**Building `limitador-testing:latest` image**

You can easily build the limitador's image from the current workspace code base with:

```bash
make build
```

The image will be tagged with `limitador-testing:latest`

**Using custom Limitador's image**

The `LIMITADOR_IMAGE` environment variable overrides the default image. For example:

```bash
make deploy-in-memory LIMITADOR_IMAGE=quay.io/3scale/limitador:latest
```

### Tear Down

```bash
make tear-down
```