### PR TITLE
Watcher supports k8s envs 2

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,81 @@
+---
+name: e2e tests
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+jobs:
+  limits_file_watcher:
+    name: Limits File Watcher in k8s environment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Build Limitador Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: limitador-testing
+          tags: latest
+          dockerfiles: |
+            ./Dockerfile
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1.1.0
+        with:
+          version: v0.11.1
+          config: limitador-server/script/kind-cluster.yaml
+          cluster_name: limitador-local
+          wait: 120s
+      - name: Check cluster info
+        run: |
+          kubectl cluster-info dump
+      - name: Load limitador docker image
+        run: |
+          podman save -o image.tar ${{ steps.build-image.outputs.image }}:${{ steps.build-image.outputs.tags }}
+          kind load image-archive --name limitador-local image.tar
+      - name: Deploy limitador
+        run: |
+          kubectl apply -f limitador-server/e2e/file-watcher/configmap.yaml
+          kubectl apply -f limitador-server/e2e/file-watcher/deployment.yaml
+          kubectl apply -f limitador-server/e2e/file-watcher/service.yaml
+      - name: Watch limitador pod resource (background)
+        timeout-minutes: 5
+        run: |
+          limitador-server/e2e/file-watcher/watch-pod-resource.sh </dev/null 2>/dev/null &
+      - name: Wait for limitador deployment availability
+        run: |
+          # use 'wait' to check for Available status in .status.conditions[]
+          kubectl wait deployment limitador --for condition=Available=True --timeout=300s
+      - name: Read limits from HTTP endpoint
+        uses: nick-fields/retry@v2
+        with:
+          timeout_seconds: 10
+          max_attempts: 10
+          command: |
+            ip=$(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+            port=$(kubectl get service limitador -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
+            curl "http://${ip}:${port}/limits/test" -o output-limits.json 2>/dev/null
+            jq --exit-status '.[] | select(.max_value == 1000)' output-limits.json
+      - name: Update limit in the configmap
+        run: |
+          kubectl apply -f limitador-server/e2e/file-watcher/configmap_updated.yaml
+          # Little tric to force kubelet to update local file
+          kubectl annotate $(kubectl get pods -l app=limitador -o name) bla=bla1
+      - name: Watch limitador pod resource (background)
+        timeout-minutes: 5
+        run: |
+          limitador-server/e2e/file-watcher/watch-pod-env.sh </dev/null 2>/dev/null &
+      - name: Read new limits from HTTP endpoint
+        uses: nick-fields/retry@v2
+        with:
+          timeout_seconds: 10
+          max_attempts: 10
+          retry_wait_seconds: 30
+          command: |
+            ip=$(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+            port=$(kubectl get service limitador -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
+            curl "http://${ip}:${port}/limits/test" -o output-limits-new.json 2>/dev/null
+            jq --exit-status '.[] | select(.max_value == 2000)' output-limits-new.json

--- a/limitador-server/e2e/file-watcher/configmap.yaml
+++ b/limitador-server/e2e/file-watcher/configmap.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: limitador-config
+data:
+  limits.yaml: |
+    ---
+    - namespace: test
+      max_value: 1000
+      seconds: 1
+      conditions: []
+      variables: ["user_id"]

--- a/limitador-server/e2e/file-watcher/configmap_updated.yaml
+++ b/limitador-server/e2e/file-watcher/configmap_updated.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: limitador-config
+data:
+  limits.yaml: |
+    ---
+    - namespace: test
+      max_value: 2000
+      seconds: 1
+      conditions: []
+      variables: ["user_id"]

--- a/limitador-server/e2e/file-watcher/deployment.yaml
+++ b/limitador-server/e2e/file-watcher/deployment.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: limitador
+  labels:
+    app: limitador
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: limitador
+  template:
+    metadata:
+      labels:
+        app: limitador
+    spec:
+      containers:
+        - name: limitador
+          image: localhost/limitador-testing:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: RUST_LOG
+              value: debug
+            - name: LIMITS_FILE
+              value: /tmp/limitador/limits.yaml
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 8081
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 5
+            timeoutSeconds: 2
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          volumeMounts:
+            - mountPath: /tmp/limitador
+              name: runtime-config
+      volumes:
+        - name: runtime-config
+          configMap:
+            name: limitador-config

--- a/limitador-server/e2e/file-watcher/service.yaml
+++ b/limitador-server/e2e/file-watcher/service.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: limitador
+  labels:
+    app: limitador
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: http
+    - name: grpc
+      protocol: TCP
+      port: 8081
+      targetPort: grpc
+  selector:
+    app: limitador
+  type: NodePort

--- a/limitador-server/e2e/file-watcher/watch-env.sh
+++ b/limitador-server/e2e/file-watcher/watch-env.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+ip=$(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+port=$(kubectl get service limitador -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
+POD_TYPE_NAME=`kubectl get pods -l app=limitador -o name`
+while true
+do
+    echo "#######################################################"
+    echo "##########Configmap content ###########################"
+    kubectl get configmap limitador-config -o yaml | yq e -
+    echo "##########limits.yaml content inside the pod ##########"
+    kubectl exec $(kubectl get pods -l app=limitador -o name) -- cat /tmp/limitador/limits.yaml
+    echo "##########HTTP endpoints limits ##########"
+    curl "http://${ip}:${port}/limits/test" 2>/dev/null | yq e -
+    sleep 5
+done

--- a/limitador-server/e2e/file-watcher/watch-pod-resource.sh
+++ b/limitador-server/e2e/file-watcher/watch-pod-resource.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+POD_TYPE_NAME=`kubectl get pods -l app=limitador -o name`
+while true
+do
+    echo "#######################################################"
+    echo "#######################################################"
+    echo "## POD: ${POD_TYPE_NAME} ########"
+    kubectl describe ${POD_TYPE_NAME}
+    sleep 5
+done

--- a/limitador-server/script/kind-cluster.yaml
+++ b/limitador-server/script/kind-cluster.yaml
@@ -3,4 +3,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+  image: kindest/node:v1.23.1

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -435,6 +435,10 @@ impl RateLimiter {
             for limit in limits_to_keep_in_ns.difference(&limits_in_namespace) {
                 self.add_limit(limit.clone());
             }
+
+            for limit in limits_to_keep_in_ns.union(&limits_in_namespace) {
+                self.storage.update_limit(limit);
+            }
         }
 
         Ok(())
@@ -612,6 +616,10 @@ impl AsyncRateLimiter {
 
             for limit in limits_to_keep_in_ns.difference(&limits_in_namespace) {
                 self.add_limit(limit.clone());
+            }
+
+            for limit in limits_to_keep_in_ns.union(&limits_in_namespace) {
+                self.storage.update_limit(limit);
             }
         }
 

--- a/limitador/src/storage/mod.rs
+++ b/limitador/src/storage/mod.rs
@@ -62,6 +62,24 @@ impl Storage {
             .insert(limit)
     }
 
+    pub fn update_limit(&self, update: &Limit) -> bool {
+        let mut namespaces = self.limits.write().unwrap();
+        let limits = namespaces.get_mut(update.namespace());
+        if let Some(limits) = limits {
+            let req_update = if let Some(limit) = limits.get(update) {
+                limit.max_value() != update.max_value() || limit.name() != update.name()
+            } else {
+                false
+            };
+            if req_update {
+                limits.remove(update);
+                limits.insert(update.clone());
+                return true;
+            }
+        }
+        false
+    }
+
     pub fn get_limits(&self, namespace: &Namespace) -> HashSet<Limit> {
         match self.limits.read().unwrap().get(namespace) {
             Some(limits) => limits.iter().cloned().collect(),
@@ -154,6 +172,24 @@ impl AsyncStorage {
                 true
             }
         }
+    }
+
+    pub fn update_limit(&self, update: &Limit) -> bool {
+        let mut namespaces = self.limits.write().unwrap();
+        let limits = namespaces.get_mut(update.namespace());
+        if let Some(limits) = limits {
+            let req_update = if let Some(limit) = limits.get(update) {
+                limit.max_value() != update.max_value() || limit.name() != update.name()
+            } else {
+                false
+            };
+            if req_update {
+                limits.remove(update);
+                limits.insert(update.clone());
+                return true;
+            }
+        }
+        false
     }
 
     pub fn get_limits(&self, namespace: &Namespace) -> HashSet<Limit> {


### PR DESCRIPTION
Take two on #95 - making sure I don't loose changes in case I screwed up while rebasing... 

The changes with the other PRs are mostly:
 - [x] rebasing
 - [x] 2feab6c that actually updates existing limits if their `max_value` or `name` property changed
 - [x] 36670d6 Cosmetics to the initial change