### PR TITLE
Full version

### DIFF
--- a/limitador-server/build.rs
+++ b/limitador-server/build.rs
@@ -1,34 +1,13 @@
+use std::error::Error;
 use std::process::Command;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let git_hash = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
-        .output()
-        .ok()
-        .filter(|output| output.status.success())
-        .and_then(|x| String::from_utf8(x.stdout).ok())
-        .map(|hash| hash[..8].to_owned());
+fn main() -> Result<(), Box<dyn Error>> {
+    set_git_hash("LIMITADOR_GIT_HASH");
+    set_profile("LIMITADOR_PROFILE");
+    generate_protobuf()
+}
 
-    let dirty = Command::new("git")
-        .args(&["diff", "--stat"])
-        .output()
-        .ok()
-        .filter(|output| output.status.success())
-        .map(|output| !matches!(output.stdout.len(), 0));
-
-    match git_hash {
-        None => println!("cargo:rustc-env=LIMITADOR_GIT_HASH=unknown"),
-        Some(hash) => match dirty {
-            Some(true) => println!("cargo:rustc-env=LIMITADOR_GIT_HASH={}-dirty", hash),
-            Some(false) => println!("cargo:rustc-env=LIMITADOR_GIT_HASH={}", hash),
-            _ => unreachable!("How can we have a git hash, yet not know if the tree is dirty?"),
-        },
-    }
-
-    if let Ok(profile) = std::env::var("PROFILE") {
-        println!("cargo:rustc-env=LIMITADOR_PROFILE={}", profile);
-    }
-
+fn generate_protobuf() -> Result<(), Box<dyn Error>> {
     tonic_build::configure()
         .build_server(true)
         .out_dir("src/envoy_rls/protobufs")
@@ -41,4 +20,37 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ],
         )?;
     Ok(())
+}
+
+fn set_profile(env: &str) {
+    if let Ok(profile) = std::env::var("PROFILE") {
+        println!("cargo:rustc-env={}={}", env, profile);
+    }
+}
+
+fn set_git_hash(env: &str) {
+    let git_hash = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|x| String::from_utf8(x.stdout).ok())
+        .map(|hash| hash[..8].to_owned());
+
+    if let Some(hash) = git_hash {
+        let dirty = Command::new("git")
+            .args(&["diff", "--stat"])
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .map(|output| !matches!(output.stdout.len(), 0));
+
+        match dirty {
+            Some(true) => println!("cargo:rustc-env={}={}-dirty", env, hash),
+            Some(false) => println!("cargo:rustc-env={}={}", env, hash),
+            _ => unreachable!("How can we have a git hash, yet not know if the tree is dirty?"),
+        }
+    } else {
+        println!("cargo:rustc-env={}=unknown", env);
+    }
 }

--- a/limitador-server/build.rs
+++ b/limitador-server/build.rs
@@ -1,4 +1,22 @@
+use std::process::Command;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let git_hash = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|x| String::from_utf8(x.stdout).ok())
+        .map(|hash| hash[..8].to_owned());
+
+    println!(
+        "cargo:rustc-env=LIMITADOR_GIT_HASH={}",
+        git_hash.unwrap_or_else(|| "unknown".to_owned())
+    );
+    if let Ok(profile) = std::env::var("PROFILE") {
+        println!("cargo:rustc-env=LIMITADOR_PROFILE={}", profile);
+    }
+
     tonic_build::configure()
         .build_server(true)
         .out_dir("src/envoy_rls/protobufs")

--- a/limitador-server/build.rs
+++ b/limitador-server/build.rs
@@ -9,10 +9,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .and_then(|x| String::from_utf8(x.stdout).ok())
         .map(|hash| hash[..8].to_owned());
 
-    println!(
-        "cargo:rustc-env=LIMITADOR_GIT_HASH={}",
-        git_hash.unwrap_or_else(|| "unknown".to_owned())
-    );
+    let dirty = Command::new("git")
+        .args(&["diff", "--stat"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| !matches!(output.stdout.len(), 0));
+
+    if Some(true) == dirty && git_hash.is_some() {
+        println!(
+            "cargo:rustc-env=LIMITADOR_GIT_HASH={}-dirty",
+            git_hash.unwrap_or_else(|| "unknown".to_owned())
+        );
+    } else {
+        println!(
+            "cargo:rustc-env=LIMITADOR_GIT_HASH={}",
+            git_hash.unwrap_or_else(|| "unknown".to_owned())
+        );
+    }
+
     if let Ok(profile) = std::env::var("PROFILE") {
         println!("cargo:rustc-env=LIMITADOR_PROFILE={}", profile);
     }

--- a/limitador-server/build.rs
+++ b/limitador-server/build.rs
@@ -16,16 +16,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .filter(|output| output.status.success())
         .map(|output| !matches!(output.stdout.len(), 0));
 
-    if Some(true) == dirty && git_hash.is_some() {
-        println!(
-            "cargo:rustc-env=LIMITADOR_GIT_HASH={}-dirty",
-            git_hash.unwrap_or_else(|| "unknown".to_owned())
-        );
-    } else {
-        println!(
-            "cargo:rustc-env=LIMITADOR_GIT_HASH={}",
-            git_hash.unwrap_or_else(|| "unknown".to_owned())
-        );
+    match git_hash {
+        None => println!("cargo:rustc-env=LIMITADOR_GIT_HASH=unknown"),
+        Some(hash) => match dirty {
+            Some(true) => println!("cargo:rustc-env=LIMITADOR_GIT_HASH={}-dirty", hash),
+            Some(false) => println!("cargo:rustc-env=LIMITADOR_GIT_HASH={}", hash),
+            _ => unreachable!("How can we have a git hash, yet not know if the tree is dirty?"),
+        },
     }
 
     if let Ok(profile) = std::env::var("PROFILE") {

--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -334,12 +334,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn create_config() -> (Configuration, String) {
-    let full_version = format!(
-        "{} build v{} ({})",
-        LIMITADOR_PROFILE,
-        LIMITADOR_VERSION,
-        env!("LIMITADOR_GIT_HASH")
-    );
+    let full_version = {
+        let build = match LIMITADOR_PROFILE {
+            "release" => "".to_owned(),
+            other => format!(" {} build", other),
+        };
+
+        format!(
+            "v{} ({}){}",
+            LIMITADOR_VERSION,
+            env!("LIMITADOR_GIT_HASH"),
+            build,
+        )
+    };
 
     // figure defaults out
     let default_limit_file = env::var("LIMITS_FILE").unwrap_or_else(|_| "".to_string());

--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -46,6 +46,8 @@ mod http_api;
 mod config;
 
 const LIMITADOR_VERSION: &str = env!("CARGO_PKG_VERSION");
+const LIMITADOR_PROFILE: &str = env!("LIMITADOR_PROFILE");
+const LIMITADOR_HEADER: &str = "Limitador Server";
 
 #[derive(Error, Debug)]
 pub enum LimitadorServerError {
@@ -222,17 +224,21 @@ impl Limiter {
 
 #[actix_rt::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = create_config();
+    let config = {
+        let (config, version) = create_config();
+        println!("{} {}", LIMITADOR_HEADER, version);
+        let mut builder = Builder::new();
+        if let Some(level) = config.log_level {
+            builder.filter(None, level);
+        } else {
+            builder.parse_default_env();
+        }
+        builder.init();
 
-    let mut builder = Builder::new();
-    if let Some(level) = config.log_level {
-        builder.filter(None, level);
-    } else {
-        builder.parse_default_env();
-    }
-    builder.init();
-
-    info!("Using config: {:?}", config);
+        info!("Version: {}", version);
+        info!("Using config: {:?}", config);
+        config
+    };
 
     let limit_file = config.limits_file.clone();
     let envoy_rls_address = config.rlp_address();
@@ -327,7 +333,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn create_config() -> Configuration {
+fn create_config() -> (Configuration, String) {
+    let full_version = format!(
+        "{} build v{} ({})",
+        LIMITADOR_PROFILE,
+        LIMITADOR_VERSION,
+        env!("LIMITADOR_GIT_HASH")
+    );
+
     // figure defaults out
     let default_limit_file = env::var("LIMITS_FILE").unwrap_or_else(|_| "".to_string());
 
@@ -374,8 +387,8 @@ fn create_config() -> Configuration {
     };
 
     // build app
-    let cmdline = App::new("Limitador Server")
-        .version(LIMITADOR_VERSION)
+    let cmdline = App::new(LIMITADOR_HEADER)
+        .version(full_version.as_str())
         .author("The Kuadrant team - github.com/Kuadrant")
         .about("Rate Limiting Server")
         .disable_help_subcommand(true)
@@ -571,7 +584,7 @@ fn create_config() -> Configuration {
         _ => unreachable!("Verbosity should at most be 4!"),
     };
 
-    config
+    (config, full_version)
 }
 
 fn storage_config_from_env() -> Result<StorageConfiguration, ()> {


### PR DESCRIPTION
This adds a more explicit version string (version, as per the `Cargo.toml`, the profile used to build if not `release` and the git sha), to the `--help` & `--version` but also logs it to `stdout` on startup as well as to the logs (`INFO`). The idea is that we have good traceability for when "something goes wrong". 

### Example
<details>

```
$ ./limitador-server ./limitador-server/examples/limits.yaml
Limitador Server debug build v0.5.1 (b3509e30)
```

#### At `INFO` log level, you get the version as well, and the dump of the actual config that'll be used 

```
$ ./limitador-server -vv ./limitador-server/examples/limits.yaml
Limitador Server debug build v0.5.1 (b3509e30)
[2022-08-02T14:01:06Z INFO  limitador_server] Version debug build v0.5.1 (b3509e30)
[2022-08-02T14:01:06Z INFO  limitador_server] Using config: Configuration { limits_file: "./limitador-server/examples/limits.yaml", storage: InMemory, rls_host: "0.0.0.0", rls_port: 8081, http_host: "0.0.0.0", http_port: 8080, limit_name_in_labels: false, log_level: Some(Info) }
```

#### if the directory tree isn't "clean", i.e. has uncommited changes

The `-dirty` suffix is added to the sha
```
$ ./limitador-server ./limitador-server/examples/limits.yaml
Limitador Server debug build v0.5.1 (2a57743d-dirty)
```

#### Logs the profile target

If it's not `release`:

```
$  ./target/debug/limitador-server --version
Limitador Server v0.5.1 (aa83d91e) debug build
```

#### finally, if `git` can't be executed, or this isn't build of a fork

Instead of the sha, you get `unknown`

```
$ ./limitador-server ./limitador-server/examples/limits.yaml
Limitador Server debug build v0.5.1 (unknown)
```
</details>
