### PR TITLE
Dev versioning?

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,7 @@ checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
 
 [[package]]
 name = "limitador"
-version = "0.2.0"
+version = "0.3.0-dev"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "limitador-server"
-version = "0.5.1"
+version = "1.0.0-dev"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limitador-server"
-version = "0.5.1"
+version = "1.0.0-dev"
 authors = ["Alex Snaps <asnaps@redhat.com>", "Eguzki Astiz Lezaun <eguzki@redhat.com>", "David Ortiz <z.david.ortiz@gmail.com>"]
 license = "Apache-2.0"
 keywords = ["rate-limiting", "rate", "limiter", "envoy", "rls"]

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limitador"
-version = "0.2.0"
+version = "0.3.0-dev"
 authors = ["David Ortiz <z.david.ortiz@gmail.com>"]
 license = "Apache-2.0"
 keywords = ["rate-limiting", "rate", "limiter"]


### PR DESCRIPTION
This changes the version of the crate to `0.3.0` and the binary's to `1.0.0`… I've added a `-dev` suffix. Trying to reflect what gets build off `main` or other branches, but mostly _not_ at 'tags' for actual releases… so to avoid ever having e.g. a `1.0.0` before and it released, and proposing to increment right after release re-adding the suffix. Not attached to `-dev` tho… just anything that differentiates it from an actual release. 
@guicassolato any point of view? It'd be great to have this across all components, wdyt?