### PR TITLE
Re-enabled lenient mode

### DIFF
--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -18,7 +18,7 @@ infinispan = [ "limitador/infinispan_storage" ]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-limitador = { path = "../limitador", features = [] }
+limitador = { path = "../limitador", features = ['lenient_conditions'] }
 tokio = { version = "1", features = ["full"] }
 thiserror = "1"
 tonic = "0.8"

--- a/limitador-server/examples/limits.yaml
+++ b/limitador-server/examples/limits.yaml
@@ -4,7 +4,7 @@
   max_value: 10
   seconds: 60
   conditions:
-    - "req.method == 'GET'"
+    - "req.method == GET"
   variables:
     - user_id
 -
@@ -12,6 +12,6 @@
   max_value: 5
   seconds: 60
   conditions:
-    - "req.method == 'POST'"
+    - "req.method == POST"
   variables:
     - user_id

--- a/limitador-server/examples/limits.yaml
+++ b/limitador-server/examples/limits.yaml
@@ -4,7 +4,7 @@
   max_value: 10
   seconds: 60
   conditions:
-    - "req.method == GET"
+    - "req.method == 'GET'"
   variables:
     - user_id
 -
@@ -12,6 +12,6 @@
   max_value: 5
   seconds: 60
   conditions:
-    - "req.method == POST"
+    - "req.method == 'POST'"
   variables:
     - user_id

--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -211,7 +211,7 @@ impl Limiter {
                             Self::Async(limiter) => limiter.configure_with(limits).await?,
                         }
                         if limitador::limit::check_deprecated_syntax_usages_and_reset() {
-                            error!("You are using deprecated syntax for your condition! See guide https://kudrant.io/migration/limitador/constraints")
+                            error!("You are using deprecated syntax for your conditions! See the migration guide https://kudrant.io/migration/limitador/constraints")
                         }
                         Ok(())
                     }

--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -210,6 +210,9 @@ impl Limiter {
                             Self::Blocking(limiter) => limiter.configure_with(limits)?,
                             Self::Async(limiter) => limiter.configure_with(limits).await?,
                         }
+                        if limitador::limit::check_deprecated_syntax_usages_and_reset() {
+                            error!("You are using deprecated syntax for your condition! See guide https://kudrant.io/migration/limitador/constraints")
+                        }
                         Ok(())
                     }
                     Err(e) => Err(LimitadorServerError::ConfigFile(format!(

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -17,6 +17,7 @@ edition = "2021"
 default = ["redis_storage"]
 redis_storage = ["redis", "r2d2", "tokio"]
 infinispan_storage = ["infinispan", "reqwest"]
+lenient_conditions = []
 
 [dependencies]
 ttl_cache = "0.5"


### PR DESCRIPTION
This re-adds the support for the "deprecated"/old syntax for conditions: 
 - [x] as a feature in the crate
 - [x] that the server enables, and checks whether some condition did use the deprecated syntax while parsing the config file, and possibly warns the user (despite being logged at `ERROR` level, as this is the default level): 

```
[2022-08-29T20:05:17Z ERROR limitador_server] You are using deprecated syntax for your condition! See guide https://kudrant.io/migration/limitador/constraints
```

The address is: 
 - [ ] open to suggestion, wrt to its parts as well
 - [ ] missing the content that explains what's expected… 

Should we add a "non-lenient" parser option, so the user can validate their newer files? Or make a "only validate limit file" option, that will not start the server but only parse the `limits file`… so that can stay even after this lenient mode gets deprecated, I think @maleck13 proposed something like that actually…