### PR TITLE
Make infinispan a feature of the server

### DIFF
--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -12,10 +12,13 @@ documentation = "https://docs.rs/limitador"
 readme = "README.md"
 edition = "2021"
 
+[features]
+infinispan = [ "limitador/infinispan_storage" ]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-limitador = { path = "../limitador", features = ['infinispan_storage'] }
+limitador = { path = "../limitador", features = [] }
 tokio = { version = "1", features = ["full"] }
 thiserror = "1"
 tonic = "0.6"

--- a/limitador-server/build.rs
+++ b/limitador-server/build.rs
@@ -4,6 +4,7 @@ use std::process::Command;
 fn main() -> Result<(), Box<dyn Error>> {
     set_git_hash("LIMITADOR_GIT_HASH");
     set_profile("LIMITADOR_PROFILE");
+    set_features("LIMITADOR_FEATURES");
     generate_protobuf()
 }
 
@@ -17,6 +18,12 @@ fn generate_protobuf() -> Result<(), Box<dyn Error>> {
         ],
     )?;
     Ok(())
+}
+
+fn set_features(env: &str) {
+    if cfg!(feature = "infinispan") {
+        println!("cargo:rustc-env={}=[+infinispan]", env);
+    }
 }
 
 fn set_profile(env: &str) {

--- a/limitador-server/src/config.rs
+++ b/limitador-server/src/config.rs
@@ -87,6 +87,7 @@ impl Default for Configuration {
 pub enum StorageConfiguration {
     InMemory,
     Redis(RedisStorageConfiguration),
+    #[cfg(feature = "infinispan")]
     Infinispan(InfinispanStorageConfiguration),
 }
 
@@ -105,6 +106,7 @@ pub struct RedisStorageCacheConfiguration {
 }
 
 #[derive(PartialEq, Eq, Debug)]
+#[cfg(feature = "infinispan")]
 pub struct InfinispanStorageConfiguration {
     pub url: String,
     pub cache: Option<String>,

--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -4,18 +4,20 @@
 extern crate log;
 extern crate clap;
 
+#[cfg(feature = "infinispan")]
+use crate::config::InfinispanStorageConfiguration;
 use crate::config::{
-    Configuration, InfinispanStorageConfiguration, RedisStorageCacheConfiguration,
-    RedisStorageConfiguration, StorageConfiguration,
+    Configuration, RedisStorageCacheConfiguration, RedisStorageConfiguration, StorageConfiguration,
 };
 use crate::envoy_rls::server::run_envoy_rls_server;
 use crate::http_api::server::run_http_server;
-use clap::builder::PossibleValuesParser;
 use clap::{App, Arg, SubCommand};
 use env_logger::Builder;
 use limitador::errors::LimitadorError;
 use limitador::limit::Limit;
+#[cfg(feature = "infinispan")]
 use limitador::storage::infinispan::{Consistency, InfinispanStorageBuilder};
+#[cfg(feature = "infinispan")]
 use limitador::storage::infinispan::{
     DEFAULT_INFINISPAN_CONSISTENCY, DEFAULT_INFINISPAN_LIMITS_CACHE_NAME,
 };
@@ -29,7 +31,6 @@ use limitador::{AsyncRateLimiter, AsyncRateLimiterBuilder, RateLimiter, RateLimi
 use log::LevelFilter;
 use notify::event::{ModifyKind, RenameMode};
 use notify::{Error, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
-use std::convert::TryInto;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -37,7 +38,6 @@ use std::time::Duration;
 use std::{env, process};
 use thiserror::Error;
 use tokio::runtime::Handle;
-use url::Url;
 
 mod envoy_rls;
 mod http_api;
@@ -75,6 +75,7 @@ impl Limiter {
             StorageConfiguration::Redis(cfg) => {
                 Self::redis_limiter(cfg, config.limit_name_in_labels).await
             }
+            #[cfg(feature = "infinispan")]
             StorageConfiguration::Infinispan(cfg) => {
                 Self::infinispan_limiter(cfg, config.limit_name_in_labels).await
             }
@@ -134,10 +135,13 @@ impl Limiter {
         cached_redis_storage.build().await
     }
 
+    #[cfg(feature = "infinispan")]
     async fn infinispan_limiter(
         cfg: InfinispanStorageConfiguration,
         limit_name_labels: bool,
     ) -> Self {
+        use url::Url;
+
         let parsed_url = Url::parse(&cfg.url).unwrap();
 
         let mut builder = InfinispanStorageBuilder::new(
@@ -370,8 +374,10 @@ fn create_config() -> (Configuration, String) {
     let redis_ttl_ratio_default = env::var("REDIS_LOCAL_CACHE_TTL_RATIO_CACHED_COUNTERS")
         .unwrap_or_else(|_| DEFAULT_TTL_RATIO_CACHED_COUNTERS.to_string());
 
+    #[cfg(feature = "infinispan")]
     let infinispan_cache_default = env::var("INFINISPAN_CACHE_NAME")
         .unwrap_or_else(|_| DEFAULT_INFINISPAN_LIMITS_CACHE_NAME.to_string());
+    #[cfg(feature = "infinispan")]
     let infinispan_consistency_default = env::var("INFINISPAN_COUNTERS_CONSISTENCY")
         .unwrap_or_else(|_| DEFAULT_INFINISPAN_CONSISTENCY.to_string());
 
@@ -502,38 +508,40 @@ fn create_config() -> (Configuration, String) {
                         .display_order(5)
                         .help("Maximum amount of counters cached"),
                 ),
-        )
-        .subcommand(
-            SubCommand::with_name("infinispan")
-                .about("Uses Infinispan to store counters")
-                .display_order(4)
-                .arg(
-                    Arg::with_name("URL")
-                        .help("Infinispan URL to use")
-                        .display_order(1)
-                        .required(true)
-                        .index(1),
-                )
-                .arg(
-                    Arg::with_name("cache name")
-                        .short('n')
-                        .long("cache-name")
-                        .takes_value(true)
-                        .default_value(&infinispan_cache_default)
-                        .display_order(2)
-                        .help("Name of the cache to store counters in"),
-                )
-                .arg(
-                    Arg::with_name("consistency")
-                        .short('c')
-                        .long("consistency")
-                        .takes_value(true)
-                        .default_value(&infinispan_consistency_default)
-                        .value_parser(PossibleValuesParser::new(["Strong", "Weak"]))
-                        .display_order(3)
-                        .help("The consistency to use to read from the cache"),
-                ),
         );
+
+    #[cfg(feature = "infinispan")]
+    let cmdline = cmdline.subcommand(
+        SubCommand::with_name("infinispan")
+            .about("Uses Infinispan to store counters")
+            .display_order(4)
+            .arg(
+                Arg::with_name("URL")
+                    .help("Infinispan URL to use")
+                    .display_order(1)
+                    .required(true)
+                    .index(1),
+            )
+            .arg(
+                Arg::with_name("cache name")
+                    .short('n')
+                    .long("cache-name")
+                    .takes_value(true)
+                    .default_value(&infinispan_cache_default)
+                    .display_order(2)
+                    .help("Name of the cache to store counters in"),
+            )
+            .arg(
+                Arg::with_name("consistency")
+                    .short('c')
+                    .long("consistency")
+                    .takes_value(true)
+                    .default_value(&infinispan_consistency_default)
+                    .value_parser(clap::builder::PossibleValuesParser::new(["Strong", "Weak"]))
+                    .display_order(3)
+                    .help("The consistency to use to read from the cache"),
+            ),
+    );
 
     let matches = cmdline.get_matches();
 
@@ -552,6 +560,7 @@ fn create_config() -> (Configuration, String) {
                 max_counters: *sub.get_one("max").unwrap(),
             }),
         }),
+        #[cfg(feature = "infinispan")]
         Some(("infinispan", sub)) => {
             StorageConfiguration::Infinispan(InfinispanStorageConfiguration {
                 url: sub.value_of("URL").unwrap().to_owned(),
@@ -623,6 +632,7 @@ fn storage_config_from_env() -> Result<StorageConfiguration, ()> {
                 None
             },
         })),
+        #[cfg(feature = "infinispan")]
         (Err(_), Ok(url)) => Ok(StorageConfiguration::Infinispan(
             InfinispanStorageConfiguration {
                 url,

--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -31,6 +31,7 @@ use limitador::{AsyncRateLimiter, AsyncRateLimiterBuilder, RateLimiter, RateLimi
 use log::LevelFilter;
 use notify::event::{ModifyKind, RenameMode};
 use notify::{Error, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::env::VarError;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -604,7 +605,11 @@ fn create_config() -> (Configuration, String) {
 
 fn storage_config_from_env() -> Result<StorageConfiguration, ()> {
     let redis_url = env::var("REDIS_URL");
-    let infinispan_url = env::var("INFINISPAN_URL");
+    let infinispan_url = if cfg!(feature = "infinispan") {
+        env::var("INFINISPAN_URL")
+    } else {
+        Err(VarError::NotPresent)
+    };
 
     match (redis_url, infinispan_url) {
         (Ok(_), Ok(_)) => Err(()),

--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -47,6 +47,7 @@ mod config;
 
 const LIMITADOR_VERSION: &str = env!("CARGO_PKG_VERSION");
 const LIMITADOR_PROFILE: &str = env!("LIMITADOR_PROFILE");
+const LIMITADOR_FEATURES: Option<&'static str> = option_env!("LIMITADOR_FEATURES");
 const LIMITADOR_HEADER: &str = "Limitador Server";
 
 #[derive(Error, Debug)]
@@ -345,9 +346,10 @@ fn create_config() -> (Configuration, String) {
         };
 
         format!(
-            "v{} ({}){}",
+            "v{} ({}) {}{}",
             LIMITADOR_VERSION,
             env!("LIMITADOR_GIT_HASH"),
+            LIMITADOR_FEATURES.unwrap_or(""),
             build,
         )
     };


### PR DESCRIPTION
Closes #108 
On MacOS, this makes the `release`-build binary about 17% smaller (to ~10MB), RSS is barely impacted (~2%) at less than 6MB (that's using the same config in both cases, i.e. in-mem with two limits loaded). 
On Linux, I get better results in terms of gain, while the file size is about the same gain ~16%, the RSS gain is much nicer with -45% down from 9.8 to 5.4MB! 