### PR TITLE
Resolve limits_file_dir from the canonicalized limit_file

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -57,7 +57,7 @@ jobs:
           command: |
             ip=$(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
             port=$(kubectl get service limitador -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
-            curl "http://${ip}:${port}/limits/test" -o output-limits.json 2>/dev/null
+            curl -s "http://${ip}:${port}/limits/test" | tee output-limits.json 
             jq --exit-status '.[] | select(.max_value == 1000)' output-limits.json
       - name: Update limit in the configmap
         run: |
@@ -77,5 +77,5 @@ jobs:
           command: |
             ip=$(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
             port=$(kubectl get service limitador -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
-            curl "http://${ip}:${port}/limits/test" -o output-limits-new.json 2>/dev/null
+            curl -s "http://${ip}:${port}/limits/test" | tee output-limits-new.json 
             jq --exit-status '.[] | select(.max_value == 2000)' output-limits-new.json

--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -269,7 +269,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let limiter = Arc::clone(&rate_limiter);
     let handle = Handle::current();
     // it should not fail because the limits file has already been read
-    let limits_file_dir = Path::new(&limit_file).parent().unwrap();
+    let mut limits_file_dir = Path::new(&limit_file).parent().unwrap();
+    if limits_file_dir.as_os_str().is_empty() {
+        limits_file_dir = Path::new(".");
+    }
     let limits_file_path_cloned = limit_file.to_owned();
     // structure needed to keep state of the last known canonical limits file path
     let mut last_known_canonical_path = fs::canonicalize(&limit_file).unwrap();


### PR DESCRIPTION
closes #119 

Somehow using the `fs::canonicalize(&limit_file)` to resolve the parent directory fails monitoring the changes in a k8s cluster. I'm not real sure why… I need to understand how k8s maps this `ConfigMap` and remaps it on changes… 
In the meantime, if we didn't resolve a absolute path from the `Path::new(&limit_file).parent()` we then fall back to use the parent dir… 