### PR TITLE
Stricter Limit parsing

### DIFF
--- a/limitador/src/limit.rs
+++ b/limitador/src/limit.rs
@@ -50,9 +50,10 @@ impl From<String> for Namespace {
 }
 
 #[derive(Eq, Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Limit {
     namespace: Namespace,
-    #[serde(skip_serializing, default)]
+    #[serde(skip_serializing)]
     max_value: i64,
     seconds: u64,
     #[serde(skip_serializing, default)]

--- a/limitador/src/limit.rs
+++ b/limitador/src/limit.rs
@@ -53,7 +53,7 @@ impl From<String> for Namespace {
 #[serde(deny_unknown_fields)]
 pub struct Limit {
     namespace: Namespace,
-    #[serde(skip_serializing)]
+    #[serde(skip_serializing, default)]
     max_value: i64,
     seconds: u64,
     #[serde(skip_serializing, default)]


### PR DESCRIPTION
We ignore `max_value` as per #87 … but since we use the same (de)serialization mechanism for data coming in (limits file) and data going out (to the counter storage), this comes with a sad side effect:

You can leave the `max_value` out of your limits file and it will default to `0` which is probably not what one would ever want. I could still validate that when loading limits from the file, they have a non-negative value as a separate validation… but with this change, at least if someone misspells `max_value` (e.g. `maxvalue`, which happened to me), the parsing will fail with a good explanation.

```rust
    #[serde(skip_serializing, default)]
    max_value: i64,
```