### PR TITLE
Fallback to github sha, if it can't be resolved using `git`

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -32,6 +32,8 @@ jobs:
           tags: ${{ env.IMG_TAGS }}
           dockerfiles: |
             ./Dockerfile
+          build-args: |
+            GITHUB_SHA=${{ github.sha }}
       - name: Push Image
         if: ${{ !env.ACT }}
         id: push-to-quay

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ COPY ./Cargo.toml ./Cargo.toml
 COPY limitador/Cargo.toml ./limitador/Cargo.toml
 COPY limitador-server/Cargo.toml ./limitador-server/Cargo.toml
 
+ARG GITHUB_SHA
+ENV GITHUB_SHA=${GITHUB_SHA:-unknown}
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 
 RUN mkdir -p limitador/src limitador-server/src

--- a/limitador-server/build.rs
+++ b/limitador-server/build.rs
@@ -33,7 +33,7 @@ fn set_profile(env: &str) {
 }
 
 fn set_git_hash(env: &str) {
-    let git_hash = Command::new("git")
+    let git_hash = Command::new("/usr/bin/git")
         .args(&["rev-parse", "HEAD"])
         .output()
         .ok()
@@ -55,6 +55,9 @@ fn set_git_hash(env: &str) {
             _ => unreachable!("How can we have a git hash, yet not know if the tree is dirty?"),
         }
     } else {
-        println!("cargo:rustc-env={}=unknown", env);
+        let fallback = option_env!("GITHUB_SHA")
+            .map(|sha| if sha.len() > 8 { &sha[..8] } else { sha })
+            .unwrap_or("NO_SHA");
+        println!("cargo:rustc-env={}={}", env, fallback);
     }
 }

--- a/limitador-server/build.rs
+++ b/limitador-server/build.rs
@@ -33,15 +33,15 @@ fn set_profile(env: &str) {
 }
 
 fn set_git_hash(env: &str) {
-    let git_hash = Command::new("/usr/bin/git")
+    let git_sha = Command::new("/usr/bin/git")
         .args(&["rev-parse", "HEAD"])
         .output()
         .ok()
         .filter(|output| output.status.success())
         .and_then(|x| String::from_utf8(x.stdout).ok())
-        .map(|hash| hash[..8].to_owned());
+        .map(|sha| sha[..8].to_owned());
 
-    if let Some(hash) = git_hash {
+    if let Some(sha) = git_sha {
         let dirty = Command::new("git")
             .args(&["diff", "--stat"])
             .output()
@@ -50,8 +50,8 @@ fn set_git_hash(env: &str) {
             .map(|output| !matches!(output.stdout.len(), 0));
 
         match dirty {
-            Some(true) => println!("cargo:rustc-env={}={}-dirty", env, hash),
-            Some(false) => println!("cargo:rustc-env={}={}", env, hash),
+            Some(true) => println!("cargo:rustc-env={}={}-dirty", env, sha),
+            Some(false) => println!("cargo:rustc-env={}={}", env, sha),
             _ => unreachable!("How can we have a git hash, yet not know if the tree is dirty?"),
         }
     } else {


### PR DESCRIPTION
Before this change, we'd lose the sha this was build from and the version would report `unknown`:

```sh
❯ docker run quay.io/kuadrant/limitador limitador-server --help
Limitador Server v1.0.0-dev (unknown)
The Kuadrant team - github.com/Kuadrant
```

But now `b9d2e48e`

```sh
❯ docker run quay.io/kuadrant/limitador:github_sha limitador-server --help
Limitador Server v1.0.0-dev (b9d2e48e)
The Kuadrant team - github.com/Kuadrant
```