### PR TITLE
Add version to package spec used to publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,4 +30,4 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
       - name: Publish
-        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p limitador
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p limitador:${{ github.event.inputs.version }}


### PR DESCRIPTION
With adding the version to the package being released, if the `Cargo.toml` `version` isn't matching, the publish would fail:

```
cargo publish -p limitador:0.3.0
error: package ID specification `limitador@0.3.0` did not match any packages
Did you mean one of these?

  limitador@0.3.0-rc1

```