### PR TITLE
Preparing crate-v0.3.0 and server-v1.0.0 releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,7 +1185,7 @@ checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "limitador"
-version = "0.3.0-rc1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "limitador-server"
-version = "1.0.0-rc1"
+version = "1.0.0"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/limitador-server/CHANGELOG.md
+++ b/limitador-server/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 Notable changes to the Limitador server will be tracked in this document.
 
+## 1.0.0 - 2022-10-21
+
+### Added
+
+- Support for command line arguments and options
+- Validation of the complete environment on start
+- `LIMIT_FILE` is monitored for changes and hot-reloaded
+
+### Changed
+
+- [Syntax for condition](../doc/migrations/conditions.md) within `Limit`s changed
+- Removed the HTTP endpoints to mutate `Limit`s
+- `Limit`s are solely loaded from the `LIMIT_FILE`
+- Only `Counter`s to `Limit`s are persisted, `Limit`s loaded from file are held in memory
+- Duplicated `Limit`s with same namespace, conditions and variables is now impossible
+
+### Removed
+
+- By default, Infinispan support isn't compiled in. Use feature `infinispan` at build time
+
 ## 0.5.1 - 2022-05-25
 
 ### Changed

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limitador-server"
-version = "1.0.0-rc1"
+version = "1.0.0"
 authors = ["Alex Snaps <asnaps@redhat.com>", "Eguzki Astiz Lezaun <eguzki@redhat.com>", "David Ortiz <z.david.ortiz@gmail.com>"]
 license = "Apache-2.0"
 keywords = ["rate-limiting", "rate", "limiter", "envoy", "rls"]

--- a/limitador-server/kubernetes/README.md
+++ b/limitador-server/kubernetes/README.md
@@ -116,7 +116,7 @@ kubectl apply -f limitador-podmonitor.yaml
 ```
 
 ### Grafana dashboard
-Then, if you have grafana deployed in the cluster, you can import a [3scale Limitador](limitador-grafanadashboard.json) grafana dashboard that we have prepared, which includes:
+Then, if you have grafana deployed in the cluster, you can import a [Kuadrant Limitador](limitador-grafanadashboard.json) grafana dashboard that we have prepared, which includes:
 - Kuard envoyproxy sidecar metrics (globally and per pod)
 - Limitador metrics (globally and per pod)
 - And for every deployed component (limitador, kuard, redis):

--- a/limitador-server/kubernetes/limitador-deployment.yaml
+++ b/limitador-server/kubernetes/limitador-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: limitador
-          image: quay.io/3scale/limitador:0.5.1
+          image: quay.io/kuadrant/limitador:v1.0.0
           imagePullPolicy: IfNotPresent
           env:
             - name: RUST_LOG

--- a/limitador-server/kubernetes/limitador-grafanadashboard.json
+++ b/limitador-server/kubernetes/limitador-grafanadashboard.json
@@ -2010,7 +2010,7 @@
   "schemaVersion": 18,
   "style": "dark",
   "tags": [
-    "3scale",
+    "kuadrant",
     "backend"
   ],
   "templating": {
@@ -2149,6 +2149,6 @@
     ]
   },
   "timezone": "",
-  "title": "3scale Limitador",
+  "title": "Kuadrant Limitador",
   "version": 8
 }

--- a/limitador/CHANGELOG.md
+++ b/limitador/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 Notable changes to Limitador will be tracked in this document.
 
+## 0.3.0 - 2022-10-21
+
+### Added 
+
+ - Infinispan as an alternate storage for counters `feature = "infinispan_storage"`
+ - `lenient_conditions` feature to allow for deprecated `Condition` syntax
+ - Added _not equal_ (`!=`) operator support in `Condition`s
+
+### Changed
+
+ - `Limit`s are now _only_ held in memory, `Counter`s for there are stored using the `Storage` used
+ - `Limit` identity now ignores the `max_value` and `name` field. So that they can be replaced properly
+ - Serialized form for `Limit`s, used to lookup `Counter`s, changed. Upgrading to this version, existing persisted `Counter`s are lost 
+ - New `Condition` syntax within `Limit`s: `KEY_B == 'VALUE_B'`
+ - Simplified some function signatures to avoid explicit lifetimes 
+ - Functions now take `Into<Namespace>` instead of `TryInto` as the conversion can't ever fail
+ - Only require a reference `&Namespace` when ownership over the value isn't needed
+ - Defaults for `(Async)CounterStorage` configurations are now public
+ - Errors when creating a `CounterStorage` or `AsyncCounterStorage` are returned, instead of `panic!`ing
+
+### Deleted
+
+- Merge pull request #130 from Kuadrant/issue_100
+
 ## 0.2.0 - 2021-03-08
 
 ### Added

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limitador"
-version = "0.3.0-rc1"
+version = "0.3.0"
 authors = ["David Ortiz <z.david.ortiz@gmail.com>", "Eguzki Astiz Lezaun <eguzki@redhat.com>", "Alex Snaps <asnaps@redhat.com>"]
 license = "Apache-2.0"
 keywords = ["rate-limiting", "rate", "limiter"]


### PR DESCRIPTION
To be merged when we have the release script for the server container image

 - [ ] Fix dates in `CHANGELOG.md`s