### PR TITLE
Clippy

### DIFF
--- a/limitador-server/build.rs
+++ b/limitador-server/build.rs
@@ -34,7 +34,7 @@ fn set_profile(env: &str) {
 
 fn set_git_hash(env: &str) {
     let git_sha = Command::new("/usr/bin/git")
-        .args(&["rev-parse", "HEAD"])
+        .args(["rev-parse", "HEAD"])
         .output()
         .ok()
         .filter(|output| output.status.success())
@@ -43,7 +43,7 @@ fn set_git_hash(env: &str) {
 
     if let Some(sha) = git_sha {
         let dirty = Command::new("git")
-            .args(&["diff", "--stat"])
+            .args(["diff", "--stat"])
             .output()
             .ok()
             .filter(|output| output.status.success())

--- a/limitador/src/storage/infinispan/infinispan_storage.rs
+++ b/limitador/src/storage/infinispan/infinispan_storage.rs
@@ -153,7 +153,7 @@ impl InfinispanStorage {
                 let cache_name = DEFAULT_INFINISPAN_LIMITS_CACHE_NAME;
 
                 let _ = infinispan
-                    .run(&request::caches::create_local(&cache_name))
+                    .run(&request::caches::create_local(cache_name))
                     .await
                     .unwrap();
 


### PR DESCRIPTION
### what 

Starting with Rustc 1.65 (`rustc 1.65.0 (897e37553 2022-11-02) (from rustc 1.64.0 (a55dd71d5 2022-09-19))`), clippy complained about a needless borrow

```rust
error: the borrowed expression implements the required traits
  --> limitador-server/build.rs:37:15
   |
37 |         .args(&["rev-parse", "HEAD"])
   |               ^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `["rev-parse", "HEAD"]`
   |
   = note: `-D clippy::needless-borrow` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
```