### PR TITLE
GH action build image using redhat-actions/buildah-build@v2

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -24,30 +24,29 @@ jobs:
         id: add-latest-tag
         run: |
           echo "IMG_TAGS=latest" >> $GITHUB_ENV
-
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2        
-      - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to Quay.io
-        uses: redhat-actions/podman-login@v1
+        uses: docker/setup-qemu-action@v2
+      - name: Build Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
         with:
+          image: limitador
+          tags: ${{ env.IMG_TAGS }}
+          platforms: linux/amd64,linux/arm64
+          dockerfiles: |
+            ./Dockerfile
+          build-args: |
+            GITHUB_SHA=${{ github.sha }}
+      - name: Push Image
+        if: ${{ !env.ACT }}
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
           registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
-
-      - name: Build and Push Image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/limitador:${{ env.IMG_TAGS }}
-          build-args: |
-            GITHUB_SHA=${{ github.sha }}
-
       - name: Print Image URL
         run: |
-          echo "Image pushed to: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/limitador:${{ env.IMG_TAGS }}"
+          echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,27 +13,9 @@ RUN apk update \
 
 WORKDIR /usr/src/limitador
 
-COPY ./Cargo.lock ./Cargo.lock
-COPY ./Cargo.toml ./Cargo.toml
-
-COPY limitador/Cargo.toml ./limitador/Cargo.toml
-COPY limitador-server/Cargo.toml ./limitador-server/Cargo.toml
-
 ARG GITHUB_SHA
 ENV GITHUB_SHA=${GITHUB_SHA:-unknown}
 ENV RUSTFLAGS="-C target-feature=-crt-static"
-
-RUN mkdir -p limitador/src limitador-server/src
-
-RUN echo "fn main() {println!(\"if you see this, the build broke\")}" > limitador/src/main.rs \
-    && echo "fn main() {println!(\"if you see this, the build broke\")}" > limitador-server/src/main.rs
-
-RUN source $HOME/.cargo/env \
-    && cargo build --release --all-features
-
-# avoid downloading and compiling all the dependencies when there's a change in
-# our code.
-RUN rm -f target/release/deps/limitador*
 
 COPY . .
 


### PR DESCRIPTION
### what

* Using `redhat-actions/buildah-build@v2` action to build images. Same as other kuadrant components
* No `unknown on unknown` docker child images created, only `linux on amd64` and `linux on arm64` as expected
* Simplify docker image build. From two step builds workflow (deps + limitador), to one step build workflow.