### PR TITLE
fix: redis expires_in value when load_counters was used was *1000 due…

### DIFF
--- a/limitador/src/storage/redis/mod.rs
+++ b/limitador/src/storage/redis/mod.rs
@@ -49,11 +49,16 @@ pub fn is_limited(
     for (i, counter) in counters.iter_mut().enumerate() {
         let remaining = counter_vals[i].unwrap_or(counter.max_value()) - delta;
         counter.set_remaining(remaining);
-        let expires_in = Duration::from_secs(
-            counter_ttls_msecs[i]
-                .map(|x| x as u64)
-                .unwrap_or(counter.seconds()),
-        );
+        let expires_in = counter_ttls_msecs[i]
+            .map(|x| {
+                if x >= 0 {
+                    Duration::from_millis(x as u64)
+                } else {
+                    Duration::from_secs(counter.seconds())
+                }
+            })
+            .unwrap_or(Duration::from_secs(counter.seconds()));
+
         counter.set_expires_in(expires_in);
         if first_limited.is_none() && remaining < 0 {
             first_limited = Some(Authorization::Limited(


### PR DESCRIPTION
… to wrong duration conversion.

Added unit test to double check the value is within the expected bounds