### PR TITLE
Limitador now tags with sha too

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -7,7 +7,7 @@ on:
     tags: ['*']
 
 env:
-  IMG_TAGS: ${{ github.ref_name }}
+  IMG_TAGS: ${{ github.sha }} ${{ github.ref_name }}
   IMG_REGISTRY_HOST: quay.io
   IMG_REGISTRY_ORG: kuadrant
   MAIN_BRANCH_NAME: main


### PR DESCRIPTION
This PR makes the build job to add the `github.ref` _sha_ as another tag for the final images.