### PR TITLE
Move to UBI8 parent image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,24 @@
 # Build Stage
 # ------------------------------------------------------------------------------
 
-FROM alpine:3.16 as limitador-build
+FROM registry.access.redhat.com/ubi8/ubi:8.7 as limitador-build
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 ARG RUSTC_VERSION=1.67.1
-RUN apk update \
-    && apk upgrade \
-    && apk add build-base binutils-gold openssl3-dev protoc protobuf-dev curl git \
-    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --no-modify-path --profile minimal --default-toolchain ${RUSTC_VERSION} -c rustfmt -y
+
+# the powertools repo is required for protobuf-c and protobuf-devel
+RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags=nodocs install \
+      http://mirror.centos.org/centos/8-stream/BaseOS/`arch`/os/Packages/centos-gpg-keys-8-6.el8.noarch.rpm \
+      http://mirror.centos.org/centos/8-stream/BaseOS/`arch`/os/Packages/centos-stream-repos-8-6.el8.noarch.rpm \
+ && dnf -y --setopt=install_weak_deps=False --setopt=tsflags=nodocs install epel-release \
+ && dnf config-manager --set-enabled powertools
+
+RUN PKGS="gcc-c++ gcc-toolset-12-binutils-gold openssl3-devel protobuf-c protobuf-devel git" \
+    && dnf install --nodocs --assumeyes $PKGS \
+    && rpm --verify --nogroup --nouser $PKGS \
+    && yum -y clean all
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --no-modify-path --profile minimal --default-toolchain ${RUSTC_VERSION} -c rustfmt -y
 
 WORKDIR /usr/src/limitador
 
@@ -26,12 +36,16 @@ RUN source $HOME/.cargo/env \
 # Run Stage
 # ------------------------------------------------------------------------------
 
-FROM alpine:3.16
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 
-RUN apk add libgcc
+# shadow-utils is required for `groupadd`, etc.
+RUN PKGS="libgcc shadow-utils" \
+    && microdnf install --nodocs $PKGS \
+    && rpm --verify --nogroup --nouser $PKGS \
+    && microdnf -y clean all
 
-RUN addgroup -g 1000 limitador \
-    && adduser -D -s /bin/sh -u 1000 -G limitador limitador
+RUN groupadd -g 1000 limitador \
+    && useradd -u 1000 -g limitador -s /bin/sh -m -d /home/limitador limitador
 
 WORKDIR /home/limitador/bin/
 ENV PATH="/home/limitador/bin:${PATH}"


### PR DESCRIPTION
This will help with producing a product build for limitador, and makes many things easier such as rebuilds on Common Vulnerability and Exposure (CVE) patches, (e.g. Container Health Index (CHI) - the ‘A’ / ‘B’ / ‘C’ grades shown on Red Hat Container Catalog (RHCC) ), cross-product dependencies, etc.

Notes:
* slightly different package names in ubi8, but this shouldn't be introducing anything new.