### PR TITLE
🔥 Sled and use RocksDB instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "bindgen"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +449,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,10 +475,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clang-sys"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -681,7 +732,7 @@ dependencies = [
  "hashbrown",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.7",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -824,16 +875,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,15 +979,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +998,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
@@ -1280,10 +1318,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.10.0+7.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe4d5874f5ff2bc616e55e8c6086d478fcda13faf9495768a4aa1c22042d30b"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "limitador"
@@ -1304,10 +1385,10 @@ dependencies = [
  "redis",
  "reqwest",
  "rmp-serde",
+ "rocksdb",
  "serde",
  "serde_json",
  "serial_test",
- "sled",
  "tempdir",
  "thiserror",
  "tokio",
@@ -1388,6 +1469,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,6 +1504,12 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1457,6 +1554,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1571,7 +1678,7 @@ dependencies = [
  "paperclip-actix",
  "paperclip-core",
  "paperclip-macros",
- "parking_lot 0.12.1",
+ "parking_lot",
  "semver",
  "serde",
  "serde_derive",
@@ -1593,7 +1700,7 @@ dependencies = [
  "once_cell",
  "paperclip-core",
  "paperclip-macros",
- "parking_lot 0.12.1",
+ "parking_lot",
  "serde_json",
 ]
 
@@ -1607,7 +1714,7 @@ dependencies = [
  "mime",
  "once_cell",
  "paperclip-macros",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project",
  "regex",
  "serde",
@@ -1636,37 +1743,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.7",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1687,6 +1769,12 @@ name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -1840,7 +1928,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot 0.12.1",
+ "parking_lot",
  "protobuf",
  "thiserror",
 ]
@@ -1921,7 +2009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
  "log",
- "parking_lot 0.12.1",
+ "parking_lot",
  "scheduled-thread-pool",
 ]
 
@@ -2131,6 +2219,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocksdb"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015439787fce1e75d55f279078d33ff14b4af5d93d995e8838ee4631301c8a99"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2189,7 +2293,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
- "parking_lot 0.12.1",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2315,7 +2419,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot",
  "serial_test_derive",
 ]
 
@@ -2358,6 +2462,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2373,22 +2483,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "sled"
-version = "0.34.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
-dependencies = [
- "crc32fast",
- "crossbeam-epoch",
- "crossbeam-utils",
- "fs2",
- "fxhash",
- "libc",
- "log",
- "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -2595,7 +2689,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 ARG RUSTC_VERSION=1.67.1
 RUN apk update \
     && apk upgrade \
-    && apk add build-base binutils-gold openssl3-dev protoc protobuf-dev curl git \
+    && apk add build-base binutils-gold openssl3-dev protoc protobuf-dev curl git linux-headers clang \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --no-modify-path --profile minimal --default-toolchain ${RUSTC_VERSION} -c rustfmt -y
 
 WORKDIR /usr/src/limitador
@@ -28,7 +28,7 @@ RUN source $HOME/.cargo/env \
 
 FROM alpine:3.16
 
-RUN apk add libgcc
+RUN apk add libgcc libstdc++
 
 RUN addgroup -g 1000 limitador \
     && adduser -D -s /bin/sh -u 1000 -G limitador limitador

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -14,7 +14,8 @@ edition = "2021"
 
 # We make redis and infinispan optional to be able to compile for wasm32.
 [features]
-default = ["redis_storage"]
+default = ["disk_storage", "redis_storage"]
+disk_storage = ["rocksdb"]
 redis_storage = ["redis", "r2d2", "tokio"]
 infinispan_storage = ["infinispan", "reqwest", "base64"]
 lenient_conditions = []
@@ -31,9 +32,9 @@ async-trait = "0.1"
 cfg-if = "1"
 prometheus = "0.13"
 lazy_static = "1"
-sled = "0.34.7"
 
 # Optional dependencies
+rocksdb = { version = "0.20.1", optional = true, features = ["multi-threaded-cf"] }
 redis = { version = "0.21", optional = true, features = [
     "connection-manager",
     "tokio-comp",

--- a/limitador/benches/bench.rs
+++ b/limitador/benches/bench.rs
@@ -14,9 +14,9 @@ use tempdir::TempDir;
 const SEED: u64 = 42;
 
 #[cfg(not(feature = "redis"))]
-criterion_group!(benches, bench_in_mem, bench_sled);
+criterion_group!(benches, bench_in_mem, bench_disk);
 #[cfg(feature = "redis")]
-criterion_group!(benches, bench_in_mem, bench_sled, bench_redis);
+criterion_group!(benches, bench_in_mem, bench_disk, bench_redis);
 
 criterion_main!(benches);
 
@@ -96,8 +96,8 @@ fn bench_in_mem(c: &mut Criterion) {
     group.finish();
 }
 
-fn bench_sled(c: &mut Criterion) {
-    let mut group = c.benchmark_group("Sled");
+fn bench_disk(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Disk");
     for (index, scenario) in TEST_SCENARIOS.iter().enumerate() {
         group.bench_with_input(
             BenchmarkId::new("is_rate_limited", scenario),

--- a/limitador/src/storage/disk/mod.rs
+++ b/limitador/src/storage/disk/mod.rs
@@ -1,12 +1,12 @@
 use crate::storage::StorageErr;
 
 mod expiring_value;
-mod sled_storage;
+mod rocksdb_storage;
 
-pub use sled_storage::SledStorage as DiskStorage;
+pub use rocksdb_storage::RocksDbStorage as DiskStorage;
 
-impl From<sled::Error> for StorageErr {
-    fn from(error: sled::Error) -> Self {
+impl From<rocksdb::Error> for StorageErr {
+    fn from(error: rocksdb::Error) -> Self {
         Self {
             msg: format!("Underlying storage error: {error}"),
         }

--- a/limitador/src/storage/disk/rocksdb_storage.rs
+++ b/limitador/src/storage/disk/rocksdb_storage.rs
@@ -6,15 +6,18 @@ use crate::storage::keys::bin::{
     key_for_counter, partial_counter_from_counter_key, prefix_for_namespace,
 };
 use crate::storage::{Authorization, CounterStorage, StorageErr};
-use sled::{Config, Db, IVec, Mode};
+use rocksdb::{
+    CompactionDecision, DBCompressionType, DBWithThreadMode, IteratorMode, MultiThreaded, Options,
+    DB,
+};
 use std::collections::{BTreeSet, HashSet};
 use std::time::{Duration, SystemTime};
 
-pub struct SledStorage {
-    db: Db,
+pub struct RocksDbStorage {
+    db: DBWithThreadMode<MultiThreaded>,
 }
 
-impl CounterStorage for SledStorage {
+impl CounterStorage for RocksDbStorage {
     fn is_within_limits(&self, counter: &Counter, delta: i64) -> Result<bool, StorageErr> {
         let key = key_for_counter(counter);
         let value = self.insert_or_update(&key, counter, 0)?;
@@ -37,10 +40,12 @@ impl CounterStorage for SledStorage {
 
         for counter in &mut *counters {
             let key = key_for_counter(counter);
-            let (val, ttl) = match self.db.get(&key)? {
+            let slice: &[u8] = key.as_ref();
+            let (val, ttl) = match self.db.get(slice)? {
                 None => (0, Duration::from_secs(counter.limit().seconds())),
                 Some(raw) => {
-                    let value: ExpiringValue = raw.as_ref().try_into()?;
+                    let slice: &[u8] = raw.as_ref();
+                    let value: ExpiringValue = slice.try_into()?;
                     (value.value(), value.ttl())
                 }
             };
@@ -70,7 +75,7 @@ impl CounterStorage for SledStorage {
         let mut counters = HashSet::default();
         let namepaces: BTreeSet<&str> = limits.iter().map(|l| l.namespace().as_ref()).collect();
         for ns in namepaces {
-            for entry in self.db.range(prefix_for_namespace(ns)..) {
+            for entry in self.db.prefix_iterator(prefix_for_namespace(ns)) {
                 let (key, value) = entry?;
                 let mut counter = partial_counter_from_counter_key(key.as_ref());
                 if counter.namespace().as_ref() != ns {
@@ -97,28 +102,53 @@ impl CounterStorage for SledStorage {
     fn delete_counters(&self, limits: HashSet<Limit>) -> Result<(), StorageErr> {
         let counters = self.get_counters(&limits)?;
         for counter in &counters {
-            self.db.remove(key_for_counter(counter))?;
+            self.db.delete(key_for_counter(counter))?;
         }
         Ok(())
     }
 
     fn clear(&self) -> Result<(), StorageErr> {
-        Ok(self.db.clear()?)
-    }
-}
-
-impl From<OptimizeFor> for Mode {
-    fn from(value: OptimizeFor) -> Self {
-        match value {
-            OptimizeFor::Space => Mode::LowSpace,
-            OptimizeFor::Throughput => Mode::HighThroughput,
+        for entry in self.db.iterator(IteratorMode::Start) {
+            self.db.delete(entry?.0)?
         }
+        Ok(())
     }
 }
 
-impl SledStorage {
+impl RocksDbStorage {
     pub fn open<P: AsRef<std::path::Path>>(path: P, mode: OptimizeFor) -> Result<Self, StorageErr> {
-        let db = Config::new().mode(mode.into()).path(path).open()?;
+        let mut opts = Options::default();
+        match mode {
+            OptimizeFor::Space => {
+                opts.set_compression_type(DBCompressionType::Bz2);
+                opts.set_compaction_filter("ExpiredValueFilter", |_level, _key, value| {
+                    if let Ok(value) = ExpiringValue::try_from(value) {
+                        if value.value_at(SystemTime::now()) != 0 {
+                            return CompactionDecision::Keep;
+                        }
+                    }
+                    CompactionDecision::Remove
+                });
+            }
+            OptimizeFor::Throughput => {
+                opts.set_compression_type(DBCompressionType::None);
+            }
+        }
+        opts.set_merge_operator_associative("ExpiringValueMerge", |_key, start, operands| {
+            let now = SystemTime::now();
+            let mut value: ExpiringValue = start
+                .map(|raw: &[u8]| raw.try_into().unwrap_or_default())
+                .unwrap_or_default();
+            for op in operands {
+                // ignore (corrupted?) values pending merges
+                if let Ok(pending) = ExpiringValue::try_from(op) {
+                    value = value.merge(pending, now);
+                }
+            }
+            Some(Vec::from(value))
+        });
+        opts.create_if_missing(true);
+        let db = DB::open(&opts, path).unwrap();
         Ok(Self { db })
     }
 
@@ -128,40 +158,28 @@ impl SledStorage {
         counter: &Counter,
         delta: i64,
     ) -> Result<ExpiringValue, StorageErr> {
-        Ok(self.db.update_and_fetch(key, |prev| {
-            let updated_value = match prev {
-                Some(raw) => {
-                    let value: ExpiringValue = match TryInto::<ExpiringValue>::try_into(raw) {
-                        Ok(val) => val.update(delta, counter.seconds()),
-                        Err(_) => ExpiringValue::new(
-                            delta,
-                            SystemTime::now() + Duration::from_secs(counter.limit().seconds()),
-                        ),
-                    };
-                    value
-                }
-                None => ExpiringValue::new(
-                    delta,
-                    SystemTime::now() + Duration::from_secs(counter.limit().seconds()),
-                ),
-            };
-            Some::<IVec>(IVec::from(<ExpiringValue as Into<Vec<u8>>>::into(
-                updated_value,
-            )))
-        })?)
-        .map(|option| {
-            option
-                .expect("we always have a counter now!")
-                .as_ref()
-                .try_into()
-                .expect("This has to work!")
-        })
+        let now = SystemTime::now();
+        let value = match self.db.get(key)? {
+            None => ExpiringValue::default(),
+            Some(raw) => {
+                let slice: &[u8] = raw.as_ref();
+                slice.try_into()?
+            }
+        };
+        if value.value_at(now) + delta <= counter.max_value() {
+            let expiring_value =
+                ExpiringValue::new(delta, now + Duration::from_secs(counter.limit().seconds()));
+            self.db
+                .merge(key, <ExpiringValue as Into<Vec<u8>>>::into(expiring_value))?;
+            return Ok(value.update(delta, counter.seconds(), now));
+        }
+        Ok(value)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::SledStorage;
+    use super::RocksDbStorage;
     use crate::counter::Counter;
     use crate::limit::Limit;
     use crate::storage::disk::OptimizeFor;
@@ -179,7 +197,7 @@ mod tests {
 
         let tmp = TempDir::new("limitador-disk-tests").expect("We should have a dir!");
         {
-            let storage = SledStorage::open(tmp.path(), OptimizeFor::Space)
+            let storage = RocksDbStorage::open(tmp.path(), OptimizeFor::Space)
                 .expect("We should have a storage");
             let mut files = fs::read_dir(tmp.as_ref()).expect("Couldn't access data dir");
             assert!(files.next().is_some());
@@ -204,7 +222,7 @@ mod tests {
         }
 
         {
-            let storage = SledStorage::open(tmp.path(), OptimizeFor::Space)
+            let storage = RocksDbStorage::open(tmp.path(), OptimizeFor::Space)
                 .expect("We should still have a storage");
             assert!(
                 !storage.is_within_limits(&counter, 1).unwrap(),

--- a/limitador/src/storage/disk/sled_storage.rs
+++ b/limitador/src/storage/disk/sled_storage.rs
@@ -145,7 +145,9 @@ impl SledStorage {
                     SystemTime::now() + Duration::from_secs(counter.limit().seconds()),
                 ),
             };
-            Some::<IVec>(updated_value.into())
+            Some::<IVec>(IVec::from(<ExpiringValue as Into<Vec<u8>>>::into(
+                updated_value,
+            )))
         })?)
         .map(|option| {
             option

--- a/limitador/src/storage/mod.rs
+++ b/limitador/src/storage/mod.rs
@@ -6,6 +6,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::RwLock;
 use thiserror::Error;
 
+#[cfg(feature = "disk_storage")]
 pub mod disk;
 pub mod in_memory;
 pub mod wasm;

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -14,7 +14,7 @@ macro_rules! test_with_all_storage_impls {
             }
 
             #[tokio::test]
-            async fn [<$function _sled_storage>]() {
+            async fn [<$function _disk_storage>]() {
                 let dir = TempDir::new("limitador-disk-integration-tests").expect("We should have a dir!");
                 let rate_limiter =
                     RateLimiter::new_with_storage(Box::new(DiskStorage::open(dir.path(), OptimizeFor::Throughput).expect("Couldn't open temp dir")));


### PR DESCRIPTION
This builds on and supersedes both #146 & #167 … It replaces [sled](https://crates.io/crates/sled) as the underlying storage for local persistence with [RocksDB](https://rocksdb.org/) using the [Rust bindings](https://crates.io/crates/rocksdb)… which both were extensively battle tested. 

If we think this is indeed a better choice, it'd probably be worthwhile `git rebase -i` from HEAD of main, squashing all the work from the other PRs… I kept them as is for now, hoping this makes reviewing somewhat easier.