### PR TITLE
add version when publishing to crates.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,4 +30,4 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
       - name: Publish
-        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p limitador
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p limitador:${{ github.event.inputs.version }}


### PR DESCRIPTION
This makes sure the `version` within the `limitador/Cargo.toml` matches the version we're supposedly publishing. 