### PR TITLE
Set container entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,4 +57,6 @@ RUN chown limitador:limitador limitador-server
 
 USER limitador
 
+ENTRYPOINT ["/bin/sh", "-c"]
+
 CMD ["limitador-server"]


### PR DESCRIPTION
Use more strict `ENTRYPOINT` command to run the server.