### PR TITLE
Bench: Actually create different limits for each scenario

### DIFF
--- a/limitador/benches/bench.rs
+++ b/limitador/benches/bench.rs
@@ -280,11 +280,11 @@ fn generate_test_data(
     for idx_namespace in 0..scenario.n_namespaces {
         let namespace = idx_namespace.to_string();
 
-        for _ in 0..scenario.n_limits_per_ns {
+        for limit_idx in 0..scenario.n_limits_per_ns {
             test_limits.push(Limit::new(
                 namespace.clone(),
                 i64::MAX,
-                10,
+                ((limit_idx * 60) + 10) as u64,
                 conditions.clone(),
                 variables.clone(),
             ))


### PR DESCRIPTION
So this is going to hurt:

We always created the bench "wrong", or rather we created dups of one identical `Limit` in each namespace, when it was more than `1` (i.e. `10` & `50`). Sadly this meant that Limitador would only ever do _one_ limit  (with more variables and conditions tho)... So this fixes that, and as such exposes the `O(n)` problem I mentioned in our refinement call...

## Bench result, compared as to when it was 1 limit, whereas this now are 10 limits to be tested against:

### 10 namespaces with 10 limits each with 10 conditions and 10 variables

#### In memory:

<img width="972" alt="image" src="https://github.com/Kuadrant/limitador/assets/509058/0f83e421-290f-4a04-83c4-2b12494b0d9b">

#### On disk:

<img width="956" alt="image" src="https://github.com/Kuadrant/limitador/assets/509058/1374aa10-432a-4297-be41-752b27059702">

#### With Redis:

<img width="951" alt="image" src="https://github.com/Kuadrant/limitador/assets/509058/acb47061-1cf0-4643-a269-8c8b099aabc5">


As expected, Memory is the worst: `O(n)`, while Redis, which does an `MGET` is the least impacted. While the operation is still `O(n)` within Redis, the network overhead ans (de)serialization dominates the latency here… 
