### PR TITLE
[fix] Adding "/" and "-" chars for the new condition format

### DIFF
--- a/limitador/src/limit.rs
+++ b/limitador/src/limit.rs
@@ -613,7 +613,7 @@ mod conditions {
 
         fn valid_id_char(&mut self) -> bool {
             let char = self.input[self.pos];
-            char.is_alphanumeric() || char == '.' || char == '_'
+            char.is_alphanumeric() || char == '.' || char == '_' || char == '-' || char == '/'
         }
 
         fn scan_string(&mut self, until: char) -> Result<Token, SyntaxError> {

--- a/limitador/src/limit.rs
+++ b/limitador/src/limit.rs
@@ -777,14 +777,14 @@ mod conditions {
 
         #[test]
         fn test_charset() {
-            let tokens =
-                Scanner::scan(" 変数 == '  💖 '".to_owned()).expect("Should parse alright!");
+            let tokens = Scanner::scan(" love.en-US/愛.jp == '  💖 '".to_owned())
+                .expect("Should parse alright!");
             assert_eq!(tokens.len(), 3);
             assert_eq!(
                 tokens[0],
                 Token {
                     token_type: TokenType::Identifier,
-                    literal: Some(Identifier("変数".to_owned())),
+                    literal: Some(Identifier("love.en-US/愛.jp".to_owned())),
                     pos: 2,
                 }
             );
@@ -793,7 +793,7 @@ mod conditions {
                 Token {
                     token_type: TokenType::EqualEqual,
                     literal: None,
-                    pos: 5,
+                    pos: 18,
                 }
             );
             assert_eq!(
@@ -801,7 +801,7 @@ mod conditions {
                 Token {
                     token_type: TokenType::String,
                     literal: Some(Literal::String("  💖 ".to_owned())),
-                    pos: 8,
+                    pos: 21,
                 }
             );
         }


### PR DESCRIPTION
This PR addresses the need to change the new condition format introduced [RLP V2 in Kuadrant](https://github.com/Kuadrant/kuadrant-operator/pull/218)