### PR TITLE
fix: codecov badge using wrong branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Crates.io](https://img.shields.io/crates/v/limitador)](https://crates.io/crates/limitador)
 [![Docker Repository on Quay](https://quay.io/repository/kuadrant/limitador/status
 "Docker Repository on Quay")](https://quay.io/repository/kuadrant/limitador)
-[![codecov](https://codecov.io/gh/Kuadrant/limitador/branch/master/graph/badge.svg?token=CE9LD3XCJT)](https://codecov.io/gh/Kuadrant/limitador)
+[![codecov](https://codecov.io/gh/Kuadrant/limitador/branch/main/graph/badge.svg?token=CE9LD3XCJT)](https://codecov.io/gh/Kuadrant/limitador)
 
 Limitador is a generic rate-limiter written in Rust. It can be used as a
 library, or as a service. The service exposes HTTP endpoints to apply and observe


### PR DESCRIPTION
* Codecov badge was using `master` instead of `main` so the code coverage percentage was not shown from inital work in  https://github.com/Kuadrant/limitador/pull/192