### PR TITLE
Multi thread check & update

### DIFF
--- a/limitador/src/storage/in_memory.rs
+++ b/limitador/src/storage/in_memory.rs
@@ -175,7 +175,7 @@ impl CounterStorage for InMemoryStorage {
         }
 
         // Update and check counters
-        counter_values_to_update.sort_by(|a, b| a.1.limit().seconds().cmp(&b.1.limit().seconds()));
+        counter_values_to_update.sort_by(|a, b| a.0.ttl().cmp(&b.0.ttl()));
 
         for (expiring_value, counter) in counter_values_to_update {
             if let Some(limited) = check_post_update(&counter, expiring_value, delta) {
@@ -183,8 +183,7 @@ impl CounterStorage for InMemoryStorage {
             }
         }
 
-        qualified_counter_values_to_updated
-            .sort_by(|a, b| a.1.limit().seconds().cmp(&b.1.limit().seconds()));
+        qualified_counter_values_to_updated.sort_by(|a, b| a.0.ttl().cmp(&b.0.ttl()));
 
         for (arc_expiring_value, counter) in qualified_counter_values_to_updated {
             if let Some(limited) = check_post_update(&counter, &arc_expiring_value, delta) {

--- a/limitador/src/storage/in_memory.rs
+++ b/limitador/src/storage/in_memory.rs
@@ -175,11 +175,16 @@ impl CounterStorage for InMemoryStorage {
         }
 
         // Update and check counters
+        counter_values_to_update.sort_by(|a, b| a.1.limit().seconds().cmp(&b.1.limit().seconds()));
+
         for (expiring_value, counter) in counter_values_to_update {
             if let Some(limited) = check_post_update(&counter, expiring_value, delta) {
                 return Ok(limited);
             }
         }
+
+        qualified_counter_values_to_updated
+            .sort_by(|a, b| a.1.limit().seconds().cmp(&b.1.limit().seconds()));
 
         for (arc_expiring_value, counter) in qualified_counter_values_to_updated {
             if let Some(limited) = check_post_update(&counter, &arc_expiring_value, delta) {

--- a/limitador/src/storage/in_memory.rs
+++ b/limitador/src/storage/in_memory.rs
@@ -96,7 +96,7 @@ impl CounterStorage for InMemoryStorage {
         delta: i64,
         load_counters: bool,
     ) -> Result<Authorization, StorageErr> {
-        let limits_by_namespace = self.limits_for_namespace.write().unwrap();
+        let limits_by_namespace = self.limits_for_namespace.read().unwrap();
         let mut first_limited = None;
         let mut counter_values_to_update: Vec<(&AtomicExpiringValue, Counter)> = Vec::new();
         let mut qualified_counter_values_to_updated: Vec<(Arc<AtomicExpiringValue>, Counter)> =


### PR DESCRIPTION
This PR is yet another step closer to proper multi thread Limitador.

However, the changes introduced makes de `check_and_update` "racy", since different requests will check and update at the same time:

1. It could/will happen that one thread will _load_ a counter value at the "check" phase and at the same time, a different thread will store a value at the "update" phase to the same counter.
2. Some counters will end up being updated while others won't if one ends up being limited in the update phase.
3. Those competing threads might end limiting a bit late (overshooting).

Regarding the bench, there's a regression of 3% but it's kind of a lie, since we are not benching for multi-threading requests.
