### PR TITLE
Update migration URL to new website format

### DIFF
--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -249,7 +249,7 @@ impl Limiter {
                                 Self::Async(limiter) => limiter.configure_with(limits).await?,
                             }
                             if limitador::limit::check_deprecated_syntax_usages_and_reset() {
-                                error!("You are using deprecated syntax for your conditions! See the migration guide https://kuadrant.io/docs/limitador/migrations/conditions.html")
+                                error!("You are using deprecated syntax for your conditions! See the migration guide https://docs.kuadrant.io/limitador/doc/migrations/conditions/")
                             }
                             Ok(())
                         }


### PR DESCRIPTION
With the new website, docs are now at docs.kuadrant.io, see this other PR: https://github.com/Kuadrant/kuadrant.github.io/pull/31