### PR TITLE
coverage test only on main branch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,64 @@
+---
+name: Coverage
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: abelfodil/protoc-action@v1
+        with:
+          protoc-version: '3.19.4'
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    services:
+      infinispan:
+        image: infinispan/server:11.0.9.Final
+        ports:
+          - 11222:11222
+        env:
+          USER: username
+          PASS: password
+    steps:
+      - uses: actions/checkout@v2
+      - uses: supercharge/redis-github-action@1.1.0
+        with:
+          redis-version: 5
+      # Nightly is required for code coverage with doctests
+      # https://github.com/taiki-e/cargo-llvm-cov/issues/2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: abelfodil/protoc-action@v1
+        with:
+          protoc-version: '3.19.4'
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Test and Generate code coverage
+        run: cargo +nightly llvm-cov --all-features --workspace --lcov --doctests --output-path lcov.info
+      - name: Codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: env.CODECOV_TOKEN != null
+        uses: codecov/codecov-action@v3
+        with:
+          verbose: true
+          fail_ci_if_error: false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,23 +50,15 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
       - uses: abelfodil/protoc-action@v1
         with:
           protoc-version: '3.19.4'
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Test and Generate code coverage
-        run: cargo +nightly llvm-cov --all-features --workspace --lcov --doctests --output-path lcov.info
-      - name: Codecov
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        if: env.CODECOV_TOKEN != null
-        uses: codecov/codecov-action@v3
+      - uses: actions-rs/cargo@v1
         with:
-          verbose: true
-          fail_ci_if_error: false
+          command: test
+          args: --all-features -vv
 
   fmt:
     name: Rustfmt


### PR DESCRIPTION
There is an incompatibility between nightly toolchain and [time](https://crates.io/crates/time) v0.3.28. This makes coverage measurement a broken task until new `time` crate is released. The [fix](https://github.com/time-rs/time/pull/622) has already been merged but a new crate has not been release as of today.

This PR runs coverage measurement only on `main` branch, which will keep failing unfortunately. But at least it will not block all the PR's. 

When the new `time` crate is released, the coverage measurement can be brought back to PR's if we want to check coverage increase/decrease due to the PR changes.