### PR TITLE
Cross compilation v1

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -28,32 +28,25 @@ jobs:
         if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
         run: |
           echo "IMG_TAGS=${{ env.IMG_TAGS }} ${{ github.ref_name }}" >> $GITHUB_ENV
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Build Image
-        id: build-image
-        uses: redhat-actions/buildah-build@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker image on amd64
+        uses: docker/build-push-action@v5
         with:
-          image: limitador
-          tags: ${{ env.IMG_TAGS }}
-          platforms: linux/amd64,linux/arm64
-          dockerfiles: |
-            ./Dockerfile
+          context: .
+          push: false
+          load: true
           build-args: |
             GITHUB_SHA=${{ github.sha }}
-      - name: Smoke Test
-        run: |
-          podman run --rm -t ${{ steps.build-image.outputs.image }}:${{ github.sha }} limitador-server --help
-      - name: Push Image
-        if: ${{ !env.ACT }}
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
+          tags: ${{ env.IMG_TAGS }}
+          file : ./Dockerfile
+      - name: Build Docker image on arm64
+        uses: docker/build-push-action@v5
         with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
-          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
-          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
-      - name: Print Image URL
-        run: |
-          echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+          context: .
+          push: false
+          load: true
+          build-args: |
+            GITHUB_SHA=${{ github.sha }}
+          tags: ${{ env.IMG_TAGS }}
+          file : ./Dockerfile.aarch64

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Add branch name tag
         if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
         run: |
-          echo "IMG_TAGS=${{ env.IMG_TAGS }} ${{ github.ref_name }}" >> $GITHUB_ENV
+          echo "IMG_TAGS=${{ github.ref_name }}" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build Docker image on amd64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,6 +1567,7 @@ dependencies = [
  "limitador",
  "log",
  "notify",
+ "openssl",
  "paperclip",
  "prost",
  "prost-types",
@@ -1866,6 +1867,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.1.5+3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "559068e4c12950d7dcaa1857a61725c0d38d4fc03ff8e070ab31a75d6e316491"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,6 +1883,7 @@ checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,24 +2,10 @@
 # Build Stage
 # ------------------------------------------------------------------------------
 
-FROM registry.access.redhat.com/ubi8/ubi:8.7 as limitador-build
-ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+FROM rust:1.72 as limitador-build
 
-ARG RUSTC_VERSION=1.72.0
-
-# the powertools repo is required for protobuf-c and protobuf-devel
-RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags=nodocs install \
-      http://mirror.centos.org/centos/8-stream/BaseOS/`arch`/os/Packages/centos-gpg-keys-8-6.el8.noarch.rpm \
-      http://mirror.centos.org/centos/8-stream/BaseOS/`arch`/os/Packages/centos-stream-repos-8-6.el8.noarch.rpm \
- && dnf -y --setopt=install_weak_deps=False --setopt=tsflags=nodocs install epel-release \
- && dnf config-manager --set-enabled powertools
-
-RUN PKGS="gcc-c++ gcc-toolset-12-binutils-gold openssl-devel protobuf-c protobuf-devel git clang kernel-headers" \
-    && dnf install --nodocs --assumeyes $PKGS \
-    && rpm --verify --nogroup --nouser $PKGS \
-    && yum -y clean all
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --no-modify-path --profile minimal --default-toolchain ${RUSTC_VERSION} -c rustfmt -y
+RUN apt update && apt upgrade -y
+RUN apt install -y protobuf-compiler clang
 
 WORKDIR /usr/src/limitador
 
@@ -29,8 +15,7 @@ ENV RUSTFLAGS="-C target-feature=-crt-static"
 
 COPY . .
 
-RUN source $HOME/.cargo/env \
-    && cargo build --release
+RUN cargo build --release
 
 # ------------------------------------------------------------------------------
 # Run Stage

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,52 @@
+# ------------------------------------------------------------------------------
+# Build Stage cross compiling
+# ------------------------------------------------------------------------------
+
+FROM rust:1.72 as limitador-build
+
+RUN apt update && apt upgrade -y
+RUN apt install -y protobuf-compiler clang
+RUN apt install -y g++-aarch64-linux-gnu libc6-dev-arm64-cross
+
+RUN rustup target add aarch64-unknown-linux-gnu
+RUN rustup toolchain install stable-aarch64-unknown-linux-gnu
+
+WORKDIR /usr/src/limitador
+
+ARG GITHUB_SHA
+ENV GITHUB_SHA=${GITHUB_SHA:-unknown}
+ENV RUSTFLAGS="-C target-feature=-crt-static"
+
+COPY . .
+
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+    CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
+    CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
+
+RUN cargo build --release --target aarch64-unknown-linux-gnu
+
+# ------------------------------------------------------------------------------
+# Run Stage
+# ------------------------------------------------------------------------------
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+
+# shadow-utils is required for `useradd`
+RUN PKGS="libgcc libstdc++ shadow-utils" \
+    && microdnf --assumeyes install --nodocs $PKGS \
+    && rpm --verify --nogroup --nouser $PKGS \
+    && microdnf -y clean all
+RUN useradd -u 1000 -s /bin/sh -m -d /home/limitador limitador
+
+WORKDIR /home/limitador/bin/
+ENV PATH="/home/limitador/bin:${PATH}"
+
+COPY --from=limitador-build /usr/src/limitador/limitador-server/examples/limits.yaml ../
+COPY --from=limitador-build /usr/src/limitador/target/aarch64-unknown-linux-gnu/release/limitador-server ./limitador-server
+
+RUN chown -R limitador:root /home/limitador \
+    && chmod -R 750 /home/limitador
+
+USER limitador
+
+CMD ["limitador-server"]

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -37,6 +37,7 @@ const_format = "0.2.31"
 lazy_static = "1.4.0"
 clap = "4.3"
 sysinfo = "0.29.7"
+openssl = { version = "0.10.57", features = ["vendored"] }
 
 [build-dependencies]
 tonic-build = "0.10"


### PR DESCRIPTION
* Using `rust:1,72` as based image. 
* Remove QEMU virtualization
* Following [Rust Cross Compilation](https://kerkour.com/rust-cross-compilation)
* It compiles in both amd64 and arm64 archs.
* Using `openssl = { version = "0.10.57", features = ["vendored"] }` dep as I was not able to install or compile openssl in arm.

The current issue is that the binary is not compatible in ubi7 image
```
$ docker run --rm -t docker.io/library/limitador:test01 limitador-server
limitador-server: /lib64/libm.so.6: version `GLIBC_2.29' not found (required by limitador-server)
limitador-server: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by limitador-server)
limitador-server: /lib64/libc.so.6: version `GLIBC_2.30' not found (required by limitador-server)
limitador-server: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by limitador-server)
limitador-server: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by limitador-server)
limitador-server: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by limitador-server)
limitador-server: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by limitador-server)
limitador-server: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.26' not found (required by limitador-server)
```