### PR TITLE
refactor: use or_default() instead of or_insert_with()

### DIFF
--- a/limitador/src/storage/in_memory.rs
+++ b/limitador/src/storage/in_memory.rs
@@ -40,9 +40,9 @@ impl CounterStorage for InMemoryStorage {
             let mut limits_by_namespace = self.limits_for_namespace.write().unwrap();
             limits_by_namespace
                 .entry(limit.namespace().clone())
-                .or_insert_with(HashMap::new)
+                .or_default()
                 .entry(limit.clone())
-                .or_insert_with(AtomicExpiringValue::default);
+                .or_default();
         }
         Ok(())
     }


### PR DESCRIPTION
Since rust 1.73 was released, clippy recommends using `or_default()`

- https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-173
- https://rust-lang.github.io/rust-clippy/master/index.html#/unwrap_or_default

Clippy workflow action fails without this change since rust 1.73 was released
- https://github.com/Kuadrant/limitador/actions?query=branch%3Amain