### PR TITLE
refactor: use actions-rust-lang/setup-rust-toolchain@v1 & docker/setup-buildx-action@v3 for e2e

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,19 @@
 Dockerfile
 *.swp
 .dockerignore
+.gitignore
 .git
-
+.github
+doc
+.idea
+**/*.yaml
+**/*.md
+**/*.json
+**/*.sh
+**/*.png
+**/*.svg
 # OSX files
 .DS_Store
+
+# Exception - Used in docker build
+!limitador-server/examples/limits.yaml

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Add latest tag
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,12 +11,8 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: abelfodil/protoc-action@v1
         with:
           protoc-version: '3.19.4'
@@ -36,17 +32,15 @@ jobs:
           USER: username
           PASS: password
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: supercharge/redis-github-action@1.1.0
         with:
           redis-version: 5
       # Nightly is required for code coverage with doctests
       # https://github.com/taiki-e/cargo-llvm-cov/issues/2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: nightly
-          override: true
       - uses: abelfodil/protoc-action@v1
         with:
           protoc-version: '3.19.4'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,19 +13,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            limitador-testing
+          tags: |
+            type=raw,value=latest
       - name: Build Limitador Image
         id: build-image
-        uses: redhat-actions/buildah-build@v2
+        uses: docker/build-push-action@v5
         with:
-          image: limitador-testing
-          tags: latest
-          dockerfiles: |
-            ./Dockerfile
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          load: true
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.1.0
+        uses: helm/kind-action@v1.8.0
         with:
-          version: v0.11.1
+          version: v0.20.0
           config: limitador-server/script/kind-cluster.yaml
           cluster_name: limitador-local
           wait: 120s
@@ -34,8 +45,7 @@ jobs:
           kubectl cluster-info dump
       - name: Load limitador docker image
         run: |
-          podman save -o image.tar ${{ steps.build-image.outputs.image }}:${{ steps.build-image.outputs.tags }}
-          kind load image-archive --name limitador-local image.tar
+          kind load docker-image ${{ steps.meta.outputs.tags }} -n limitador-local
       - name: Deploy limitador
         run: |
           kubectl apply -f limitador-server/e2e/file-watcher/configmap.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: supercharge/redis-github-action@1.1.0
         with:
           redis-version: 5
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: crate-v${{ github.event.inputs.version }}
       - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,18 +16,12 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: abelfodil/protoc-action@v1
         with:
           protoc-version: '3.19.4'
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - run: cargo check
 
   test:
     name: Test Suite
@@ -41,100 +35,68 @@ jobs:
           USER: username
           PASS: password
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: supercharge/redis-github-action@1.1.0
         with:
           redis-version: 5
-      # Nightly is required for code coverage with doctests
-      # https://github.com/taiki-e/cargo-llvm-cov/issues/2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: abelfodil/protoc-action@v1
         with:
           protoc-version: '3.19.4'
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features -vv
+      - run: cargo test --all-features -vv
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+          components: rustfmt
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
+          components: clippy
       - uses: abelfodil/protoc-action@v1
         with:
           protoc-version: '3.19.4'
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --all-targets -- -D warnings
+      - run: cargo clippy --all-features --all-targets -- -D warnings
 
   bench:
     name: Bench
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: supercharge/redis-github-action@1.1.0
         with:
           redis-version: 5
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: abelfodil/protoc-action@v1
         with:
           protoc-version: '3.19.4'
-      - uses: actions-rs/cargo@v1
-        with:
-          command: bench
+      - run: cargo bench
 
   wasm-build:
     name: Build for WASM
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           target: wasm32-unknown-unknown
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target=wasm32-unknown-unknown --no-default-features --lib --manifest-path ./limitador/Cargo.toml
+      - run: cargo build --target=wasm32-unknown-unknown --no-default-features --lib --manifest-path ./limitador/Cargo.toml
 
   kind:
     name: Try in kind (Kubernetes in Docker)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - uses: engineerd/setup-kind@v0.5.0
         with:
           version: v0.11.1

--- a/limitador-server/e2e/file-watcher/deployment.yaml
+++ b/limitador-server/e2e/file-watcher/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: limitador
-          image: localhost/limitador-testing:latest
+          image: limitador-testing:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: RUST_LOG


### PR DESCRIPTION
* actions-rust-lang/setup-rust-toolchain@v1 incorporates using github action cache. Subsequent builds will use cache if there has been no dependency changes 
  * https://github.com/actions-rust-lang/setup-rust-toolchain
  * https://github.com/Swatinem/rust-cache
* Use docker/setup-buildx-action@v3 to cache docker layers to github action cache. Subsequent builds will use cache if layers have not been invalidated by changes
  * https://github.com/docker/setup-buildx-action
  * https://github.com/docker/build-push-action
* update .dockerignore to include doc related files so that layer cache is not invalidated by changes to these files