### PR TITLE
gRPC server reflection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,6 +1577,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+ "tonic-reflection",
  "url",
 ]
 
@@ -3025,6 +3026,19 @@ dependencies = [
  "prost-build",
  "quote",
  "syn 2.0.32",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fa37c513df1339d197f4ba21d28c918b9ef1ac1768265f11ecb6b7f1cba1b76"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ port, that implements the Envoy Rate Limit protocol (v3).
 
 - [**Getting started**](#getting-started)
 - [**How it works**](/doc/how-it-works.md)
+- [**Configuration**](/doc/server/configuration.md)
 - [**Development**](#development)
 - [**Testing Environment**](limitador-server/sandbox/README.md)
 - [**Kubernetes**](limitador-server/kubernetes/)

--- a/doc/server/configuration.md
+++ b/doc/server/configuration.md
@@ -35,6 +35,8 @@ Options:
           Validates the LIMITS_FILE and exits
   -H, --rate-limit-headers <rate_limit_headers>
           Enables rate limit response headers [default: NONE] [possible values: NONE, DRAFT_VERSION_03]
+      --grpc-reflection-service
+          Enables gRPC server reflection service
   -h, --help
           Print help
   -V, --version

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -22,6 +22,7 @@ limitador = { path = "../limitador", features = ['lenient_conditions'] }
 tokio = { version = "1", features = ["full"] }
 thiserror = "1"
 tonic = "0.10"
+tonic-reflection = "0.10.2"
 prost = "0.12"
 prost-types = "0.12"
 serde_yaml = "0.9"

--- a/limitador-server/build.rs
+++ b/limitador-server/build.rs
@@ -1,4 +1,6 @@
+use std::env;
 use std::error::Error;
+use std::path::PathBuf;
 use std::process::Command;
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -9,14 +11,18 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 fn generate_protobuf() -> Result<(), Box<dyn Error>> {
-    tonic_build::configure().build_server(true).compile(
-        &["envoy/service/ratelimit/v3/rls.proto"],
-        &[
-            "vendor/protobufs/data-plane-api",
-            "vendor/protobufs/protoc-gen-validate",
-            "vendor/protobufs/xds",
-        ],
-    )?;
+    let original_out_dir = PathBuf::from(env::var("OUT_DIR")?);
+    tonic_build::configure()
+        .build_server(true)
+        .file_descriptor_set_path(original_out_dir.join("rls.bin"))
+        .compile(
+            &["envoy/service/ratelimit/v3/rls.proto"],
+            &[
+                "vendor/protobufs/data-plane-api",
+                "vendor/protobufs/protoc-gen-validate",
+                "vendor/protobufs/xds",
+            ],
+        )?;
     Ok(())
 }
 

--- a/limitador-server/sandbox/.gitignore
+++ b/limitador-server/sandbox/.gitignore
@@ -1,3 +1,4 @@
+/bin/
 *.crt
 *.key
 *.pem

--- a/limitador-server/sandbox/Makefile
+++ b/limitador-server/sandbox/Makefile
@@ -74,8 +74,29 @@ clean-containers: ## clean containers
 	- $(DOCKER) compose -f docker-compose-envoy.yaml -f docker-compose-limitador-redis.yaml down --volumes --remove-orphans
 	- $(DOCKER)_compose -f docker-compose-envoy.yaml -f docker-compose-limitador-redis-cached.yaml down --volumes --remove-orphans
 	- $(DOCKER) compose -f docker-compose-envoy.yaml -f docker-compose-limitador-infinispan.yaml down --volumes --remove-orphans
+	- $(DOCKER) compose -f docker-compose-envoy.yaml -f docker-compose-limitador-disk.yaml down --volumes --remove-orphans
 	- $(MAKE) cleancerts
 
 clean: ## clean all
 	- $(MAKE) clean-containers
 	- $(MAKE) redis-clean-certs
+
+GRPCURL=$(PROJECT_PATH)/bin/grpcurl
+$(GRPCURL):
+	$(call go-install-tool,$(GRPCURL),github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.8.9)
+
+.PHONY: grpcurl
+grpcurl: $(GRPCURL) ## Download grpcurl locally if necessary.
+
+# go-install-tool will 'go install' any package $2 and install it to $1.
+define go-install-tool
+@[ -f $(1) ] || { \
+set -e ;\
+TMP_DIR=$$(mktemp -d) ;\
+cd $$TMP_DIR ;\
+go mod init tmp ;\
+echo "Downloading $(2)" ;\
+GOBIN=$(PROJECT_PATH)/bin go install $(2) ;\
+rm -rf $$TMP_DIR ;\
+}
+endef

--- a/limitador-server/sandbox/README.md
+++ b/limitador-server/sandbox/README.md
@@ -24,6 +24,7 @@ Check out `make help` for all the targets.
 | Redis Secured | `make deploy-redis-tls` | Uses Redis with TLS and password protected to store counters |
 | Redis Cached | `make deploy-redis-cached` | Uses Redis to store counters, with an in-memory cache |
 | Infinispan | `make deploy-infinispan` | Uses Infinispan to store counters |
+| Disk | `make deploy-disk` | Uses disk to store counters |
 
 ### Limitador's admin HTTP endpoint
 

--- a/limitador-server/sandbox/docker-compose-limitador-disk.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-disk.yaml
@@ -24,5 +24,6 @@ services:
       - "8081"
     ports:
       - "18080:8080"
+      - "18081:8081"
     volumes:
       - ./limits.yaml:/opt/kuadrant/limits/limits.yaml

--- a/limitador-server/sandbox/docker-compose-limitador-disk.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-disk.yaml
@@ -16,6 +16,7 @@ services:
       - --http-port
       - "8080"
       - -vvv
+      - --grpc-reflection-service
       - /opt/kuadrant/limits/limits.yaml
       - disk
       - "/tmp/data"

--- a/limitador-server/sandbox/docker-compose-limitador-infinispan.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-infinispan.yaml
@@ -29,6 +29,7 @@ services:
       - "8081"
     ports:
       - "18080:8080"
+      - "18081:8081"
     volumes:
       - ./limits.yaml:/opt/kuadrant/limits/limits.yaml
   infinispan:

--- a/limitador-server/sandbox/docker-compose-limitador-infinispan.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-infinispan.yaml
@@ -17,6 +17,7 @@ services:
       - --http-port
       - "8080"
       - -vvvv
+      - --grpc-reflection-service
       - /opt/kuadrant/limits/limits.yaml
       - infinispan
       - --cache-name

--- a/limitador-server/sandbox/docker-compose-limitador-memory.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-memory.yaml
@@ -23,5 +23,6 @@ services:
       - "8081"
     ports:
       - "18080:8080"
+      - "18081:8081"
     volumes:
       - ./limits.yaml:/opt/kuadrant/limits/limits.yaml

--- a/limitador-server/sandbox/docker-compose-limitador-memory.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-memory.yaml
@@ -16,6 +16,7 @@ services:
       - --http-port
       - "8080"
       - -vvv
+      - --grpc-reflection-service
       - /opt/kuadrant/limits/limits.yaml
       - memory
     expose:

--- a/limitador-server/sandbox/docker-compose-limitador-redis-cached.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-redis-cached.yaml
@@ -33,6 +33,7 @@ services:
       - "8081"
     ports:
       - "18080:8080"
+      - "18081:8081"
     volumes:
       - ./limits.yaml:/opt/kuadrant/limits/limits.yaml
   redis:

--- a/limitador-server/sandbox/docker-compose-limitador-redis-cached.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-redis-cached.yaml
@@ -17,6 +17,7 @@ services:
       - --http-port
       - "8080"
       - -vvv
+      - --grpc-reflection-service
       - /opt/kuadrant/limits/limits.yaml
       - redis_cached
       - --ttl

--- a/limitador-server/sandbox/docker-compose-limitador-redis-tls.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-redis-tls.yaml
@@ -17,6 +17,7 @@ services:
       - --http-port
       - "8080"
       - -vvv
+      - --grpc-reflection-service
       - /opt/kuadrant/limits/limits.yaml
       - redis
       - rediss://:foobared@redis:6379/#insecure

--- a/limitador-server/sandbox/docker-compose-limitador-redis.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-redis.yaml
@@ -25,6 +25,7 @@ services:
       - "8081"
     ports:
       - "18080:8080"
+      - "18081:8081"
     volumes:
       - ./limits.yaml:/opt/kuadrant/limits/limits.yaml
   redis:

--- a/limitador-server/sandbox/docker-compose-limitador-redis.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-redis.yaml
@@ -17,6 +17,7 @@ services:
       - --http-port
       - "8080"
       - -vvv
+      - --grpc-reflection-service
       - /opt/kuadrant/limits/limits.yaml
       - redis
       - redis://redis:6379

--- a/limitador-server/src/config.rs
+++ b/limitador-server/src/config.rs
@@ -33,6 +33,7 @@ pub struct Configuration {
     pub limit_name_in_labels: bool,
     pub log_level: Option<LevelFilter>,
     pub rate_limit_headers: RateLimitHeaders,
+    pub grpc_reflection_service: bool,
 }
 
 pub mod env {
@@ -83,6 +84,7 @@ impl Configuration {
         http_port: u16,
         limit_name_in_labels: bool,
         rate_limit_headers: RateLimitHeaders,
+        grpc_reflection_service: bool,
     ) -> Self {
         Self {
             limits_file,
@@ -94,6 +96,7 @@ impl Configuration {
             limit_name_in_labels,
             log_level: None,
             rate_limit_headers,
+            grpc_reflection_service,
         }
     }
 
@@ -121,6 +124,7 @@ impl Default for Configuration {
             limit_name_in_labels: false,
             log_level: None,
             rate_limit_headers: RateLimitHeaders::None,
+            grpc_reflection_service: false,
         }
     }
 }

--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -302,6 +302,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let envoy_rls_address = config.rlp_address();
     let http_api_address = config.http_address();
     let rate_limit_headers = config.rate_limit_headers.clone();
+    let grpc_reflection_service = config.grpc_reflection_service;
 
     let rate_limiter: Arc<Limiter> = match Limiter::new(config).await {
         Ok(limiter) => Arc::new(limiter),
@@ -390,6 +391,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         envoy_rls_address.to_string(),
         rate_limiter.clone(),
         rate_limit_headers,
+        grpc_reflection_service,
     ));
 
     info!("HTTP server starting on {}", http_api_address);
@@ -514,6 +516,13 @@ fn create_config() -> (Configuration, &'static str) {
                     "DRAFT_VERSION_03",
                 ]))
                 .help("Enables rate limit response headers"),
+        )
+        .arg(
+            Arg::new("grpc_reflection_service")
+                .long("grpc-reflection-service")
+                .action(ArgAction::SetTrue)
+                .display_order(9)
+                .help("enable gRPC server reflection service"),
         )
         .subcommand(
             Command::new("memory")
@@ -745,6 +754,7 @@ fn create_config() -> (Configuration, &'static str) {
         matches.get_flag("limit_name_in_labels")
             || env_option_is_enabled("LIMIT_NAME_IN_PROMETHEUS_LABELS"),
         rate_limit_headers,
+        matches.get_flag("grpc_reflection_service"),
     );
 
     config.log_level = match matches.get_count("v") {

--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -522,7 +522,7 @@ fn create_config() -> (Configuration, &'static str) {
                 .long("grpc-reflection-service")
                 .action(ArgAction::SetTrue)
                 .display_order(9)
-                .help("enable gRPC server reflection service"),
+                .help("Enables gRPC server reflection service"),
         )
         .subcommand(
             Command::new("memory")


### PR DESCRIPTION
### What

gRPC server reflection provided by [tonic-reflection](https://crates.io/crates/tonic-reflection/0.10.2)

Opt-in feature to be enabled using `--grpc-reflection-service` command line option. 

### Verification steps

Run `sandbox` dev environment

```bash
cd limitador-server/sandbox
make build
make deploy-in-memory
```
> **Note**: `make deploy-in-memory` runs limitador with the  `--grpc-reflection-service` command line option set.

In a separate shell, inspect the RLS GRPC endpoint. First, let's install [grpcurl](https://github.com/fullstorydev/grpcurl) tool. You need [Go SDK 1.8+](https://golang.org/doc/install) installed.

```bash
make grpcurl
```

Inspect `RateLimitService` GRPC service

```bash
bin/grpcurl -plaintext 127.0.0.1:18081 describe envoy.service.ratelimit.v3.RateLimitService
```
The output should be the following
```bash
envoy.service.ratelimit.v3.RateLimitService is a service:
service RateLimitService {
  // Determine whether rate limiting should take place.
  rpc ShouldRateLimit ( .envoy.service.ratelimit.v3.RateLimitRequest ) returns ( .envoy.service.ratelimit.v3.RateLimitResponse );
}
```
If the reflection API is not available the output looks like

```bash
Failed to resolve symbol "envoy.service.ratelimit.v3.RateLimitService": server does not support the reflection API
```

Make a manual request to the RLS endpoint

```bash
bin/grpcurl -plaintext -d @ 127.0.0.1:18081 envoy.service.ratelimit.v3.RateLimitService.ShouldRateLimit <<EOM
{
    "domain": "test_namespace",
    "hits_addend": 1,
    "descriptors": [
        {
            "entries": [
                {
                    "key": "req.method",
                    "value": "POST"
                }
            ]
        }
    ]
}
EOM
```
> Note that `grpcurl` does not need proto files or compiled protoset files. The reflection service tells `grpc` how to parse request and response.

The response should be the following:

```json
{
  "overallCode": "OK"
}
```

Let's check that rate limiting is working. The limits file looks like

```yaml
- namespace: test_namespace
  max_value: 5
  seconds: 60
  conditions:
    - "req.method == 'POST'"
  variables: []
```

Thus, the limit is set to max 5 request for 60 seconds. Do repeated requests. you should see `OVER_LIMIT` response after 5 requests.

```bash
while :; do bin/grpcurl -plaintext -d @ 127.0.0.1:18081 envoy.service.ratelimit.v3.RateLimitService.ShouldRateLimit <<EOM; sleep 1; done
{
    "domain": "test_namespace",
    "hits_addend": 1,
    "descriptors": [
        {
            "entries": [
                {
                    "key": "req.method",
                    "value": "POST"
                }
            ]
        }
    ]
}
EOM
```
The expected output

```json
{
  "overallCode": "OK"
}
{
  "overallCode": "OK"
}
{
  "overallCode": "OK"
}
{
  "overallCode": "OK"
}
{
  "overallCode": "OK"
}
{
  "overallCode": "OVER_LIMIT"
}
{
  "overallCode": "OVER_LIMIT"
}
{
  "overallCode": "OVER_LIMIT"
}
```

