### PR TITLE
refactor: use x.first() instead of x.get(0)

### DIFF
--- a/limitador-server/src/http_api/server.rs
+++ b/limitador-server/src/http_api/server.rs
@@ -266,7 +266,7 @@ mod tests {
             .to_request();
         let resp_limits: Vec<Limit> = test::call_and_read_body_json(&app, req).await;
         assert_eq!(resp_limits.len(), 1);
-        assert_eq!(*resp_limits.get(0).unwrap(), Limit::from(&limit));
+        assert_eq!(*resp_limits.first().unwrap(), Limit::from(&limit));
     }
 
     #[actix_rt::test]


### PR DESCRIPTION
Clippy lint is failing due to https://rust-lang.github.io/rust-clippy/master/index.html#/get_first