### PR TITLE
store increments in redis

### DIFF
--- a/limitador/src/storage/redis/mod.rs
+++ b/limitador/src/storage/redis/mod.rs
@@ -47,7 +47,8 @@ pub fn is_limited(
 
     let mut first_limited = None;
     for (i, counter) in counters.iter_mut().enumerate() {
-        let remaining = counter_vals[i].unwrap_or(counter.max_value()) - delta;
+        // remaining  = max - (curr_val + delta)
+        let remaining = counter.max_value() - (counter_vals[i].unwrap_or(0) + delta);
         counter.set_remaining(remaining);
         let expires_in = counter_ttls_msecs[i]
             .map(|x| {

--- a/limitador/src/storage/redis/scripts.rs
+++ b/limitador/src/storage/redis/scripts.rs
@@ -9,15 +9,15 @@
 
 // KEYS[1]: counter key
 // KEYS[2]: key that contains the counters that belong to the limit
-// ARGV[1]: counter max val
-// ARGV[2]: counter TTL
-// ARGV[3]: delta
+// ARGV[1]: counter TTL
+// ARGV[2]: delta
 pub const SCRIPT_UPDATE_COUNTER: &str = "
-    local set_res = redis.call('set', KEYS[1], ARGV[1], 'EX', ARGV[2], 'NX')
-    redis.call('incrby', KEYS[1], - ARGV[3])
-    if set_res then
-        redis.call('sadd', KEYS[2], KEYS[1])
-    end";
+    local c = redis.call('incrby', KEYS[1], ARGV[2])
+    if c == tonumber(ARGV[2]) then
+      redis.call('expire', KEYS[1], ARGV[1], 'NX')
+      redis.call('sadd', KEYS[2], KEYS[1])
+    end
+    return c";
 
 // KEYS: the function returns the value and TTL (in ms) for these keys
 // The first position of the list returned contains the value of KEYS[1], the

--- a/limitador/src/storage/redis/scripts.rs
+++ b/limitador/src/storage/redis/scripts.rs
@@ -14,7 +14,7 @@
 pub const SCRIPT_UPDATE_COUNTER: &str = "
     local c = redis.call('incrby', KEYS[1], ARGV[2])
     if c == tonumber(ARGV[2]) then
-      redis.call('expire', KEYS[1], ARGV[1], 'NX')
+      redis.call('expire', KEYS[1], ARGV[1])
       redis.call('sadd', KEYS[2], KEYS[1])
     end
     return c";


### PR DESCRIPTION
### What

Fixes #269 

:warning: Breaks backward compatibility

### Verification steps

* Checkout this code branch

```bash
cd limitador-server/sandbox/
```

* Build limitador image `limitador-testing` for the current branch
```bash
make build
```

* Run sandbox with redis 

The applied limit is 
```yaml
- namespace: test_namespace 
  max_value: 10             
  seconds: 60               
  conditions:               
  - "req.method == 'GET'" 
  variables: []             
- namespace: test_namespace 
  max_value: 5              
  seconds: 60               
  conditions:               
  - "req.method == 'POST'"
  variables: [] 
```

```bash
make deploy-redis
```

* Open a new shell

* Let's create a counter running on `ShouldRateLimit` request

```bash
make grpcurl
```

```bash
bin/grpcurl -plaintext -d @ 127.0.0.1:18081 envoy.service.ratelimit.v3.RateLimitService.ShouldRateLimit <<EOM
{
    "domain": "test_namespace",
    "hits_addend": 1,
    "descriptors": [
        {
            "entries": [
                {
                    "key": "req.method",
                    "value": "POST"
                }
            ]
        }
    ]
}
EOM
```

* Check the counter value
```
docker compose -p sandbox exec redis redis-cli get "namespace:{test_namespace},,counter:{\"limit\":{\"namespace\":\"test_namespace\",\"seconds\":60,\"conditions\":[\"req.method == \\\"POST\\\"\"],\"variables\":[]},\"set_variables\":{},\"remaining\":null,\"expires_in\":null}"
```
> Counters have TTL of 60sec, so do not go for a coffee between the request and the redis counter read.

That should be `1`

* Run yet another `ShouldRateLimit` request
```bash
bin/grpcurl -plaintext -d @ 127.0.0.1:18081 envoy.service.ratelimit.v3.RateLimitService.ShouldRateLimit <<EOM
{
    "domain": "test_namespace",
    "hits_addend": 1,
    "descriptors": [
        {
            "entries": [
                {
                    "key": "req.method",
                    "value": "POST"
                }
            ]
        }
    ]
}
EOM
```

* Check the counter value
```bash
docker compose -p sandbox exec redis redis-cli get "namespace:{test_namespace},,counter:{\"limit\":{\"namespace\":\"test_namespace\",\"seconds\":60,\"conditions\":[\"req.method == \\\"POST\\\"\"],\"variables\":[]},\"set_variables\":{},\"remaining\":null,\"expires_in\":null}"
```

That should be `2`

* run N times

```bash
while :; do bin/grpcurl -plaintext -d @ 127.0.0.1:18081 envoy.service.ratelimit.v3.RateLimitService.ShouldRateLimit <<EOM; sleep 1; done
{
    "domain": "test_namespace",
    "hits_addend": 1,
    "descriptors": [
        {
            "entries": [
                {
                    "key": "req.method",
                    "value": "POST"
                }
            ]
        }
    ]
}
EOM
```

After few hits, the response should be `"overallCode": "OVER_LIMIT"` and the counter value should be `5`

```bash
docker compose -p sandbox exec redis redis-cli get "namespace:{test_namespace},,counter:{\"limit\":{\"namespace\":\"test_namespace\",\"seconds\":60,\"conditions\":[\"req.method == \\\"POST\\\"\"],\"variables\":[]},\"set_variables\":{},\"remaining\":null,\"expires_in\":null}"
```

### Tear down sandbox

```bash
make clean
```