### PR TITLE
integration tests for async redis with local cache

### DIFF
--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -83,7 +83,7 @@ impl AsyncCounterStorage for CachedRedisStorage {
             for counter in counters.iter_mut() {
                 match cached_counters.get(counter) {
                     Some(val) => {
-                        if first_limited.is_none() && val - delta < 0 {
+                        if first_limited.is_none() && val + delta > counter.max_value() {
                             let a = Authorization::Limited(
                                 counter.limit().name().map(|n| n.to_owned()),
                             );
@@ -93,7 +93,7 @@ impl AsyncCounterStorage for CachedRedisStorage {
                             first_limited = Some(a);
                         }
                         if load_counters {
-                            counter.set_remaining(val);
+                            counter.set_remaining(counter.max_value() - val - delta);
                             // todo: how do we get the ttl for this entry?
                             // counter.set_expires_in(Duration::from_secs(counter.seconds()));
                         }
@@ -128,7 +128,7 @@ impl AsyncCounterStorage for CachedRedisStorage {
                         counter_ttls_msecs[i],
                         ttl_margin,
                     );
-                    let remaining = counter_vals[i].unwrap_or(counter.max_value()) - delta;
+                    let remaining = counter.max_value() - counter_vals[i].unwrap_or(0) - delta;
                     if first_limited.is_none() && remaining < 0 {
                         first_limited = Some(Authorization::Limited(
                             counter.limit().name().map(|n| n.to_owned()),
@@ -136,7 +136,13 @@ impl AsyncCounterStorage for CachedRedisStorage {
                     }
                     if load_counters {
                         counter.set_remaining(remaining);
-                        counter.set_expires_in(Duration::from_millis(counter_ttls_msecs[i] as u64));
+                        let counter_ttl = if counter_ttls_msecs[i] >= 0 {
+                            Duration::from_millis(counter_ttls_msecs[i] as u64)
+                        } else {
+                            Duration::from_secs(counter.max_value() as u64)
+                        };
+
+                        counter.set_expires_in(counter_ttl);
                     }
                 }
             }
@@ -150,7 +156,7 @@ impl AsyncCounterStorage for CachedRedisStorage {
         {
             let mut cached_counters = self.cached_counters.lock().unwrap();
             for counter in counters.iter() {
-                cached_counters.decrease_by(counter, delta);
+                cached_counters.increase_by(counter, delta);
             }
         }
 

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -59,7 +59,7 @@ macro_rules! test_with_all_storage_impls {
             #[serial]
             async fn [<$function _with_async_redis_and_local_cache>]() {
                 let storage_builder = CachedRedisStorageBuilder::new("redis://127.0.0.1:6379").
-                    flushing_period(None).
+                    flushing_period(Some(Duration::from_millis(200))).
                     max_ttl_cached_counters(Duration::from_secs(3600)).
                     ttl_ratio_cached_counters(1).
                     max_cached_counters(10000);


### PR DESCRIPTION
### What

Integration tests for async redis with local cache

Notes:
* Not added tests for checking behavior when cache ttl expires or cache is flushed to redis.
* Counter increments instead of decrements for redis_cached.