### PR TITLE
Removed the lazy static from the prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,7 +1554,6 @@ dependencies = [
  "futures",
  "getrandom",
  "infinispan",
- "lazy_static",
  "moka",
  "paste",
  "postcard",

--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -310,8 +310,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .init();
         };
 
-        prometheus_metrics.set_use_limit_name_in_label(limit_name_in_metrics);
-
         info!("Version: {}", version);
         info!("Using config: {:?}", config);
         (config, prometheus_metrics)

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -32,7 +32,6 @@ thiserror = "1"
 futures = "0.3"
 async-trait = "0.1"
 cfg-if = "1"
-lazy_static = "1"
 tracing = "0.1.40"
 
 # Optional dependencies


### PR DESCRIPTION
Removes the lazy static reference to prometheus metrics and uses an Arc instead. This solves the issue with updating the `use_limit_name_label` on limited calls (resulting in a internal server error 500) as it's now initialised correctly.

The http server now uses a `RateLimitData` struct that contains the metrics and the limiter.