### PR TITLE
feat: CachedRedisStorage will now default to flushing a batch ASAP to…

### DIFF
--- a/limitador/src/storage/redis/mod.rs
+++ b/limitador/src/storage/redis/mod.rs
@@ -7,7 +7,7 @@ mod redis_cached;
 mod redis_sync;
 mod scripts;
 
-pub const DEFAULT_FLUSHING_PERIOD_SEC: u64 = 1;
+pub const DEFAULT_FLUSHING_PERIOD_SEC: u64 = 0;
 pub const DEFAULT_MAX_CACHED_COUNTERS: usize = 10000;
 pub const DEFAULT_MAX_TTL_CACHED_COUNTERS_SEC: u64 = 5;
 pub const DEFAULT_TTL_RATIO_CACHED_COUNTERS: u64 = 10;


### PR DESCRIPTION
… reduce the length of time the cache is out of sync with Redis counters.

Setting a flushing_period is still supported to have a delay before flushing which can be useful to reduce the load on the Redis server in exchange for having staler counters in limitador.