### PR TITLE
Support pending writes within CachedCounterValue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,7 @@ dependencies = [
  "base64 0.22.0",
  "cfg-if",
  "criterion",
+ "dashmap",
  "futures",
  "getrandom",
  "infinispan",

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -22,6 +22,7 @@ lenient_conditions = []
 
 [dependencies]
 moka = { version = "0.12", features = ["sync"] }
+dashmap = "5.5.3"
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1", features = ["derive"] }
 postcard = { version = "1.0.4", features = ["use-std"] }

--- a/limitador/src/storage/redis/counters_cache.rs
+++ b/limitador/src/storage/redis/counters_cache.rs
@@ -5,11 +5,13 @@ use crate::storage::redis::{
     DEFAULT_TTL_RATIO_CACHED_COUNTERS,
 };
 use moka::sync::Cache;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 pub struct CachedCounterValue {
     value: AtomicExpiringValue,
+    initial_value: AtomicI64,
     expiry: AtomicExpiryTime,
 }
 
@@ -24,6 +26,7 @@ impl CachedCounterValue {
         let now = SystemTime::now();
         Self {
             value: AtomicExpiringValue::new(value, now + Duration::from_secs(counter.seconds())),
+            initial_value: AtomicI64::new(value),
             expiry: AtomicExpiryTime::from_now(ttl),
         }
     }
@@ -39,8 +42,46 @@ impl CachedCounterValue {
     }
 
     pub fn delta(&self, counter: &Counter, delta: i64) -> i64 {
-        self.value
-            .update(delta, counter.seconds(), SystemTime::now())
+        let value = self
+            .value
+            .update(delta, counter.seconds(), SystemTime::now());
+        if value == delta {
+            // new window, invalidate initial value
+            self.initial_value.store(0, Ordering::SeqCst);
+        }
+        value
+    }
+
+    #[allow(dead_code)]
+    pub fn pending_writes(&self) -> Result<i64, ()> {
+        let start = self.initial_value.load(Ordering::SeqCst);
+        let value = self.value.value_at(SystemTime::now());
+        let offset = if start == 0 {
+            value
+        } else {
+            let writes = value - start;
+            if writes > 0 {
+                writes
+            } else {
+                value
+            }
+        };
+        match self
+            .initial_value
+            .compare_exchange(start, value, Ordering::SeqCst, Ordering::SeqCst)
+        {
+            Ok(_) => Ok(offset),
+            Err(newer) => {
+                if newer == 0 {
+                    // We got expired in the meantime, this fresh value can wait the next iteration
+                    Ok(0)
+                } else {
+                    // Concurrent call to this method?
+                    // We could support that with a CAS loop in the future if needed
+                    Err(())
+                }
+            }
+        }
     }
 
     pub fn hits(&self, _: &Counter) -> i64 {

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -579,7 +579,7 @@ mod tests {
         let partitioned = Arc::new(AtomicBool::new(false));
 
         if let Some(c) = cached_counters.get(&counter) {
-            assert_eq!(c.hits(&counter), 1);
+            assert_eq!(c.hits(&counter), 2);
         }
 
         flush_batcher_and_update_counters(mock_client, true, cached_counters.clone(), partitioned)

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -223,7 +223,6 @@ impl CachedRedisStorage {
             let counters_cache_clone = counters_cache.clone();
             let conn = redis_conn_manager.clone();
             let p = Arc::clone(&partitioned);
-            let mut interval = tokio::time::interval(flushing_period);
             tokio::spawn(async move {
                 loop {
                     flush_batcher_and_update_counters(
@@ -233,7 +232,6 @@ impl CachedRedisStorage {
                         p.clone(),
                     )
                     .await;
-                    interval.tick().await;
                 }
             });
         }

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -499,7 +499,7 @@ mod tests {
 
         counters_and_deltas.insert(
             counter.clone(),
-            Arc::new(CachedCounterValue::from(
+            Arc::new(CachedCounterValue::from_authority(
                 &counter,
                 1,
                 Duration::from_secs(60),
@@ -561,12 +561,11 @@ mod tests {
         let cache = CountersCacheBuilder::new().build(Duration::from_millis(1));
         cache.batcher().add(
             counter.clone(),
-            Arc::new(CachedCounterValue::from(
+            Arc::new(CachedCounterValue::from_authority(
                 &counter,
                 2,
                 Duration::from_secs(60),
             )),
-            false,
         );
         cache.insert(
             counter.clone(),


### PR DESCRIPTION
Alright, this is a shot at unifying the "write-behind" and the cache we use in front of Redis.
It does so in a few ways:
 - The "pending increments" are recorded directly in the `CachedCounterValue`
 - Both the cache and the "write-behind queue" (still a Map) point to the same _instance_ of a `CachedCounterValue` (within an `Arc`) for the same `Counter` "key"
 - All entries added to the `Cache` _should be_ atomic and only then added to the `Batcher` (our write-behind "queue")
 - We _always_ look up in the `Batcher` if a `CachedCounterValue` is mapped to key, in case it got evicted from the cache
 - We _only_ add `CachedCounterValue` to the `Batcher` with an `.pending_writes() > 0`
 - We _only_ remove atomically from the `Batched` if the `.pending_writes() == 0`
 - If we ever added two different `CachedCounterValue` instances (there is a race when inserting into the cache and being evicted _before_ we made it into the `Batcher`, where we then merge the pending writes from one `CachedCounterValue` into the other one

This was achieved by doing:
 - [x] folding the pending writes within the `CachedCounterValue`
 - [x] change the `CachedRedisStorage.batcher_counter_updates` to point to the same `Arc` as within `CountersCache.cache`
 - [x] use the `CachedCounterValue` to populate the batch to redis (and update the values back)
 - [x] Introduce a proper `Batcher` type back exposing `.add()` and `.consume(u64).await`
 - [x] Have the `Batcher` awaken on either: flush period being elapsed the batch size being reached
 - [x] Flush on "important" flushes being required
 - [x] `.consume` would return the most "important" updates first always
 - [x] Lookup the queue on cache misses
 - [x] Address #298

This still misses tests 🤦 yet I still think this is better than what we had before... So, I think we should merge this and iterate, but only if my reasoning makes sense and "seems to be implemented" in this PR. 