### PR TITLE
Refactor metrics to use alternate metrics crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,8 +39,8 @@ dependencies = [
  "encoding_rs",
  "flate2",
  "futures-core",
- "h2",
- "http",
+ "h2 0.3.26",
+ "http 0.2.12",
  "httparse",
  "httpdate",
  "itoa",
@@ -75,7 +75,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22475596539443685426b6bdadb926ad0ecaefdfc5fb05e5e3441f15463c511"
 dependencies = [
  "bytestring",
- "http",
+ "http 0.2.12",
  "regex",
  "serde",
  "tracing",
@@ -359,9 +359,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -385,8 +385,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -1110,7 +1110,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.1.0",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -1148,6 +1167,9 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heapless"
@@ -1193,13 +1215,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -1225,9 +1281,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1240,12 +1296,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1258,10 +1335,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1301,7 +1414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d961790ad3dae0ea7ec1a4ab2c32de1a0bf5f3d7d7fddb0a0f2059b96ecafe0a"
 dependencies = [
  "base64 0.13.1",
- "http",
+ "http 0.2.12",
  "reqwest",
  "serde",
  "serde_json",
@@ -1481,6 +1594,7 @@ dependencies = [
  "futures",
  "getrandom",
  "infinispan",
+ "metrics",
  "moka",
  "paste",
  "postcard",
@@ -1511,6 +1625,8 @@ dependencies = [
  "lazy_static",
  "limitador",
  "log",
+ "metrics",
+ "metrics-exporter-prometheus",
  "notify",
  "openssl",
  "opentelemetry",
@@ -1518,7 +1634,6 @@ dependencies = [
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "paperclip",
- "prometheus",
  "prost",
  "prost-types",
  "serde",
@@ -1605,6 +1720,52 @@ name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "metrics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d58e362dc7206e9456ddbcdbd53c71ba441020e62104703075a69151e38d85f"
+dependencies = [
+ "base64 0.22.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "indexmap 2.2.6",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.14.3",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -1864,7 +2025,7 @@ checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
 dependencies = [
  "async-trait",
  "futures-core",
- "http",
+ "http 0.2.12",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
@@ -2007,7 +2168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e25ce2c5362c8d48dc89e0f9ca076d507f7c1eabd04f0d593cdf5addff90c"
 dependencies = [
  "heck 0.4.1",
- "http",
+ "http 0.2.12",
  "lazy_static",
  "mime",
  "proc-macro-error",
@@ -2130,6 +2291,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "postcard"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2197,21 +2364,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
- "parking_lot",
- "protobuf",
- "thiserror",
-]
-
-[[package]]
 name = "prost"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2263,12 +2415,6 @@ checksum = "3235c33eb02c1f1e212abdbe34c78b264b038fb58ca612664343271e36e55ffe"
 dependencies = [
  "prost",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quanta"
@@ -2464,11 +2610,11 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-tls",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -2763,6 +2909,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "slab"
@@ -3094,10 +3246,10 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 edition = "2021"
 
 [features]
-infinispan = [ "limitador/infinispan_storage" ]
+infinispan = ["limitador/infinispan_storage"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -46,7 +46,8 @@ lazy_static = "1.4.0"
 clap = "4.3"
 sysinfo = "0.30.10"
 openssl = { version = "0.10.57", features = ["vendored"] }
-prometheus = "0.13.3"
+metrics = "0.22.3"
+metrics-exporter-prometheus = "0.14.0"
 
 
 [build-dependencies]

--- a/limitador-server/src/envoy_rls/server.rs
+++ b/limitador-server/src/envoy_rls/server.rs
@@ -276,6 +276,7 @@ mod tests {
 
     use crate::envoy_rls::server::envoy::extensions::common::ratelimit::v3::rate_limit_descriptor::Entry;
     use crate::envoy_rls::server::envoy::extensions::common::ratelimit::v3::RateLimitDescriptor;
+    use crate::prometheus_metrics::tests::TEST_PROMETHEUS_HANDLE;
     use crate::Configuration;
 
     use super::*;
@@ -311,7 +312,10 @@ mod tests {
         let rate_limiter = MyRateLimiter::new(
             Arc::new(Limiter::Blocking(limiter)),
             RateLimitHeaders::DraftVersion03,
-            Arc::new(PrometheusMetrics::default()),
+            Arc::new(PrometheusMetrics::new_with_handle(
+                false,
+                TEST_PROMETHEUS_HANDLE.clone(),
+            )),
         );
 
         let req = RateLimitRequest {
@@ -370,7 +374,10 @@ mod tests {
         let rate_limiter = MyRateLimiter::new(
             Arc::new(Limiter::new(Configuration::default()).await.unwrap()),
             RateLimitHeaders::DraftVersion03,
-            Arc::new(PrometheusMetrics::default()),
+            Arc::new(PrometheusMetrics::new_with_handle(
+                false,
+                TEST_PROMETHEUS_HANDLE.clone(),
+            )),
         );
 
         let req = RateLimitRequest {
@@ -401,7 +408,10 @@ mod tests {
         let rate_limiter = MyRateLimiter::new(
             Arc::new(Limiter::new(Configuration::default()).await.unwrap()),
             RateLimitHeaders::DraftVersion03,
-            Arc::new(PrometheusMetrics::default()),
+            Arc::new(PrometheusMetrics::new_with_handle(
+                false,
+                TEST_PROMETHEUS_HANDLE.clone(),
+            )),
         );
 
         let req = RateLimitRequest {
@@ -444,7 +454,10 @@ mod tests {
         let rate_limiter = MyRateLimiter::new(
             Arc::new(Limiter::Blocking(limiter)),
             RateLimitHeaders::DraftVersion03,
-            Arc::new(PrometheusMetrics::default()),
+            Arc::new(PrometheusMetrics::new_with_handle(
+                false,
+                TEST_PROMETHEUS_HANDLE.clone(),
+            )),
         );
 
         let req = RateLimitRequest {
@@ -503,7 +516,10 @@ mod tests {
         let rate_limiter = MyRateLimiter::new(
             Arc::new(Limiter::Blocking(limiter)),
             RateLimitHeaders::DraftVersion03,
-            Arc::new(PrometheusMetrics::default()),
+            Arc::new(PrometheusMetrics::new_with_handle(
+                false,
+                TEST_PROMETHEUS_HANDLE.clone(),
+            )),
         );
 
         let req = RateLimitRequest {
@@ -569,7 +585,10 @@ mod tests {
         let rate_limiter = MyRateLimiter::new(
             Arc::new(Limiter::Blocking(limiter)),
             RateLimitHeaders::DraftVersion03,
-            Arc::new(PrometheusMetrics::default()),
+            Arc::new(PrometheusMetrics::new_with_handle(
+                false,
+                TEST_PROMETHEUS_HANDLE.clone(),
+            )),
         );
 
         let req = RateLimitRequest {

--- a/limitador-server/src/http_api/server.rs
+++ b/limitador-server/src/http_api/server.rs
@@ -232,6 +232,7 @@ pub async fn run_http_server(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::prometheus_metrics::tests::TEST_PROMETHEUS_HANDLE;
     use crate::Configuration;
     use actix_web::{test, web};
     use limitador::limit::Limit as LimitadorLimit;
@@ -258,7 +259,9 @@ mod tests {
     async fn test_metrics() {
         let rate_limiter: Arc<Limiter> =
             Arc::new(Limiter::new(Configuration::default()).await.unwrap());
-        let prometheus_metrics: Arc<PrometheusMetrics> = Arc::new(PrometheusMetrics::default());
+        let prometheus_metrics: Arc<PrometheusMetrics> = Arc::new(
+            PrometheusMetrics::new_with_handle(false, TEST_PROMETHEUS_HANDLE.clone()),
+        );
         let data = web::Data::new(RateLimitData::new(rate_limiter, prometheus_metrics));
         let app = test::init_service(
             App::new()
@@ -283,7 +286,9 @@ mod tests {
 
         let limit = create_test_limit(&limiter, namespace, 10).await;
         let rate_limiter: Arc<Limiter> = Arc::new(limiter);
-        let prometheus_metrics: Arc<PrometheusMetrics> = Arc::new(PrometheusMetrics::default());
+        let prometheus_metrics: Arc<PrometheusMetrics> = Arc::new(
+            PrometheusMetrics::new_with_handle(false, TEST_PROMETHEUS_HANDLE.clone()),
+        );
         let data = web::Data::new(RateLimitData::new(rate_limiter, prometheus_metrics));
         let app = test::init_service(
             App::new()
@@ -310,7 +315,9 @@ mod tests {
         let namespace = "test_namespace";
         let _limit = create_test_limit(&limiter, namespace, 1).await;
         let rate_limiter: Arc<Limiter> = Arc::new(limiter);
-        let prometheus_metrics: Arc<PrometheusMetrics> = Arc::new(PrometheusMetrics::default());
+        let prometheus_metrics: Arc<PrometheusMetrics> = Arc::new(
+            PrometheusMetrics::new_with_handle(false, TEST_PROMETHEUS_HANDLE.clone()),
+        );
         let data = web::Data::new(RateLimitData::new(rate_limiter, prometheus_metrics));
         let app = test::init_service(
             App::new()
@@ -355,7 +362,9 @@ mod tests {
         let _limit = create_test_limit(&limiter, namespace, 1).await;
 
         let rate_limiter: Arc<Limiter> = Arc::new(limiter);
-        let prometheus_metrics: Arc<PrometheusMetrics> = Arc::new(PrometheusMetrics::default());
+        let prometheus_metrics: Arc<PrometheusMetrics> = Arc::new(
+            PrometheusMetrics::new_with_handle(false, TEST_PROMETHEUS_HANDLE.clone()),
+        );
         let data = web::Data::new(RateLimitData::new(rate_limiter, prometheus_metrics));
         let app = test::init_service(
             App::new()

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -33,6 +33,7 @@ futures = "0.3"
 async-trait = "0.1"
 cfg-if = "1"
 tracing = "0.1.40"
+metrics = "0.22.3"
 
 # Optional dependencies
 rocksdb = { version = "0.22", optional = true, features = ["multi-threaded-cf"] }

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -12,6 +12,7 @@ use crate::storage::redis::{
 };
 use crate::storage::{AsyncCounterStorage, Authorization, StorageErr};
 use async_trait::async_trait;
+use metrics::gauge;
 use redis::aio::{ConnectionLike, ConnectionManager};
 use redis::{ConnectionInfo, RedisError};
 use std::collections::{HashMap, HashSet};
@@ -219,8 +220,10 @@ fn flip_partitioned(storage: &AtomicBool, partition: bool) -> bool {
         .is_ok();
     if we_flipped {
         if partition {
+            gauge!("datastore_partitioned").set(1);
             error!("Partition to Redis detected!")
         } else {
+            gauge!("datastore_partitioned").set(0);
             warn!("Partition to Redis resolved!");
         }
     }


### PR DESCRIPTION
# Changes

I've removed the original prometheus crate and added metrics, and prometheus metrics exporter. These support using the metrics API, and the exporter allows us to get a handle to be able to still use actix to export the metrics at `/metrics`.

* Metrics are configured with the help message via the `describe_*` methods on init
* They are no longer stored in the struct and used from the macro directly (due to the macro supporting labels but no method on the metrics types)
* The `prometheus_metrics` struct is still passed to `envoy_rls/server` and to the `http_api/server` to retain the config `limit_name_in_labels` for writing the metrics - not 100% sold on this solution though
* The prom metrics struct now retains a handle to the global prometheus recorder, as this can only be set once for the lifetime of the application. The tests share a single lazy static handle
* I've provided an example for adding a `datastore_partitioned` metric to the limitador library

# Verification

Checkout this branch and build server:
```
cargo build --bin limitador-server
```

Run the server:
```
./target/debug/limitador-server -vvv --grpc-reflection-service --limit-name-in-labels limitador-server/sandbox/limits.yaml redis_cached redis://127.0.0.1
```

Check metrics endpoint:
```
curl localhost:8080/metrics
# HELP limitador_up Limitador is running
# TYPE limitador_up gauge
limitador_up 1
```

# TODO
- [x] Fix tests, unable to configure the prometheus exporter