### PR TITLE
PRs comming from forks do not push images

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -133,7 +133,7 @@ jobs:
     name: Build on forks
     # for forks
     if: |
-      github.event.repository.full_name != github.repository)
+      github.event.repository.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -13,6 +13,13 @@ env:
   MAIN_BRANCH_NAME: main
 
 jobs:
+  dump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
   build:
     name: Build
     # for tags and not forks

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -15,7 +15,11 @@ env:
 jobs:
   build:
     name: Build
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # for tags and not forks
+    if: |
+      (startsWith(github.ref, 'refs/tags/')) ||
+      (!startsWith(github.ref, 'refs/tags/') &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -73,7 +77,11 @@ jobs:
           retention-days: 1
   merge:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # for tags and not forks
+    if: |
+      (startsWith(github.ref, 'refs/tags/')) ||
+      (!startsWith(github.ref, 'refs/tags/') &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     needs:
       - build
     steps:
@@ -115,8 +123,10 @@ jobs:
         run: |
           docker run --rm -t ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/limitador:${{ steps.meta.outputs.version }} limitador-server --help
   build-from-forks:
-    name: Build
-    if: github.event.pull_request.head.repo.full_name != github.repository
+    name: Build on forks
+    if: |
+      !startsWith(github.ref, 'refs/tags/') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -15,6 +15,7 @@ env:
 jobs:
   build:
     name: Build
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -72,6 +73,7 @@ jobs:
           retention-days: 1
   merge:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     needs:
       - build
     steps:
@@ -112,3 +114,18 @@ jobs:
       - name: Smoke Test
         run: |
           docker run --rm -t ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/limitador:${{ steps.meta.outputs.version }} limitador-server --help
+  build-from-forks:
+    name: Build
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Build Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: limitador
+          tags: ${{ github.sha }}
+          dockerfiles: |
+            ./Dockerfile

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -22,11 +22,11 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
   build:
     name: Build
-    # for tags and not forks
+    # for regulars pushes, tags and not forks
     if: |
       (startsWith(github.ref, 'refs/tags/')) ||
       (!startsWith(github.ref, 'refs/tags/') &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      github.event.repository.full_name == github.repository)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -84,11 +84,11 @@ jobs:
           retention-days: 1
   merge:
     runs-on: ubuntu-latest
-    # for tags and not forks
+    # for regulars pushes, tags and not forks
     if: |
       (startsWith(github.ref, 'refs/tags/')) ||
       (!startsWith(github.ref, 'refs/tags/') &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      github.event.repository.full_name == github.repository)
     needs:
       - build
     steps:
@@ -131,9 +131,9 @@ jobs:
           docker run --rm -t ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/limitador:${{ steps.meta.outputs.version }} limitador-server --help
   build-from-forks:
     name: Build on forks
+    # for forks
     if: |
-      !startsWith(github.ref, 'refs/tags/') &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.repository.full_name != github.repository)
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -146,3 +146,6 @@ jobs:
           tags: ${{ github.sha }}
           dockerfiles: |
             ./Dockerfile
+      - name: Smoke Test
+        run: |
+          docker run --rm -t limitador:${{ github.sha }} limitador-server --help


### PR DESCRIPTION
### What

GH action runs on pushes coming from forked PR's do not have permissions to access docker image repo in quay.io.

This PR adds some conditionals to skip those steps that would fail otherwise.

But building the image and running smoke tests on the image is still a value for forked PR's, so allowing them as a separated job. Not doing multi-arch build with layer caching as the regular image building, though.

### Tested

- [ ] Pushes from kuadrant users
- [ ] Pushes from external users (forked PR's)
- [ ] Tags