### PR TITLE
Easier expiry

### DIFF
--- a/limitador/src/storage/redis/counters_cache.rs
+++ b/limitador/src/storage/redis/counters_cache.rs
@@ -128,7 +128,9 @@ impl CachedCounterValue {
     }
 
     pub fn requires_fast_flush(&self, within: &Duration) -> bool {
-        self.from_authority.load(Ordering::Acquire).not() || &self.value.ttl() <= within
+        self.from_authority.load(Ordering::Acquire).not()
+            || self.expired_at(SystemTime::now())
+            || &self.value.ttl() <= within
     }
 }
 

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -75,11 +75,10 @@ impl AsyncCounterStorage for CachedRedisStorage {
         let mut not_cached: Vec<&mut Counter> = vec![];
         let mut first_limited = None;
 
-        let now = SystemTime::now();
         // Check cached counters
         for counter in counters.iter_mut() {
             match self.cached_counters.get(counter) {
-                Some(val) if !val.expired_at(now) => {
+                Some(val) => {
                     if first_limited.is_none() && val.is_limited(counter, delta) {
                         let a =
                             Authorization::Limited(counter.limit().name().map(|n| n.to_owned()));


### PR DESCRIPTION
this change is about _not_ reset a `CachedCounterValue` when it's expired, but rather keep its value and consider it requiring a fast flush (which it already did before, by considering it as if it was absent from the cache for the `check_and_update` body, but then `increase_by` would still increment the expired value).
This now uses the value from the `cache` the entire call stack... 

