### PR TITLE
Additional metrics

### DIFF
--- a/limitador-server/src/metrics.rs
+++ b/limitador-server/src/metrics.rs
@@ -11,6 +11,7 @@ pub struct Timings {
     idle: u64,
     busy: u64,
     last: Instant,
+    updated: bool,
 }
 
 impl Timings {
@@ -19,6 +20,7 @@ impl Timings {
             idle: 0,
             busy: 0,
             last: Instant::now(),
+            updated: false,
         }
     }
 }
@@ -31,6 +33,7 @@ impl ops::Add for Timings {
             busy: self.busy + rhs.busy,
             idle: self.idle + rhs.idle,
             last: self.last.max(rhs.last),
+            updated: self.updated || rhs.updated,
         }
     }
 }
@@ -160,6 +163,7 @@ where
             let now = Instant::now();
             timings.idle += (now - timings.last).as_nanos() as u64;
             timings.last = now;
+            timings.updated = true;
         }
     }
 
@@ -171,6 +175,7 @@ where
             let now = Instant::now();
             timings.busy += (now - timings.last).as_nanos() as u64;
             timings.last = now;
+            timings.updated = true;
         }
     }
 
@@ -210,7 +215,9 @@ where
             }
             // IF we are aggregator call consume function
             if let Some(metrics_group) = self.groups.get(name) {
-                (metrics_group.consumer)(*span_state.group_times.get(name).unwrap())
+                if let Some(t) = span_state.group_times.get(name).filter(|&t| t.updated) {
+                    (metrics_group.consumer)(*t);
+                }
             }
         }
     }
@@ -228,11 +235,13 @@ mod tests {
             idle: 5,
             busy: 5,
             last: now,
+            updated: false,
         };
         let t2 = Timings {
             idle: 3,
             busy: 5,
             last: now,
+            updated: false,
         };
         let t3 = t1 + t2;
         assert_eq!(
@@ -240,7 +249,8 @@ mod tests {
             Timings {
                 idle: 8,
                 busy: 10,
-                last: now
+                last: now,
+                updated: false,
             }
         )
     }
@@ -252,11 +262,13 @@ mod tests {
             idle: 5,
             busy: 5,
             last: now,
+            updated: false,
         };
         let t2 = Timings {
             idle: 3,
             busy: 5,
             last: now,
+            updated: false,
         };
         t1 += t2;
         assert_eq!(
@@ -264,7 +276,8 @@ mod tests {
             Timings {
                 idle: 8,
                 busy: 10,
-                last: now
+                last: now,
+                updated: false,
             }
         )
     }
@@ -277,6 +290,7 @@ mod tests {
             idle: 5,
             busy: 5,
             last: Instant::now(),
+            updated: true,
         };
         span_state.increment(&group, t1);
         assert_eq!(span_state.group_times.get(&group).unwrap().idle, t1.idle);

--- a/limitador-server/src/prometheus_metrics.rs
+++ b/limitador-server/src/prometheus_metrics.rs
@@ -1,7 +1,9 @@
-use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge};
+use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use std::sync::Arc;
+use std::time::Duration;
 
+use crate::metrics::Timings;
 use limitador::limit::Namespace;
 
 const NAMESPACE_LABEL: &str = "limitador_namespace";
@@ -40,7 +42,7 @@ impl PrometheusMetrics {
         prometheus_handle: Arc<PrometheusHandle>,
     ) -> Self {
         describe_histogram!(
-            "counter_latency",
+            "datastore_latency",
             "Latency to the underlying counter datastore"
         );
         describe_counter!("authorized_calls", "Authorized calls");
@@ -90,6 +92,10 @@ impl PrometheusMetrics {
 
     pub fn gather_metrics(&self) -> String {
         self.prometheus_handle.render()
+    }
+
+    pub fn record_datastore_latency(timings: Timings) {
+        histogram!("datastore_latency").record(Duration::from(timings).as_secs_f64())
     }
 }
 

--- a/limitador-server/src/prometheus_metrics.rs
+++ b/limitador-server/src/prometheus_metrics.rs
@@ -47,6 +47,11 @@ impl PrometheusMetrics {
         describe_counter!("limited_calls", "Limited calls");
         describe_gauge!("limitador_up", "Limitador is running");
         gauge!("limitador_up").set(1);
+        describe_gauge!(
+            "datastore_partitioned",
+            "Limitador is partitioned from backing datastore"
+        );
+        gauge!("datastore_partitioned").set(0);
         Self {
             use_limit_name_label,
             prometheus_handle,

--- a/limitador/src/storage/redis/counters_cache.rs
+++ b/limitador/src/storage/redis/counters_cache.rs
@@ -3,7 +3,7 @@ use crate::storage::atomic_expiring_value::AtomicExpiringValue;
 use crate::storage::redis::DEFAULT_MAX_CACHED_COUNTERS;
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
-use metrics::gauge;
+use metrics::{gauge, histogram};
 use moka::sync::Cache;
 use std::collections::HashMap;
 use std::future::Future;
@@ -185,6 +185,7 @@ impl Batcher {
                     let value = self.updates.get(counter).unwrap().clone();
                     result.insert(counter.clone(), value);
                 }
+                histogram!("batcher_flush_size").record(result.len() as f64);
                 let result = consumer(result).await;
                 batch.iter().for_each(|counter| {
                     let prev = self

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -330,7 +330,7 @@ async fn update_counters<C: ConnectionLike>(
 
     Ok(res)
 }
-
+#[tracing::instrument(skip_all)]
 async fn flush_batcher_and_update_counters<C: ConnectionLike>(
     mut redis_conn: C,
     storage_is_alive: bool,

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -307,11 +307,10 @@ async fn update_counters<C: ConnectionLike>(
             }
         }
 
-        let span = debug_span!("datastore");
         // The redis crate is not working with tables, thus the response will be a Vec of counter values
         let script_res: Vec<i64> = script_invocation
             .invoke_async(redis_conn)
-            .instrument(span)
+            .instrument(debug_span!("datastore"))
             .await?;
 
         // We need to update the values and ttls returned by redis


### PR DESCRIPTION
## Changes
- Added `liveness_latency` histogram metric, `cache_size` gauge and `batcher_size` gauge
- Made the `datastore_partitioned` metric always present
- Ensured that we only record `datastore_latency` metrics if the timing data is present
- For `redis_cached` we aggregate the `datastore` span calls by the batcher flushes
- Refactored to store the metrics layer consumer function in a `Box`, enabling different consumer functions to be provided
- Added a `batcher_flush_size` histogram
- Added an `eviction_listener` to the cache to allow us to decrement the `cache_size` as well as to monitor the `evicted_pending_writes` in a histogram
- Still thinking on the implementation.. but added a `counter_overshoot` histogram for when we `add_from_authority` and which pushes us over the counter max val