### PR TITLE
fix: use usize instead of u64 for batch-size arg

### DIFF
--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -593,7 +593,7 @@ fn create_config() -> (Configuration, &'static str) {
                     Arg::new("batch")
                         .long("batch-size")
                         .action(ArgAction::Set)
-                        .value_parser(clap::value_parser!(u64))
+                        .value_parser(clap::value_parser!(usize))
                         .default_value(
                             config::env::REDIS_LOCAL_CACHE_BATCH_SIZE
                                 .unwrap_or(leak(DEFAULT_BATCH_SIZE)),


### PR DESCRIPTION
Limitador Operator using the latest limitador image with redis has a failing test when starting up the limitador pod with the following error since https://github.com/Kuadrant/limitador/pull/318 was introduced:
```sh
➜  ~ kubectl logs limitador-limitador-lcrp7-dffc56ff-qzccn -n test-namespace-8sgz7
thread 'main' panicked at /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.2/src/parser/error.rs:32:9:
Mismatch between definition and access of `batch`. Could not downcast to TypeId { t: (8519994227001858441, 10522819541147869382) }, need to downcast to TypeId { t: (11446210613632762899, 3222440509213045925) }

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
Seems to be related to mismatch of types defined at:
https://github.com/Kuadrant/limitador/blob/25346a660f8145d6be70e499d790d28e4c53acbf/limitador-server/src/config.rs#L167
vs 
https://github.com/Kuadrant/limitador/blob/25346a660f8145d6be70e499d790d28e4c53acbf/limitador-server/src/main.rs#L596

Caveat: Not sure is this the correct change since I don't know Rust but changing the type and using a custom image with the change passed the test in limitador operator test at least 🤷 