### PR TITLE
Update workflow redis versions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: supercharge/redis-github-action@1.1.0
         with:
-          redis-version: 5
+          redis-version: 7
       # Nightly is required for code coverage with doctests
       # https://github.com/taiki-e/cargo-llvm-cov/issues/2
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           protoc-version: '3.19.4'
       - uses: supercharge/redis-github-action@1.1.0
         with:
-          redis-version: 5
+          redis-version: 7
       - uses: actions/checkout@v4
         with:
           ref: crate-v${{ github.event.inputs.version }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: supercharge/redis-github-action@1.1.0
         with:
-          redis-version: 5
+          redis-version: 7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: abelfodil/protoc-action@v1
         with:


### PR DESCRIPTION
I noticed coverage is failing since we updated the lua scripts to use the redis 7+ commands https://github.com/Kuadrant/limitador/actions/runs/9125009281/job/25090317961#step:8:886

```
Unrecoverable Redis error!: StorageErr { msg: "An error was signalled by the server - ResponseError: Error running script (call to f_95a717e821d8fbdd667b5e4c6fede4c9cad16006): @user_script:15: @user_script: 15: Unknown Redis command called from Lua script ", transient: false }
```

Updating all the workflows to use the same version.