### PR TITLE
All the fixes

### DIFF
--- a/limitador/src/storage/redis/counters_cache.rs
+++ b/limitador/src/storage/redis/counters_cache.rs
@@ -233,10 +233,7 @@ impl Batcher {
                         info!("Priority flush!");
                         true
                     },
-                    _ = tokio::time::sleep(self.interval) => {
-                        // info!("Time limit hit!");
-                        true
-                    },
+                    _ = tokio::time::sleep(self.interval) => true,
                 }
             }
         }

--- a/limitador/src/storage/redis/counters_cache.rs
+++ b/limitador/src/storage/redis/counters_cache.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tokio::select;
 use tokio::sync::{Notify, Semaphore};
+use tracing::info;
 
 #[derive(Debug)]
 pub struct CachedCounterValue {
@@ -221,15 +222,24 @@ impl Batcher {
                 return result;
             } else {
                 ready = select! {
-                    _ = self.notifier.notified() => self.batch_ready(max),
-                    _ = tokio::time::sleep(self.interval) => true,
+                    _ = async {
+                        loop {
+                            self.notifier.notified().await;
+                            if self.batch_ready(max) {
+                                break;
+                            }
+                        }
+                    } => {
+                        info!("Priority flush!");
+                        true
+                    },
+                    _ = tokio::time::sleep(self.interval) => {
+                        // info!("Time limit hit!");
+                        true
+                    },
                 }
             }
         }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.updates.is_empty()
     }
 
     fn batch_ready(&self, size: usize) -> bool {

--- a/limitador/src/storage/redis/redis_async.rs
+++ b/limitador/src/storage/redis/redis_async.rs
@@ -9,12 +9,11 @@ use crate::storage::redis::is_limited;
 use crate::storage::redis::scripts::{SCRIPT_UPDATE_COUNTER, VALUES_AND_TTLS};
 use crate::storage::{AsyncCounterStorage, Authorization, StorageErr};
 use async_trait::async_trait;
-use metrics::histogram;
 use redis::{AsyncCommands, RedisError};
 use std::collections::HashSet;
 use std::str::FromStr;
-use std::time::{Duration, Instant};
-use tracing::{debug_span, warn, Instrument};
+use std::time::Duration;
+use tracing::{debug_span, Instrument};
 
 // Note: this implementation does not guarantee exact limits. Ensuring that we
 // never go over the limits would hurt performance. This implementation
@@ -207,25 +206,6 @@ impl AsyncRedisStorage {
 
     pub fn new_with_conn_manager(conn_manager: ConnectionManager) -> Self {
         Self { conn_manager }
-    }
-
-    pub async fn is_alive(&self) -> bool {
-        let now = Instant::now();
-        self.conn_manager
-            .clone()
-            .incr::<&str, i32, u64>("LIMITADOR_LIVE_CHECK", 1)
-            .await
-            .map_err(|err| {
-                let err = <RedisError as Into<StorageErr>>::into(err);
-                if !err.is_transient() {
-                    panic!("Unrecoverable Redis error: {}", err);
-                }
-                warn!("Live check failure: {}", err);
-                err
-            })
-            .is_ok()
-            .then(|| histogram!("liveness_latency").record(now.elapsed().as_secs_f64()))
-            .is_some()
     }
 
     async fn delete_counters_associated_with_limit(&self, limit: &Limit) -> Result<(), StorageErr> {

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -17,10 +17,11 @@ use redis::aio::{ConnectionLike, ConnectionManager};
 use redis::{ConnectionInfo, RedisError};
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
+use std::sync::atomic::Ordering::Acquire;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{debug_span, error, warn, Instrument};
+use tracing::{debug_span, error, info, warn, Instrument};
 
 // This is just a first version.
 //
@@ -189,7 +190,6 @@ impl CachedRedisStorage {
             AsyncRedisStorage::new_with_conn_manager(redis_conn_manager.clone());
 
         {
-            let storage = async_redis_storage.clone();
             let counters_cache_clone = counters_cache.clone();
             let conn = redis_conn_manager.clone();
             let p = Arc::clone(&partitioned);
@@ -197,7 +197,6 @@ impl CachedRedisStorage {
                 loop {
                     flush_batcher_and_update_counters(
                         conn.clone(),
-                        storage.is_alive().await,
                         counters_cache_clone.clone(),
                         p.clone(),
                         batch_size,
@@ -339,48 +338,51 @@ async fn update_counters<C: ConnectionLike>(
 #[tracing::instrument(skip_all)]
 async fn flush_batcher_and_update_counters<C: ConnectionLike>(
     mut redis_conn: C,
-    storage_is_alive: bool,
     cached_counters: Arc<CountersCache>,
     partitioned: Arc<AtomicBool>,
     batch_size: usize,
 ) {
-    if partitioned.load(Ordering::Acquire) || !storage_is_alive {
-        if !cached_counters.batcher().is_empty() {
+    let updated_counters = cached_counters
+        .batcher()
+        .consume(batch_size, |counters| {
+            if !counters.is_empty() && !partitioned.load(Acquire) {
+                info!("Flushing {} counter updates", counters.len());
+            }
+            update_counters(&mut redis_conn, counters)
+        })
+        .await
+        .map(|res| {
+            // info!("Success {} counters", res.len());
             flip_partitioned(&partitioned, false);
-        }
-    } else {
-        let updated_counters = cached_counters
-            .batcher()
-            .consume(batch_size, |counters| {
-                update_counters(&mut redis_conn, counters)
-            })
-            .await
-            .or_else(|(data, err)| {
-                if err.is_transient() {
-                    flip_partitioned(&partitioned, true);
-                    let counters = data.len();
-                    let mut reverted = 0;
-                    for (counter, old_value, pending_writes, _) in data {
-                        if cached_counters
-                            .return_pending_writes(&counter, old_value, pending_writes)
-                            .is_err()
-                        {
-                            error!("Couldn't revert writes back to {:?}", &counter);
-                        } else {
-                            reverted += 1;
-                        }
-                    }
-                    warn!("Reverted {} of {} counter increments", reverted, counters);
-                    Ok(Vec::new())
-                } else {
-                    Err(err)
+            res
+        })
+        .or_else(|(data, err)| {
+            if err.is_transient() {
+                if flip_partitioned(&partitioned, true) {
+                    warn!("Error flushing {}", err);
                 }
-            })
-            .expect("Unrecoverable Redis error!");
+                let counters = data.len();
+                let mut reverted = 0;
+                for (counter, old_value, pending_writes, _) in data {
+                    if cached_counters
+                        .return_pending_writes(&counter, old_value, pending_writes)
+                        .is_err()
+                    {
+                        error!("Couldn't revert writes back to {:?}", &counter);
+                    } else {
+                        reverted += 1;
+                    }
+                }
+                warn!("Reverted {} of {} counter increments", reverted, counters);
+                Ok(Vec::new())
+            } else {
+                Err(err)
+            }
+        })
+        .expect("Unrecoverable Redis error!");
 
-        for (counter, new_value, remote_deltas, ttl) in updated_counters {
-            cached_counters.apply_remote_delta(counter, new_value, remote_deltas, ttl);
-        }
+    for (counter, new_value, remote_deltas, ttl) in updated_counters {
+        cached_counters.apply_remote_delta(counter, new_value, remote_deltas, ttl);
     }
 }
 
@@ -531,7 +533,6 @@ mod tests {
 
         flush_batcher_and_update_counters(
             mock_client,
-            true,
             cached_counters.clone(),
             partitioned,
             100,

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -531,13 +531,8 @@ mod tests {
             assert_eq!(c.hits(&counter), 2);
         }
 
-        flush_batcher_and_update_counters(
-            mock_client,
-            cached_counters.clone(),
-            partitioned,
-            100,
-        )
-        .await;
+        flush_batcher_and_update_counters(mock_client, cached_counters.clone(), partitioned, 100)
+            .await;
 
         let c = cached_counters.get(&counter).unwrap();
         assert_eq!(c.hits(&counter), 8);

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -582,14 +582,8 @@ mod tests {
             assert_eq!(c.hits(&counter), 5);
         }
 
-        flush_batcher_and_update_counters(
-            mock_client,
-            true,
-            cached_counters.clone(),
-            partitioned,
-            100,
-        )
-        .await;
+        flush_batcher_and_update_counters(mock_client, cached_counters.clone(), partitioned, 100)
+            .await;
 
         let c = cached_counters.get(&counter).unwrap();
         assert_eq!(c.hits(&counter), 5);


### PR DESCRIPTION
If you test this in `INFO` level log as such: 

```shell
$ ./target/debug/limitador-server limitador-server/examples/limits.yaml -vv --grpc-reflection-service redis_cached  redis://localhost:6379
```

And then start the driver, you'd get a first log for the priority flush: 

```
INFO flush_batcher_and_update_counters: limitador::storage::redis::counters_cache: Priority flush!
```

Then further for the per second flushes: 

```
2024-05-21T15:43:58.456434Z  INFO flush_batcher_and_update_counters: limitador::storage::redis::redis_cached: Flushing 1 counter updates
2024-05-21T15:43:59.458124Z  INFO flush_batcher_and_update_counters: limitador::storage::redis::redis_cached: Flushing 1 counter updates
```

Then shut redis down: 

```
2024-05-21T15:44:03.472454Z ERROR flush_batcher_and_update_counters: limitador::storage::redis::redis_cached: Partition to Redis detected!
2024-05-21T15:44:03.472467Z  WARN flush_batcher_and_update_counters: limitador::storage::redis::redis_cached: Error flushing error while accessing the limits storage: broken pipe
```

No more logs for the duration of the partition, restart redis, and...

```
2024-05-21T15:44:08.480444Z  WARN flush_batcher_and_update_counters: limitador::storage::redis::redis_cached: Partition to Redis resolved!
2024-05-21T15:44:09.481024Z  INFO flush_batcher_and_update_counters: limitador::storage::redis::redis_cached: Flushing 1 counter updates
```