### PR TITLE
GitHub CI improvements.

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,26 @@
+---
+name: Benchmark
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+
+jobs:
+  bench:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supercharge/redis-github-action@1.1.0
+        with:
+          redis-version: 7
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+      - uses: abelfodil/protoc-action@v1
+        with:
+          protoc-version: '3.19.4'
+      - run: cargo bench

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -4,8 +4,10 @@ name: Build Image
 on:
   workflow_dispatch:
   push:
-    branches: ['*']
-    tags: ['*']
+    branches:
+      - main
+    tags:
+      - "*"
 
 env:
   IMG_REGISTRY_HOST: quay.io

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: abelfodil/protoc-action@v1
         with:
           protoc-version: '3.19.4'
@@ -33,6 +34,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly
+      - uses: Swatinem/rust-cache@v2
       - uses: abelfodil/protoc-action@v1
         with:
           protoc-version: '3.19.4'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,7 +3,7 @@ name: e2e tests
 on:
   push:
     branches:
-      - '*'
+      - 'main'
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ name: Limitador
 on:
   push:
     branches:
-      - '*'
+      - 'main'
   pull_request:
     branches:
       - '*'
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: abelfodil/protoc-action@v1
         with:
           protoc-version: '3.19.4'
@@ -32,6 +33,7 @@ jobs:
         with:
           redis-version: 7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: abelfodil/protoc-action@v1
         with:
           protoc-version: '3.19.4'
@@ -45,6 +47,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
+      - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
 
   clippy:
@@ -55,6 +58,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
+      - uses: Swatinem/rust-cache@v2
       - uses: abelfodil/protoc-action@v1
         with:
           protoc-version: '3.19.4'
@@ -69,6 +73,7 @@ jobs:
         with:
           redis-version: 7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: abelfodil/protoc-action@v1
         with:
           protoc-version: '3.19.4'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,21 +64,6 @@ jobs:
           protoc-version: '3.19.4'
       - run: cargo clippy --all-features --all-targets -- -D warnings
 
-  bench:
-    name: Bench
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: supercharge/redis-github-action@1.1.0
-        with:
-          redis-version: 7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
-      - uses: abelfodil/protoc-action@v1
-        with:
-          protoc-version: '3.19.4'
-      - run: cargo bench
-
   kind:
     name: Try in kind (Kubernetes in Docker)
     runs-on: ubuntu-latest


### PR DESCRIPTION
* Only run the image build on main and tags (not needed on feature branches).
* Cache rust dependencies to speed builds up.