### PR TITLE
Fix `--no-default-features` and bench

### DIFF
--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -63,6 +63,12 @@ time = "0.3.36"
 serial_test = "3.0"
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
 redis-test = { version = "0.4.0", features = ["aio"] }
+redis = { version = "0.25", features = [
+    "connection-manager",
+    "tokio-comp",
+    "tls-native-tls",
+    "tokio-native-tls-comp",
+] }
 paste = "1"
 rand = "0.8"
 tempfile = "3.5.0"

--- a/limitador/benches/bench.rs
+++ b/limitador/benches/bench.rs
@@ -13,6 +13,7 @@ use limitador::storage::disk::{DiskStorage, OptimizeFor};
 #[cfg(feature = "distributed_storage")]
 use limitador::storage::distributed::CrInMemoryStorage;
 use limitador::storage::in_memory::InMemoryStorage;
+#[cfg(feature = "redis_storage")]
 use limitador::storage::redis::CachedRedisStorageBuilder;
 use limitador::storage::{AsyncCounterStorage, CounterStorage};
 use limitador::{AsyncRateLimiter, RateLimiter};


### PR DESCRIPTION
`redis-test` in our dev-dependencies depends on `redis` but doesn't enable the async runtime... so this needs to be done explicitly by our crate.

In turn: `--no-default-features` compiles _and_ lets us run `bench` on just the in mem store, or that and other `*_storage`s as one decides