### PR TITLE
[distributed storage] support re-syncing counters after a peer is partitioned.

### DIFF
--- a/limitador/proto/distributed.proto
+++ b/limitador/proto/distributed.proto
@@ -5,18 +5,20 @@ package limitador.service.distributed.v1;
 // A packet defines all the types of messages that can be sent between replication peers.
 message Packet {
   oneof message {
-    // the Hello message is used to introduce a peer to another peer.  It is the first message sent by a peer.
+    // the hello message is used to introduce a peer to another peer.  It is the first message sent by a peer.
     Hello hello = 1;
-    // the MembershipUpdate message is used to gossip about the other peers in the cluster:
+    // the membership_update message is used to gossip about the other peers in the cluster:
     //  1) sent after the first Hello message
     //  2) sent when the membership state changes
     MembershipUpdate membership_update = 2;
-    // the Ping message is used to request a pong from the other peer.
-    Ping ping = 3;
-    // the Pong message is used to respond to a ping.
+    // the ping message is used to request a pong from the other peer.
+    Empty ping = 3;
+    // the pong message is used to respond to a ping.
     Pong pong = 4;
-    // the CounterUpdate message is used to send counter updates.
+    // the counter_update message is used to send counter updates.
     CounterUpdate counter_update = 5;
+    // the re_sync_end message is used to signal that the re-sync process has ended.
+    Empty re_sync_end = 6;
   }
 }
 
@@ -30,8 +32,8 @@ message Hello {
   optional string receiver_url = 3;
 }
 
-// A request to a peer to respond with a Pong message.
-message Ping {}
+// A packet message that does not have any additional data.
+message Empty {}
 
 // Pong is the response to a Ping and Hello message.
 message Pong {

--- a/limitador/src/storage/distributed/cr_counter_value.rs
+++ b/limitador/src/storage/distributed/cr_counter_value.rs
@@ -133,15 +133,12 @@ impl<A: Ord> CrCounterValue<A> {
         (expiry.into_inner(), map)
     }
 
-    pub fn into_ourselves_inner(self) -> (SystemTime, A, u64) {
-        let Self {
-            ourselves,
-            max_value: _,
-            value,
-            others: _,
-            expiry,
-        } = self;
-        (expiry.into_inner(), ourselves, value.into_inner())
+    pub fn local_values(&self) -> (SystemTime, &A, u64) {
+        (
+            self.expiry.clone().into_inner(),
+            &self.ourselves,
+            self.value.load(Ordering::Relaxed),
+        )
     }
 
     fn reset(&self, expiry: SystemTime) {

--- a/limitador/src/storage/distributed/cr_counter_value.rs
+++ b/limitador/src/storage/distributed/cr_counter_value.rs
@@ -133,6 +133,17 @@ impl<A: Ord> CrCounterValue<A> {
         (expiry.into_inner(), map)
     }
 
+    pub fn into_ourselves_inner(self) -> (SystemTime, A, u64) {
+        let Self {
+            ourselves,
+            max_value: _,
+            value,
+            others: _,
+            expiry,
+        } = self;
+        (expiry.into_inner(), ourselves, value.into_inner())
+    }
+
     fn reset(&self, expiry: SystemTime) {
         let mut guard = self.others.write().unwrap();
         self.expiry.update(expiry);

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -1184,8 +1184,6 @@ mod test {
         Fut: Future<Output = Vec<TestsLimiter>>,
     {
         let rate_limiters = create_distributed_limiters(2).await;
-        tokio::time::sleep(Duration::from_secs(1)).await;
-
         let namespace = "test_namespace";
         let max_hits = 3;
         let limit = Limit::new(


### PR DESCRIPTION
This likely needs more thought put into it.  A peer only resyncs when it goes from having zero active connections to 1 active connection. 