### PR TITLE
First step: Limit storage

### DIFF
--- a/limitador/src/counter.rs
+++ b/limitador/src/counter.rs
@@ -62,7 +62,7 @@ impl Counter {
 
     pub fn update_to_limit(&mut self, limit: Arc<Limit>) -> bool {
         if limit == self.limit {
-            self.limit = Arc::clone(&limit);
+            self.limit = limit;
             return true;
         }
         false

--- a/limitador/src/storage/disk/rocksdb_storage.rs
+++ b/limitador/src/storage/disk/rocksdb_storage.rs
@@ -116,7 +116,7 @@ impl CounterStorage for RocksDbStorage {
                         let value: ExpiringValue = value.as_ref().try_into()?;
                         for limit in limits {
                             if limit.deref() == counter.limit() {
-                                counter.update_to_limit(limit);
+                                counter.update_to_limit(Arc::clone(limit));
                                 let ttl = value.ttl();
                                 counter.set_expires_in(ttl);
                                 counter.set_remaining(limit.max_value() - value.value());

--- a/limitador/src/storage/distributed/mod.rs
+++ b/limitador/src/storage/distributed/mod.rs
@@ -170,10 +170,10 @@ impl CounterStorage for CrInMemoryStorage {
     }
 
     #[tracing::instrument(skip_all)]
-    fn get_counters(&self, limits: &HashSet<Limit>) -> Result<HashSet<Counter>, StorageErr> {
+    fn get_counters(&self, limits: &HashSet<Arc<Limit>>) -> Result<HashSet<Counter>, StorageErr> {
         let mut res = HashSet::new();
 
-        let limits: HashSet<_> = limits.iter().map(encode_limit_to_key).collect();
+        let limits: HashSet<_> = limits.iter().map(|l| encode_limit_to_key(l)).collect();
 
         let limits_map = self.limits.read().unwrap();
         for (key, counter_value) in limits_map.iter() {
@@ -200,9 +200,9 @@ impl CounterStorage for CrInMemoryStorage {
     }
 
     #[tracing::instrument(skip_all)]
-    fn delete_counters(&self, limits: HashSet<Limit>) -> Result<(), StorageErr> {
+    fn delete_counters(&self, limits: &HashSet<Arc<Limit>>) -> Result<(), StorageErr> {
         for limit in limits {
-            self.delete_counters_of_limit(&limit);
+            self.delete_counters_of_limit(limit);
         }
         Ok(())
     }

--- a/limitador/src/storage/in_memory.rs
+++ b/limitador/src/storage/in_memory.rs
@@ -168,10 +168,10 @@ impl CounterStorage for InMemoryStorage {
     }
 
     #[tracing::instrument(skip_all)]
-    fn get_counters(&self, limits: &HashSet<Limit>) -> Result<HashSet<Counter>, StorageErr> {
+    fn get_counters(&self, limits: &HashSet<Arc<Limit>>) -> Result<HashSet<Counter>, StorageErr> {
         let mut res = HashSet::new();
 
-        let namespaces: HashSet<&Namespace> = limits.iter().map(Limit::namespace).collect();
+        let namespaces: HashSet<&Namespace> = limits.iter().map(|l| l.namespace()).collect();
         let limits_by_namespace = self.limits_for_namespace.read().unwrap();
 
         for namespace in namespaces {
@@ -209,9 +209,9 @@ impl CounterStorage for InMemoryStorage {
     }
 
     #[tracing::instrument(skip_all)]
-    fn delete_counters(&self, limits: HashSet<Limit>) -> Result<(), StorageErr> {
+    fn delete_counters(&self, limits: &HashSet<Arc<Limit>>) -> Result<(), StorageErr> {
         for limit in limits {
-            self.delete_counters_of_limit(&limit);
+            self.delete_counters_of_limit(limit);
         }
         Ok(())
     }

--- a/limitador/src/storage/keys.rs
+++ b/limitador/src/storage/keys.rs
@@ -14,6 +14,7 @@
 
 use crate::counter::Counter;
 use crate::limit::Limit;
+use std::sync::Arc;
 
 pub fn key_for_counter(counter: &Counter) -> String {
     if counter.remaining().is_some() || counter.expires_in().is_some() {
@@ -43,9 +44,9 @@ pub fn prefix_for_namespace(namespace: &str) -> String {
     format!("namespace:{{{namespace}}},")
 }
 
-pub fn counter_from_counter_key(key: &str, limit: &Limit) -> Counter {
+pub fn counter_from_counter_key(key: &str, limit: Arc<Limit>) -> Counter {
     let mut counter = partial_counter_from_counter_key(key);
-    if !counter.update_to_limit(limit) {
+    if !counter.update_to_limit(Arc::clone(&limit)) {
         // this means some kind of data corruption _or_ most probably
         // an out of sync `impl PartialEq for Limit` vs `pub fn key_for_counter(counter: &Counter) -> String`
         panic!(

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -132,12 +132,15 @@ impl AsyncCounterStorage for CachedRedisStorage {
     }
 
     #[tracing::instrument(skip_all)]
-    async fn get_counters(&self, limits: HashSet<Limit>) -> Result<HashSet<Counter>, StorageErr> {
+    async fn get_counters(
+        &self,
+        limits: &HashSet<Arc<Limit>>,
+    ) -> Result<HashSet<Counter>, StorageErr> {
         self.async_redis_storage.get_counters(limits).await
     }
 
     #[tracing::instrument(skip_all)]
-    async fn delete_counters(&self, limits: HashSet<Limit>) -> Result<(), StorageErr> {
+    async fn delete_counters(&self, limits: &HashSet<Arc<Limit>>) -> Result<(), StorageErr> {
         self.async_redis_storage.delete_counters(limits).await
     }
 

--- a/limitador/src/storage/redis/redis_sync.rs
+++ b/limitador/src/storage/redis/redis_sync.rs
@@ -9,6 +9,8 @@ use crate::storage::redis::scripts::{SCRIPT_UPDATE_COUNTER, VALUES_AND_TTLS};
 use crate::storage::{Authorization, CounterStorage, StorageErr};
 use r2d2::{ManageConnection, Pool};
 use std::collections::HashSet;
+use std::ops::Deref;
+use std::sync::Arc;
 use std::time::Duration;
 
 const DEFAULT_REDIS_URL: &str = "redis://127.0.0.1:6379";
@@ -106,7 +108,7 @@ impl CounterStorage for RedisStorage {
     }
 
     #[tracing::instrument(skip_all)]
-    fn get_counters(&self, limits: &HashSet<Limit>) -> Result<HashSet<Counter>, StorageErr> {
+    fn get_counters(&self, limits: &HashSet<Arc<Limit>>) -> Result<HashSet<Counter>, StorageErr> {
         let mut res = HashSet::new();
 
         let mut con = self.conn_pool.get()?;
@@ -143,12 +145,12 @@ impl CounterStorage for RedisStorage {
     }
 
     #[tracing::instrument(skip_all)]
-    fn delete_counters(&self, limits: HashSet<Limit>) -> Result<(), StorageErr> {
+    fn delete_counters(&self, limits: &HashSet<Arc<Limit>>) -> Result<(), StorageErr> {
         let mut con = self.conn_pool.get()?;
 
         for limit in limits {
             let counter_keys =
-                con.smembers::<String, HashSet<String>>(key_for_counters_of_limit(&limit))?;
+                con.smembers::<String, HashSet<String>>(key_for_counters_of_limit(limit.deref()))?;
 
             for counter_key in counter_keys {
                 con.del(counter_key)?;

--- a/limitador/src/storage/redis/redis_sync.rs
+++ b/limitador/src/storage/redis/redis_sync.rs
@@ -118,7 +118,8 @@ impl CounterStorage for RedisStorage {
                 con.smembers::<String, HashSet<String>>(key_for_counters_of_limit(limit))?;
 
             for counter_key in counter_keys {
-                let mut counter: Counter = counter_from_counter_key(&counter_key, limit);
+                let mut counter: Counter =
+                    counter_from_counter_key(&counter_key, Arc::clone(limit));
 
                 // If the key does not exist, it means that the counter expired,
                 // so we don't have to return it.


### PR DESCRIPTION
Slowly refactoring this, so the idea is that: 
 - [x] `Limit` definitions are now stored in `Arc`, so that they can be shared _within_ the crate's boundaries (i.e. towards the `(Async)CounterStorage`
 - [x] Do _not_ expose `Counter` as part of the lib's API, only as part of the SPI, i.e. `(Async)CounterStorage` 
 - [x] Have `Counter.limit` be an `Arc` coming from the `Storage.limit`'s 