### PR TITLE
CEL Interperter for Conditions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,22 +577,21 @@ dependencies = [
 
 [[package]]
 name = "cel-interpreter"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121ecc72c18bacd45494c0758bd2228d26764454d9b6cffe3ab88a850e5f568e"
+version = "0.7.0"
+source = "git+https://github.com/chirino/cel-rust.git?branch=no-panic-compare#0cf3d6bdee9feb9a6a2107dc6795d09de6fff4cf"
 dependencies = [
  "cel-parser",
  "chrono",
  "nom",
  "paste",
+ "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "cel-parser"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a85ba148abbc551f1c32c8c0cff279dba234f6d38324bf372ba2395690879e"
+source = "git+https://github.com/chirino/cel-rust.git?branch=no-panic-compare#0cf3d6bdee9feb9a6a2107dc6795d09de6fff4cf"
 dependencies = [
  "lalrpop",
  "lalrpop-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +314,15 @@ name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
 
 [[package]]
 name = "async-stream"
@@ -441,6 +465,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +576,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "cel-interpreter"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121ecc72c18bacd45494c0758bd2228d26764454d9b6cffe3ab88a850e5f568e"
+dependencies = [
+ "cel-parser",
+ "chrono",
+ "nom",
+ "paste",
+ "thiserror",
+]
+
+[[package]]
+name = "cel-parser"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a85ba148abbc551f1c32c8c0cff279dba234f6d38324bf372ba2395690879e"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,7 +620,12 @@ version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -852,6 +920,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +933,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -872,6 +967,15 @@ name = "embedded-io"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "ena"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1361,6 +1465,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +1617,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "lalrpop"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "diff",
+ "ena",
+ "is-terminal",
+ "itertools 0.10.5",
+ "lalrpop-util",
+ "petgraph",
+ "regex",
+ "regex-syntax 0.6.29",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1521,6 +1679,16 @@ checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
 ]
 
 [[package]]
@@ -1556,6 +1724,8 @@ version = "0.8.0-dev"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "cel-interpreter",
+ "cel-parser",
  "cfg-if",
  "criterion",
  "dashmap",
@@ -1828,6 +1998,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nom"
@@ -2200,6 +2376,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,6 +2479,12 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -2528,6 +2719,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -2837,6 +3039,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2881,6 +3089,19 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "string_cache"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
 
 [[package]]
 name = "strsim"
@@ -2969,6 +3190,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3027,6 +3259,15 @@ checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 members = ["limitador", "limitador-server"]
 resolver = "2"
 
+
+[patch.crates-io]
+cel-interpreter = { git = "https://github.com/chirino/cel-rust.git", branch = "no-panic-compare"}
+cel-parser = { git = "https://github.com/chirino/cel-rust.git", branch = "no-panic-compare"}
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -35,7 +35,7 @@ cfg-if = "1"
 tracing = "0.1.40"
 metrics = "0.22.3"
 cel-parser = "0.6.0"
-cel-interpreter = "0.5.0"
+cel-interpreter = "0.7.0"
 
 # Optional dependencies
 rocksdb = { version = "0.22", optional = true, features = ["multi-threaded-cf"] }
@@ -88,3 +88,4 @@ tonic-build = "0.11"
 name = "bench"
 path = "benches/bench.rs"
 harness = false
+

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -33,6 +33,8 @@ async-trait = "0.1"
 cfg-if = "1"
 tracing = "0.1.40"
 metrics = "0.22.3"
+cel-parser = "0.6.0"
+cel-interpreter = "0.5.0"
 
 # Optional dependencies
 rocksdb = { version = "0.22", optional = true, features = ["multi-threaded-cf"] }

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -18,6 +18,7 @@ disk_storage = ["rocksdb"]
 distributed_storage = ["tokio", "tokio-stream", "h2", "base64", "uuid", "tonic", "tonic-reflection", "prost", "prost-types"]
 redis_storage = ["redis", "r2d2", "tokio"]
 lenient_conditions = []
+cel_conditions = []
 
 [dependencies]
 moka = { version = "0.12", features = ["sync"] }

--- a/limitador/src/limit.rs
+++ b/limitador/src/limit.rs
@@ -893,7 +893,7 @@ mod tests {
     macro_rules! assert_false {
         ($cond:expr $(,)?) => {
             paste::item! {
-               assert!(!$cond)
+               assert!(!$cond, "assertion failed: assert_false!({}) was true!", stringify!($cond))
             }
         };
     }

--- a/limitador/src/limit.rs
+++ b/limitador/src/limit.rs
@@ -886,6 +886,14 @@ mod conditions {
 mod tests {
     use super::*;
 
+    macro_rules! assert_false {
+        ($cond:expr $(,)?) => {
+            paste::item! {
+               assert!(!$cond)
+            }
+        };
+    }
+
     #[test]
     fn limit_can_have_an_optional_name() {
         let mut limit = Limit::new("test_namespace", 10, 60, vec!["x == \"5\""], vec!["y"]);
@@ -915,7 +923,7 @@ mod tests {
         values.insert("x".into(), "1".into());
         values.insert("y".into(), "1".into());
 
-        assert!(!limit.applies(&values))
+        assert_false!(limit.applies(&values))
     }
 
     #[test]
@@ -927,9 +935,9 @@ mod tests {
         values.insert("x".into(), "1".into());
         values.insert("y".into(), "1".into());
 
-        assert!(!limit.applies(&values));
+        assert_false!(limit.applies(&values));
         assert!(check_deprecated_syntax_usages_and_reset());
-        assert!(!check_deprecated_syntax_usages_and_reset());
+        assert_false!(check_deprecated_syntax_usages_and_reset());
 
         let limit = Limit::new("test_namespace", 10, 60, vec!["x == foobar"], vec!["y"]);
 
@@ -939,7 +947,7 @@ mod tests {
 
         assert!(limit.applies(&values));
         assert!(check_deprecated_syntax_usages_and_reset());
-        assert!(!check_deprecated_syntax_usages_and_reset());
+        assert_false!(check_deprecated_syntax_usages_and_reset());
     }
 
     #[test]
@@ -951,7 +959,7 @@ mod tests {
         values.insert("a".into(), "1".into());
         values.insert("y".into(), "1".into());
 
-        assert!(!limit.applies(&values))
+        assert_false!(limit.applies(&values))
     }
 
     #[test]
@@ -962,7 +970,7 @@ mod tests {
         let mut values: HashMap<String, String> = HashMap::new();
         values.insert("x".into(), "5".into());
 
-        assert!(!limit.applies(&values))
+        assert_false!(limit.applies(&values))
     }
 
     #[test]
@@ -998,7 +1006,7 @@ mod tests {
         values.insert("y".into(), "2".into());
         values.insert("z".into(), "1".into());
 
-        assert!(!limit.applies(&values))
+        assert_false!(limit.applies(&values))
     }
 
     #[test]
@@ -1091,7 +1099,7 @@ mod tests {
 
             // we can't access complex variables via simple names....
             let limit = limit_with_condition(vec![r#"cel: req.method == "GET"    "#]);
-            assert!(!limit.applies(&values));
+            assert_false!(limit.applies(&values));
 
             // But we can access it via the vars map.
             let limit = limit_with_condition(vec![r#"cel:   vars["req.method"] == "GET"    "#]);
@@ -1117,7 +1125,7 @@ mod tests {
 
             // we can't access simple variables that conflict with built-ins
             let limit = limit_with_condition(vec![r#"cel:   size == "50"  "#]);
-            assert!(!limit.applies(&values));
+            assert_false!(limit.applies(&values));
 
             // But we can access it via the vars map.
             let limit = limit_with_condition(vec![r#"cel:   vars["size"] == "50"  "#]);
@@ -1130,7 +1138,7 @@ mod tests {
 
             // we can't access simple variables that conflict with built-ins (the vars map)
             let limit = limit_with_condition(vec![r#"cel:   vars == "hello"     "#]);
-            assert!(!limit.applies(&values));
+            assert_false!(limit.applies(&values));
 
             // But we can access it via the vars map.
             let limit = limit_with_condition(vec![r#"cel:   vars["vars"] == "hello"  "#]);

--- a/limitador/src/limit.rs
+++ b/limitador/src/limit.rs
@@ -124,7 +124,7 @@ impl TryFrom<&str> for Condition {
 impl Condition {
     #[cfg(feature = "cel_conditions")]
     fn try_from_cel(source: String) -> Result<Self, ConditionParsingError> {
-        match parse(&source.strip_prefix("cel:").unwrap().to_string()) {
+        match parse(source.strip_prefix("cel:").unwrap()) {
             Ok(expression) => Ok(Condition { source, expression }),
             Err(_err) => Err(ConditionParsingError {
                 error: SyntaxError {
@@ -336,7 +336,7 @@ impl TryFrom<String> for Condition {
         if value.clone().starts_with("cel:") {
             return Condition::try_from_cel(value);
         }
-        return Condition::try_from_simple(value);
+        Condition::try_from_simple(value)
     }
 }
 

--- a/limitador/src/limit.rs
+++ b/limitador/src/limit.rs
@@ -1147,6 +1147,10 @@ mod tests {
             // But we can access it via the vars map.
             let limit = limit_with_condition(vec![r#"cel:   vars["vars"] == "hello"  "#]);
             assert!(limit.applies(&values));
+
+            // Or via the vars map with dot notation.
+            let limit = limit_with_condition(vec![r#"cel:   vars.vars == "hello"  "#]);
+            assert!(limit.applies(&values));
         }
 
         #[test]

--- a/limitador/src/limit.rs
+++ b/limitador/src/limit.rs
@@ -457,6 +457,10 @@ impl Limit {
         let mut context = Context::default();
 
         for (key, value) in values {
+            if key.starts_with('_') {
+                // reserve _* identifiers for future use.
+                continue;
+            }
             context.add_variable(key, value.clone());
         }
 
@@ -1142,6 +1146,19 @@ mod tests {
 
             // But we can access it via the vars map.
             let limit = limit_with_condition(vec![r#"cel:   vars["vars"] == "hello"  "#]);
+            assert!(limit.applies(&values));
+        }
+
+        #[test]
+        fn underscore_var() {
+            let values = HashMap::from([("_hello".to_string(), "world".to_string())]);
+
+            // _* variables are reserved for future use
+            let limit = limit_with_condition(vec![r#"cel:   _hello == "world"     "#]);
+            assert_false!(limit.applies(&values));
+
+            // But we can access it via the vars map.
+            let limit = limit_with_condition(vec![r#"cel:   vars["_hello"] == "world"  "#]);
             assert!(limit.applies(&values));
         }
     }

--- a/limitador/src/limit.rs
+++ b/limitador/src/limit.rs
@@ -6,8 +6,8 @@ use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 
 use cel_interpreter::{Context, Expression, Value};
-use cel_parser::{Atom, parse, RelationOp};
 use cel_parser::RelationOp::{Equals, NotEquals};
+use cel_parser::{parse, Atom, RelationOp};
 use serde::{Deserialize, Serialize, Serializer};
 #[cfg(feature = "lenient_conditions")]
 mod deprecated {
@@ -118,7 +118,6 @@ impl TryFrom<&str> for Condition {
 }
 
 impl Condition {
-
     fn try_from_cel(source: String) -> Result<Self, ConditionParsingError> {
         match parse(&source.strip_prefix("cel:").unwrap().to_string()) {
             Ok(expression) => Ok(Condition { source, expression }),
@@ -139,15 +138,8 @@ impl Condition {
             NotEquals => "!=",
             _ => unreachable!(),
         };
-        let quotes = if lit.contains('"') {
-            '\''
-        } else {
-            '"'
-        };
-        format!(
-            "{} {} {}{}{}",
-            var_name, predicate, quotes, lit, quotes
-        )
+        let quotes = if lit.contains('"') { '\'' } else { '"' };
+        format!("{} {} {}{}{}", var_name, predicate, quotes, lit, quotes)
     }
 
     fn try_from_simple(source: String) -> Result<Self, ConditionParsingError> {
@@ -175,11 +167,17 @@ impl Condition {
                                     _ => unreachable!(),
                                 };
                                 Ok(Condition {
-                                    source: Condition::simple_source(var_name.clone(), predicate.clone(), operand.clone()),
+                                    source: Condition::simple_source(
+                                        var_name.clone(),
+                                        predicate.clone(),
+                                        operand.clone(),
+                                    ),
                                     expression: Expression::Relation(
                                         Box::new(Expression::Ident(var_name.clone().into())),
                                         predicate,
-                                        Box::new(Expression::Atom(Atom::String(operand.clone().into()))),
+                                        Box::new(Expression::Atom(Atom::String(
+                                            operand.clone().into(),
+                                        ))),
                                     ),
                                 })
                             } else {
@@ -204,9 +202,15 @@ impl Condition {
                                     _ => unreachable!(),
                                 };
                                 Ok(Condition {
-                                    source: Condition::simple_source(var_name.clone(), predicate.clone(), operand.clone()),
+                                    source: Condition::simple_source(
+                                        var_name.clone(),
+                                        predicate.clone(),
+                                        operand.clone(),
+                                    ),
                                     expression: Expression::Relation(
-                                        Box::new(Expression::Atom(Atom::String(operand.clone().into()))),
+                                        Box::new(Expression::Atom(Atom::String(
+                                            operand.clone().into(),
+                                        ))),
                                         predicate,
                                         Box::new(Expression::Ident(var_name.clone().into())),
                                     ),
@@ -226,11 +230,17 @@ impl Condition {
                             {
                                 deprecated::deprecated_syntax_used();
                                 Ok(Condition {
-                                    source: Condition::simple_source(var_name.clone(), Equals, operand.clone()),
+                                    source: Condition::simple_source(
+                                        var_name.clone(),
+                                        Equals,
+                                        operand.clone(),
+                                    ),
                                     expression: Expression::Relation(
                                         Box::new(Expression::Ident(var_name.clone().into())),
                                         Equals,
-                                        Box::new(Expression::Atom(Atom::String(operand.clone().into()))),
+                                        Box::new(Expression::Atom(Atom::String(
+                                            operand.clone().into(),
+                                        ))),
                                     ),
                                 })
                             } else {
@@ -248,11 +258,17 @@ impl Condition {
                             {
                                 deprecated::deprecated_syntax_used();
                                 Ok(Condition {
-                                    source: Condition::simple_source(var_name.clone(), Equals, operand.to_string()),
+                                    source: Condition::simple_source(
+                                        var_name.clone(),
+                                        Equals,
+                                        operand.to_string(),
+                                    ),
                                     expression: Expression::Relation(
                                         Box::new(Expression::Ident(var_name.clone().into())),
                                         Equals,
-                                        Box::new(Expression::Atom(Atom::String(operand.to_string().into()))),
+                                        Box::new(Expression::Atom(Atom::String(
+                                            operand.to_string().into(),
+                                        ))),
                                     ),
                                 })
                             } else {
@@ -321,30 +337,6 @@ impl TryFrom<String> for Condition {
 impl From<Condition> for String {
     fn from(condition: Condition) -> Self {
         condition.source.clone()
-    }
-}
-
-#[derive(PartialEq, Eq, Debug, Clone, Hash)]
-pub enum Predicate {
-    Equal,
-    NotEqual,
-}
-
-impl Predicate {
-    fn test(&self, lhs: &str, rhs: &str) -> bool {
-        match self {
-            Predicate::Equal => lhs == rhs,
-            Predicate::NotEqual => lhs != rhs,
-        }
-    }
-}
-
-impl From<Predicate> for String {
-    fn from(op: Predicate) -> Self {
-        match op {
-            Predicate::Equal => "==".to_string(),
-            Predicate::NotEqual => "!=".to_string(),
-        }
     }
 }
 

--- a/limitador/src/limit.rs
+++ b/limitador/src/limit.rs
@@ -461,10 +461,10 @@ impl Limit {
                 // reserve _* identifiers for future use.
                 continue;
             }
-            context.add_variable(key, value.clone());
+            context.add_variable_from_value(key, value.clone());
         }
 
-        context.add_variable("vars", values.clone());
+        context.add_variable_from_value("vars", values.clone());
 
         match Value::resolve(&condition.expression, &context) {
             Ok(val) => val == true.into(),

--- a/limitador/src/storage/keys.rs
+++ b/limitador/src/storage/keys.rs
@@ -99,7 +99,7 @@ mod tests {
             vec!["app_id"],
         );
         assert_eq!(
-            "namespace:{example.com},counters_of_limit:{\"namespace\":\"example.com\",\"seconds\":60,\"conditions\":[\"req.method == 'GET'\"],\"variables\":[\"app_id\"]}",
+            "namespace:{example.com},counters_of_limit:{\"namespace\":\"example.com\",\"seconds\":60,\"conditions\":[\"req.method == \\\"GET\\\"\"],\"variables\":[\"app_id\"]}",
             key_for_counters_of_limit(&limit))
     }
 

--- a/limitador/src/storage/keys.rs
+++ b/limitador/src/storage/keys.rs
@@ -99,7 +99,7 @@ mod tests {
             vec!["app_id"],
         );
         assert_eq!(
-            "namespace:{example.com},counters_of_limit:{\"namespace\":\"example.com\",\"seconds\":60,\"conditions\":[\"req.method == \\\"GET\\\"\"],\"variables\":[\"app_id\"]}",
+            "namespace:{example.com},counters_of_limit:{\"namespace\":\"example.com\",\"seconds\":60,\"conditions\":[\"req.method == 'GET'\"],\"variables\":[\"app_id\"]}",
             key_for_counters_of_limit(&limit))
     }
 


### PR DESCRIPTION
Continues on #254 in a way that is backward compatible.  To use cel based conditions, you must prefix your condition with `cel:` 

