### PR TITLE
Ignore unknown lints

### DIFF
--- a/limitador-server/src/envoy_rls/envoy_types.rs
+++ b/limitador-server/src/envoy_rls/envoy_types.rs
@@ -1,3 +1,4 @@
+#[allow(unknown_lints)]
 pub mod envoy {
     pub mod config {
         pub mod core {

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -341,7 +341,7 @@ async fn update_counters<C: ConnectionLike>(
     Ok(res)
 }
 
-#[allow(clippy::manual_inspect)]
+#[allow(unknown_lints, clippy::manual_inspect)]
 #[tracing::instrument(skip_all)]
 async fn flush_batcher_and_update_counters<C: ConnectionLike>(
     mut redis_conn: C,


### PR DESCRIPTION
This makes `-- -D warnings` feasible on older toolchains, so that the newer lint (unknown to older clippy) doesn't create a warning