### PR TITLE
On to the next release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "limitador-server"
-version = "1.6.0-dev"
+version = "2.0.0-dev"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limitador-server"
-version = "1.6.0-dev"
+version = "2.0.0-dev"
 authors = ["Alex Snaps <asnaps@redhat.com>", "Eguzki Astiz Lezaun <eguzki@redhat.com>", "David Ortiz <z.david.ortiz@gmail.com>"]
 license = "Apache-2.0"
 keywords = ["rate-limiting", "rate", "limiter", "envoy", "rls"]


### PR DESCRIPTION
- [x] the crate's version remains v0.8.0-dev, as we skipped v0.7.0 last time we released the server
- [x] the next release will be v2, tho probably an alpha/beta, as it will break data at rest's (e.g. in Redis) format