### PR TITLE
fix image build using same artifact name

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -25,9 +25,11 @@ jobs:
           - dockerfile: Dockerfile
             platform: linux/amd64
             scope: build-amd
+            artifactsuffix: amd
           - dockerfile: Dockerfile.aarch64
             platform: linux/arm64
             scope: build-arm
+            artifactsuffix: arm
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -68,7 +70,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests
+          name: digests-${{ matrix.artifactsuffix }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -80,7 +82,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          name: digests
+          pattern: digests-*
           path: /tmp/digests
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -107,7 +109,7 @@ jobs:
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/limitador@sha256:%s ' *)
+            $(printf '${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/limitador@sha256:%s ' $(find . -type f -exec basename {} \;))
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/limitador:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
As part of actions/upload-artifact@v4, you are not able to upload to the same Artifact multiple times.

https://github.com/actions/upload-artifact/issues/480

The error when trying to upload artifact

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

The artifacts created with the changes here

![Screenshot 2024-11-22 at 00-03-29 Build Image · Kuadrant_limitador@ad872b0](https://github.com/user-attachments/assets/0451af7e-0b37-473f-81bc-67a47f88f378)
