### PR TITLE
Delete counters of qualified limits

### DIFF
--- a/limitador/src/storage/in_memory.rs
+++ b/limitador/src/storage/in_memory.rs
@@ -230,7 +230,15 @@ impl InMemoryStorage {
     }
 
     fn delete_counters_of_limit(&self, limit: &Limit) {
-        self.simple_limits.write().unwrap().remove(limit);
+        if limit.variables().is_empty() {
+            self.simple_limits.write().unwrap().remove(limit);
+        } else {
+            for (c, _) in self.qualified_counters.iter() {
+                if c.limit() == limit {
+                    self.qualified_counters.invalidate(&c);
+                }
+            }
+        }
     }
 
     fn counter_is_within_limits(counter: &Counter, current_val: Option<&u64>, delta: u64) -> bool {


### PR DESCRIPTION
I don't think this is really a desirable fix to be honest... `O(n)` isn't really sustainable. 
Probably resorting to a ordered collection and have all qualified counters for a qualified limit next to each other would be better... I'll see what I can do as part of #397 