### PR TITLE
Add a Report gRPC method for update-only rate limit accounting

### DIFF
--- a/limitador-server/build.rs
+++ b/limitador-server/build.rs
@@ -34,6 +34,7 @@ fn generate_protobuf() -> Result<(), Box<dyn Error>> {
                 "vendor/protobufs/data-plane-api",
                 "vendor/protobufs/protoc-gen-validate",
                 "vendor/protobufs/xds",
+                "vendor/protobufs/googleapis/",
             ],
         )?;
     Ok(())

--- a/limitador-server/proto/kuadrantrls.proto
+++ b/limitador-server/proto/kuadrantrls.proto
@@ -7,4 +7,7 @@ import "envoy/service/ratelimit/v3/rls.proto";
 service RateLimitService {
   // Determine whether a request should be allowed or denied based on rate limiting rules.
   rpc CheckRateLimit(envoy.service.ratelimit.v3.RateLimitRequest) returns (envoy.service.ratelimit.v3.RateLimitResponse); 
+
+  // The report method modifies specific counters associated with the descriptors, incrementing each one by the amount specified in $hits_addend$
+  rpc Report(envoy.service.ratelimit.v3.RateLimitRequest) returns (envoy.service.ratelimit.v3.RateLimitResponse); 
 }

--- a/limitador-server/src/envoy_rls/kuadrant_service.rs
+++ b/limitador-server/src/envoy_rls/kuadrant_service.rs
@@ -94,259 +94,486 @@ impl RateLimitService for KuadrantService {
 
         Ok(Response::new(reply))
     }
+
+    #[tracing::instrument(skip_all)]
+    async fn report(
+        &self,
+        request: Request<RateLimitRequest>,
+    ) -> Result<Response<RateLimitResponse>, Status> {
+        debug!("Report request received: {:?}", request);
+
+        let mut values: Vec<HashMap<String, String>> = Vec::default();
+        let (_metadata, _ext, req) = request.into_parts();
+        let namespace = req.domain;
+
+        if namespace.is_empty() {
+            return Ok(Response::new(RateLimitResponse {
+                overall_code: Code::Unknown.into(),
+                statuses: vec![],
+                request_headers_to_add: vec![],
+                response_headers_to_add: vec![],
+                raw_body: vec![],
+                dynamic_metadata: None,
+                quota: None,
+            }));
+        }
+
+        let namespace = namespace.into();
+
+        for descriptor in &req.descriptors {
+            let mut map = HashMap::default();
+            for entry in &descriptor.entries {
+                map.insert(entry.key.clone(), entry.value.clone());
+            }
+            values.push(map);
+        }
+
+        let mut ctx = Context::default();
+        ctx.list_binding("descriptors".to_string(), values);
+
+        let rate_limited_resp = match &*self.limiter {
+            Limiter::Blocking(limiter) => {
+                limiter.update_counters(&namespace, &ctx, req.hits_addend as u64)
+            }
+            Limiter::Async(limiter) => {
+                limiter
+                    .update_counters(&namespace, &ctx, req.hits_addend as u64)
+                    .await
+            }
+        };
+
+        if let Err(e) = rate_limited_resp {
+            // In this case we could return "Code::Unknown" but that's not
+            // very helpful. When envoy receives "Unknown" it simply lets
+            // the request pass and this cannot be configured using the
+            // "failure_mode_deny" attribute, so it's equivalent to
+            // returning "Code::Ok". That's why we return an "unavailable"
+            // error here. What envoy does after receiving that kind of
+            // error can be configured with "failure_mode_deny". The only
+            // errors that can happen here have to do with connecting to the
+            // limits storage, which should be temporary.
+            error!("Error: {:?}", e);
+            return Err(Status::unavailable("Service unavailable"));
+        }
+
+        let reply = RateLimitResponse {
+            overall_code: Code::Ok as i32,
+            statuses: vec![],
+            request_headers_to_add: vec![],
+            response_headers_to_add: vec![],
+            raw_body: vec![],
+            dynamic_metadata: None,
+            quota: None,
+        };
+
+        Ok(Response::new(reply))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use tonic::IntoRequest;
+    mod check_rate_limit {
+        use tonic::IntoRequest;
 
-    use limitador::limit::Limit;
-    use limitador::RateLimiter;
+        use limitador::limit::Limit;
+        use limitador::RateLimiter;
 
-    use crate::envoy_rls::server::envoy::extensions::common::ratelimit::v3::rate_limit_descriptor::Entry;
-    use crate::envoy_rls::server::envoy::extensions::common::ratelimit::v3::RateLimitDescriptor;
-    use crate::envoy_rls::server::envoy::service::ratelimit::v3::RateLimitRequest;
+        use crate::envoy_rls::server::envoy::extensions::common::ratelimit::v3::rate_limit_descriptor::Entry;
+        use crate::envoy_rls::server::envoy::extensions::common::ratelimit::v3::RateLimitDescriptor;
+        use crate::envoy_rls::server::envoy::service::ratelimit::v3::RateLimitRequest;
 
-    use super::*;
+        use super::super::*;
 
-    // All these tests use the in-memory storage implementation to simplify. We
-    // know that some storage implementations like the Redis one trade
-    // rate-limiting accuracy for performance. That would be a bit more
-    // complicated to test.
-    // Also, the logic behind these endpoints is well tested in the library,
-    // that's why running some simple tests here should be enough.
+        // All these tests use the in-memory storage implementation to simplify. We
+        // know that some storage implementations like the Redis one trade
+        // rate-limiting accuracy for performance. That would be a bit more
+        // complicated to test.
+        // Also, the logic behind these endpoints is well tested in the library,
+        // that's why running some simple tests here should be enough.
 
-    #[tokio::test]
-    async fn test_returns_ok_correctly() {
-        let namespace = "test_namespace";
-        let limit = Limit::new(
-            namespace,
-            1,
-            60,
-            vec!["descriptors[0]['req.method'] == 'GET'"
-                .try_into()
-                .expect("failed parsing!")],
-            vec!["descriptors[0]['app.id']"
-                .try_into()
-                .expect("failed parsing!")],
-        );
-
-        let limiter = RateLimiter::new(10_000);
-        limiter.add_limit(limit);
-
-        let rate_limiter = KuadrantService::new(Arc::new(Limiter::Blocking(limiter)));
-
-        let req = RateLimitRequest {
-            domain: namespace.to_string(),
-            descriptors: vec![RateLimitDescriptor {
-                entries: vec![
-                    Entry {
-                        key: "req.method".to_string(),
-                        value: "GET".to_string(),
-                    },
-                    Entry {
-                        key: "app.id".to_string(),
-                        value: "1".to_string(),
-                    },
-                ],
-                limit: None,
-            }],
-            hits_addend: 1, // irrelevant for this test
-        };
-
-        // There's a limit of 1, so the first request should return "OK"
-
-        let response = rate_limiter
-            .check_rate_limit(req.clone().into_request())
-            .await
-            .unwrap()
-            .into_inner();
-        assert_eq!(response.overall_code, i32::from(Code::Ok));
-
-        let response = rate_limiter
-            .check_rate_limit(req.clone().into_request())
-            .await
-            .unwrap()
-            .into_inner();
-        assert_eq!(response.overall_code, i32::from(Code::Ok));
-    }
-
-    #[tokio::test]
-    async fn test_returns_overlimit_correctly() {
-        let namespace = "test_namespace";
-        let limit = Limit::new(
-            namespace,
-            0,
-            60,
-            vec!["descriptors[0]['req.method'] == 'GET'"
-                .try_into()
-                .expect("failed parsing!")],
-            vec!["descriptors[0]['app.id']"
-                .try_into()
-                .expect("failed parsing!")],
-        );
-
-        let limiter = RateLimiter::new(10_000);
-        limiter.add_limit(limit);
-
-        let rate_limiter = KuadrantService::new(Arc::new(Limiter::Blocking(limiter)));
-
-        let req = RateLimitRequest {
-            domain: namespace.to_string(),
-            descriptors: vec![RateLimitDescriptor {
-                entries: vec![
-                    Entry {
-                        key: "req.method".to_string(),
-                        value: "GET".to_string(),
-                    },
-                    Entry {
-                        key: "app.id".to_string(),
-                        value: "1".to_string(),
-                    },
-                ],
-                limit: None,
-            }],
-            hits_addend: 1, // irrelevant for this test
-        };
-
-        // There's a limit of 1, so the first request should return "OK" and the
-        // second "OverLimit".
-
-        let response = rate_limiter
-            .check_rate_limit(req.into_request())
-            .await
-            .unwrap()
-            .into_inner();
-        assert_eq!(response.overall_code, i32::from(Code::OverLimit));
-    }
-
-    #[tokio::test]
-    async fn test_returns_ok_when_no_limits_apply() {
-        // No limits saved
-        let limiter = RateLimiter::new(10_000);
-        let rate_limiter = KuadrantService::new(Arc::new(Limiter::Blocking(limiter)));
-
-        let req = RateLimitRequest {
-            domain: "test_namespace".to_string(),
-            descriptors: vec![RateLimitDescriptor {
-                entries: vec![Entry {
-                    key: "req.method".to_string(),
-                    value: "GET".to_string(),
-                }],
-                limit: None,
-            }],
-            hits_addend: 1,
-        }
-        .into_request();
-
-        let response = rate_limiter
-            .check_rate_limit(req)
-            .await
-            .unwrap()
-            .into_inner();
-
-        assert_eq!(response.overall_code, i32::from(Code::Ok));
-    }
-
-    #[tokio::test]
-    async fn test_returns_unknown_when_domain_is_empty() {
-        let limiter = RateLimiter::new(10_000);
-        let rate_limiter = KuadrantService::new(Arc::new(Limiter::Blocking(limiter)));
-
-        let req = RateLimitRequest {
-            domain: "".to_string(),
-            descriptors: vec![RateLimitDescriptor {
-                entries: vec![Entry {
-                    key: "req.method".to_string(),
-                    value: "GET".to_string(),
-                }],
-                limit: None,
-            }],
-            hits_addend: 1,
-        }
-        .into_request();
-
-        let response = rate_limiter
-            .check_rate_limit(req)
-            .await
-            .unwrap()
-            .into_inner();
-        assert_eq!(response.overall_code, i32::from(Code::Unknown));
-    }
-
-    #[tokio::test]
-    async fn test_takes_into_account_all_the_descriptors() {
-        let limiter = RateLimiter::new(10_000);
-
-        let namespace = "test_namespace";
-
-        vec![
-            Limit::new(
+        #[tokio::test]
+        async fn test_returns_ok_correctly() {
+            let namespace = "test_namespace";
+            let limit = Limit::new(
                 namespace,
-                10,
+                1,
                 60,
-                vec!["descriptors[0].x == '1'"
+                vec!["descriptors[0]['req.method'] == 'GET'"
                     .try_into()
                     .expect("failed parsing!")],
-                vec!["descriptors[0].z".try_into().expect("failed parsing!")],
-            ),
-            Limit::new(
-                namespace,
-                0,
-                60,
-                vec![
-                    "descriptors[0].x == '1'"
-                        .try_into()
-                        .expect("failed parsing!"),
-                    "descriptors[1].y == '2'"
-                        .try_into()
-                        .expect("failed parsing!"),
-                ],
-                vec!["descriptors[0].z".try_into().expect("failed parsing!")],
-            ),
-        ]
-        .into_iter()
-        .for_each(|limit| {
+                vec!["descriptors[0]['app.id']"
+                    .try_into()
+                    .expect("failed parsing!")],
+            );
+
+            let limiter = RateLimiter::new(10_000);
             limiter.add_limit(limit);
-        });
 
-        let rate_limiter = KuadrantService::new(Arc::new(Limiter::Blocking(limiter)));
+            let rate_limiter = KuadrantService::new(Arc::new(Limiter::Blocking(limiter)));
 
-        let req = RateLimitRequest {
-            domain: namespace.to_string(),
-            descriptors: vec![
-                RateLimitDescriptor {
+            let req = RateLimitRequest {
+                domain: namespace.to_string(),
+                descriptors: vec![RateLimitDescriptor {
                     entries: vec![
                         Entry {
-                            key: "x".to_string(),
-                            value: "1".to_string(),
+                            key: "req.method".to_string(),
+                            value: "GET".to_string(),
                         },
                         Entry {
-                            key: "z".to_string(),
+                            key: "app.id".to_string(),
                             value: "1".to_string(),
                         },
                     ],
                     limit: None,
-                },
-                // If this is taken into account, the result will be "overlimit"
-                // because of the second limit that has a max of 0.
-                RateLimitDescriptor {
+                }],
+                hits_addend: 1, // irrelevant for this test
+            };
+
+            // There's a limit of 1, so the first request should return "OK"
+
+            let response = rate_limiter
+                .check_rate_limit(req.clone().into_request())
+                .await
+                .unwrap()
+                .into_inner();
+            assert_eq!(response.overall_code, i32::from(Code::Ok));
+
+            let response = rate_limiter
+                .check_rate_limit(req.clone().into_request())
+                .await
+                .unwrap()
+                .into_inner();
+            assert_eq!(response.overall_code, i32::from(Code::Ok));
+        }
+
+        #[tokio::test]
+        async fn test_returns_overlimit_correctly() {
+            let namespace = "test_namespace";
+            let limit = Limit::new(
+                namespace,
+                0,
+                60,
+                vec!["descriptors[0]['req.method'] == 'GET'"
+                    .try_into()
+                    .expect("failed parsing!")],
+                vec!["descriptors[0]['app.id']"
+                    .try_into()
+                    .expect("failed parsing!")],
+            );
+
+            let limiter = RateLimiter::new(10_000);
+            limiter.add_limit(limit);
+
+            let rate_limiter = KuadrantService::new(Arc::new(Limiter::Blocking(limiter)));
+
+            let req = RateLimitRequest {
+                domain: namespace.to_string(),
+                descriptors: vec![RateLimitDescriptor {
+                    entries: vec![
+                        Entry {
+                            key: "req.method".to_string(),
+                            value: "GET".to_string(),
+                        },
+                        Entry {
+                            key: "app.id".to_string(),
+                            value: "1".to_string(),
+                        },
+                    ],
+                    limit: None,
+                }],
+                hits_addend: 1, // irrelevant for this test
+            };
+
+            // There's a limit of 1, so the first request should return "OK" and the
+            // second "OverLimit".
+
+            let response = rate_limiter
+                .check_rate_limit(req.into_request())
+                .await
+                .unwrap()
+                .into_inner();
+            assert_eq!(response.overall_code, i32::from(Code::OverLimit));
+        }
+
+        #[tokio::test]
+        async fn test_returns_ok_when_no_limits_apply() {
+            // No limits saved
+            let limiter = RateLimiter::new(10_000);
+            let rate_limiter = KuadrantService::new(Arc::new(Limiter::Blocking(limiter)));
+
+            let req = RateLimitRequest {
+                domain: "test_namespace".to_string(),
+                descriptors: vec![RateLimitDescriptor {
                     entries: vec![Entry {
-                        key: "y".to_string(),
-                        value: "2".to_string(),
+                        key: "req.method".to_string(),
+                        value: "GET".to_string(),
                     }],
                     limit: None,
-                },
-            ],
-            hits_addend: 1,
-        };
+                }],
+                hits_addend: 1,
+            }
+            .into_request();
 
-        let response = rate_limiter
-            .check_rate_limit(req.into_request())
-            .await
-            .unwrap()
-            .into_inner();
+            let response = rate_limiter
+                .check_rate_limit(req)
+                .await
+                .unwrap()
+                .into_inner();
 
-        assert_eq!(response.overall_code, i32::from(Code::OverLimit));
+            assert_eq!(response.overall_code, i32::from(Code::Ok));
+        }
+
+        #[tokio::test]
+        async fn test_returns_unknown_when_domain_is_empty() {
+            let limiter = RateLimiter::new(10_000);
+            let rate_limiter = KuadrantService::new(Arc::new(Limiter::Blocking(limiter)));
+
+            let req = RateLimitRequest {
+                domain: "".to_string(),
+                descriptors: vec![RateLimitDescriptor {
+                    entries: vec![Entry {
+                        key: "req.method".to_string(),
+                        value: "GET".to_string(),
+                    }],
+                    limit: None,
+                }],
+                hits_addend: 1,
+            }
+            .into_request();
+
+            let response = rate_limiter
+                .check_rate_limit(req)
+                .await
+                .unwrap()
+                .into_inner();
+            assert_eq!(response.overall_code, i32::from(Code::Unknown));
+        }
+
+        #[tokio::test]
+        async fn test_takes_into_account_all_the_descriptors() {
+            let limiter = RateLimiter::new(10_000);
+
+            let namespace = "test_namespace";
+
+            vec![
+                Limit::new(
+                    namespace,
+                    10,
+                    60,
+                    vec!["descriptors[0].x == '1'"
+                        .try_into()
+                        .expect("failed parsing!")],
+                    vec!["descriptors[0].z".try_into().expect("failed parsing!")],
+                ),
+                Limit::new(
+                    namespace,
+                    0,
+                    60,
+                    vec![
+                        "descriptors[0].x == '1'"
+                            .try_into()
+                            .expect("failed parsing!"),
+                        "descriptors[1].y == '2'"
+                            .try_into()
+                            .expect("failed parsing!"),
+                    ],
+                    vec!["descriptors[0].z".try_into().expect("failed parsing!")],
+                ),
+            ]
+            .into_iter()
+            .for_each(|limit| {
+                limiter.add_limit(limit);
+            });
+
+            let rate_limiter = KuadrantService::new(Arc::new(Limiter::Blocking(limiter)));
+
+            let req = RateLimitRequest {
+                domain: namespace.to_string(),
+                descriptors: vec![
+                    RateLimitDescriptor {
+                        entries: vec![
+                            Entry {
+                                key: "x".to_string(),
+                                value: "1".to_string(),
+                            },
+                            Entry {
+                                key: "z".to_string(),
+                                value: "1".to_string(),
+                            },
+                        ],
+                        limit: None,
+                    },
+                    // If this is taken into account, the result will be "overlimit"
+                    // because of the second limit that has a max of 0.
+                    RateLimitDescriptor {
+                        entries: vec![Entry {
+                            key: "y".to_string(),
+                            value: "2".to_string(),
+                        }],
+                        limit: None,
+                    },
+                ],
+                hits_addend: 1,
+            };
+
+            let response = rate_limiter
+                .check_rate_limit(req.into_request())
+                .await
+                .unwrap()
+                .into_inner();
+
+            assert_eq!(response.overall_code, i32::from(Code::OverLimit));
+        }
+    }
+
+    mod report {
+        use tonic::IntoRequest;
+
+        use limitador::limit::Limit;
+        use limitador::RateLimiter;
+
+        use crate::envoy_rls::server::envoy::extensions::common::ratelimit::v3::rate_limit_descriptor::Entry;
+        use crate::envoy_rls::server::envoy::extensions::common::ratelimit::v3::RateLimitDescriptor;
+        use crate::envoy_rls::server::envoy::service::ratelimit::v3::RateLimitRequest;
+
+        use super::super::*;
+
+        #[tokio::test]
+        async fn test_returns_ok_correctly() {
+            let namespace = "test_namespace";
+            let limit = Limit::new(
+                namespace,
+                10,
+                60,
+                vec!["descriptors[0]['req.method'] == 'GET'"
+                    .try_into()
+                    .expect("failed parsing!")],
+                vec!["descriptors[0]['app.id']"
+                    .try_into()
+                    .expect("failed parsing!")],
+            );
+
+            let limiter = RateLimiter::new(10_000);
+            limiter.add_limit(limit);
+
+            let rate_limiter = KuadrantService::new(Arc::new(Limiter::Blocking(limiter)));
+
+            let req = RateLimitRequest {
+                domain: namespace.to_string(),
+                descriptors: vec![RateLimitDescriptor {
+                    entries: vec![
+                        Entry {
+                            key: "req.method".to_string(),
+                            value: "GET".to_string(),
+                        },
+                        Entry {
+                            key: "app.id".to_string(),
+                            value: "1".to_string(),
+                        },
+                    ],
+                    limit: None,
+                }],
+                hits_addend: 4,
+            };
+
+            let response = rate_limiter
+                .report(req.clone().into_request())
+                .await
+                .unwrap()
+                .into_inner();
+            assert_eq!(response.overall_code, i32::from(Code::Ok));
+        }
+
+        #[tokio::test]
+        async fn test_going_overlimit_is_ok() {
+            let namespace = "test_namespace";
+            let limit = Limit::new(
+                namespace,
+                5,
+                60,
+                vec!["descriptors[0]['req.method'] == 'GET'"
+                    .try_into()
+                    .expect("failed parsing!")],
+                vec!["descriptors[0]['app.id']"
+                    .try_into()
+                    .expect("failed parsing!")],
+            );
+
+            let limiter = RateLimiter::new(10_000);
+            limiter.add_limit(limit);
+
+            let rate_limiter = KuadrantService::new(Arc::new(Limiter::Blocking(limiter)));
+
+            let req = RateLimitRequest {
+                domain: namespace.to_string(),
+                descriptors: vec![RateLimitDescriptor {
+                    entries: vec![
+                        Entry {
+                            key: "req.method".to_string(),
+                            value: "GET".to_string(),
+                        },
+                        Entry {
+                            key: "app.id".to_string(),
+                            value: "1".to_string(),
+                        },
+                    ],
+                    limit: None,
+                }],
+                hits_addend: 20,
+            };
+
+            let response = rate_limiter
+                .report(req.into_request())
+                .await
+                .unwrap()
+                .into_inner();
+            assert_eq!(response.overall_code, i32::from(Code::Ok));
+        }
+
+        #[tokio::test]
+        async fn test_returns_ok_when_no_limits_apply() {
+            // No limits saved
+            let limiter = RateLimiter::new(10_000);
+            let rate_limiter = KuadrantService::new(Arc::new(Limiter::Blocking(limiter)));
+
+            let req = RateLimitRequest {
+                domain: "test_namespace".to_string(),
+                descriptors: vec![RateLimitDescriptor {
+                    entries: vec![Entry {
+                        key: "req.method".to_string(),
+                        value: "GET".to_string(),
+                    }],
+                    limit: None,
+                }],
+                hits_addend: 1,
+            }
+            .into_request();
+
+            let response = rate_limiter.report(req).await.unwrap().into_inner();
+
+            assert_eq!(response.overall_code, i32::from(Code::Ok));
+        }
+
+        #[tokio::test]
+        async fn test_returns_unknown_when_domain_is_empty() {
+            let limiter = RateLimiter::new(10_000);
+            let rate_limiter = KuadrantService::new(Arc::new(Limiter::Blocking(limiter)));
+
+            let req = RateLimitRequest {
+                domain: "".to_string(),
+                descriptors: vec![RateLimitDescriptor {
+                    entries: vec![Entry {
+                        key: "req.method".to_string(),
+                        value: "GET".to_string(),
+                    }],
+                    limit: None,
+                }],
+                hits_addend: 1,
+            }
+            .into_request();
+
+            let response = rate_limiter.report(req).await.unwrap().into_inner();
+            assert_eq!(response.overall_code, i32::from(Code::Unknown));
+        }
     }
 }


### PR DESCRIPTION
### What

Fixes https://github.com/Kuadrant/limitador/issues/438

Introducing new method to the existing gRPC service **kuadrant.service.ratelimit.v1.RateLimitService**

```proto
service RateLimitService {
  // The report method modifies specific counters associated with the descriptors, incrementing each one by the amount specified in $hits_addend$
  rpc Report(envoy.service.ratelimit.v3.RateLimitRequest) returns (envoy.service.ratelimit.v3.RateLimitResponse); 
}
```

### Verification steps

Run `sandbox` dev environment

```bash
cd limitador-server/sandbox
docker rmi limitador-testing:latest
make build
make deploy-in-memory
```

In a separate shell, inspect the **new**  RLS GRPC endpoint. First, let's install [grpcurl](https://github.com/fullstorydev/grpcurl) tool. You need [Go SDK 1.8+](https://golang.org/doc/install) installed.

```bash
make grpcurl
```

Inspect `RateLimitService` GRPC service

```bash
bin/grpcurl -plaintext 127.0.0.1:18081 describe kuadrant.service.ratelimit.v1.RateLimitService
```
The output should be the following
```bash
kuadrant.service.ratelimit.v1.RateLimitService is a service:
service RateLimitService {
  // Determine whether a request should be allowed or denied based on rate limiting rules.
  rpc CheckRateLimit ( .envoy.service.ratelimit.v3.RateLimitRequest ) returns ( .envoy.service.ratelimit.v3.RateLimitResponse );
  // The report method modifies specific counters associated with the descriptors, incrementing each one by the amount specified in $hits_addend$
  rpc Report ( .envoy.service.ratelimit.v3.RateLimitRequest ) returns ( .envoy.service.ratelimit.v3.RateLimitResponse );
}
```

The environment limits configuration for the following descriptor is max 5 req in 60s window. 
```
["req.method": "POST"], ["req.path": "/"]
```

Then, perform `Report` call with `hits_addend` set to 10 which is bigger than existing limit of 5.

```shell
bin/grpcurl -plaintext -d @ 127.0.0.1:18081 kuadrant.service.ratelimit.v1.RateLimitService.Report <<EOM
{
    "domain": "test_namespace",
    "hits_addend": 10,
    "descriptors": [
        {
            "entries": [
                {
                    "key": "req.method",
                    "value": "POST"
                },
                {
                    "key": "req.path",
                    "value": "/"
                }
            ]
        }
    ]
}
EOM
```

The expected response is OK even if hits_addend exceeds the existing limit. 
```
{
  "overallCode": "OK"
}
```

Let's inspect the counter

```shell
curl -v http://127.0.0.1:18080/counters/test_namespace | yq e -P
```
Returning

```yaml
- limit:
    id: null
    namespace: test_namespace
    max_value: 5
    seconds: 60
    name: null
    conditions:
      - descriptors[0]['req.method'] == 'POST'
      - descriptors[0]['req.path'] != '/json'
    variables: []
  set_variables: {}
  remaining: 18446744073709551611
  expires_in_seconds: 51
```
The expected result is `18446744073709551611` which is due to overflow issue when computing the `remaining` field. When running the  `CheckRateLimit` call should return OVER_LIMIT until the time window deadline expires. 

```shell
bin/grpcurl -plaintext -d @ 127.0.0.1:18081 kuadrant.service.ratelimit.v1.RateLimitService.CheckRateLimit <<EOM
{
    "domain": "test_namespace",
    "descriptors": [
        {
            "entries": [
                {
                    "key": "req.method",
                    "value": "POST"
                },
                {
                    "key": "req.path",
                    "value": "/"
                }
            ]
        }
    ]
}
EOM
```

The expected response is
```
{
  "overallCode": "OVER_LIMIT"
}
```