### PR TITLE
Bumping rustc from 1:70 to 1.84.1

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -4,7 +4,7 @@
 
 # Use bullseye as build image instead of Bookworm as ubi9 does not not have GLIBCXX_3.4.30
 # https://access.redhat.com/solutions/6969351
-FROM --platform=${BUILDPLATFORM} rust:1.79.0-bullseye as limitador-build
+FROM --platform=${BUILDPLATFORM} rust:1.84.1-bullseye as limitador-build
 
 RUN apt update && apt upgrade -y \
     && apt install -y protobuf-compiler clang g++-aarch64-linux-gnu libc6-dev-arm64-cross


### PR DESCRIPTION
Matching the default [Dockerfile](https://github.com/Kuadrant/limitador/blob/main/Dockerfile#L7) for linux/amd
In order to fix :

```
#14 4.957 error: rustc 1.79.0 is not supported by the following packages:
#14 4.957   icu_collections@2.0.0 requires rustc 1.82
#14 4.957   icu_locale_core@2.0.0 requires rustc 1.82
#14 4.957   icu_normalizer@2.0.0 requires rustc 1.82
#14 4.957   icu_normalizer_data@2.0.0 requires rustc 1.82
#14 4.957   icu_normalizer_data@2.0.0 requires rustc 1.82
#14 4.957   icu_normalizer_data@2.0.0 requires rustc 1.82
#14 4.957   icu_properties@2.0.1 requires rustc 1.82
#14 4.957   icu_properties_data@2.0.1 requires rustc 1.82
#14 4.957   icu_properties_data@2.0.1 requires rustc 1.82
#14 4.957   icu_properties_data@2.0.1 requires rustc 1.82
#14 4.957   icu_provider@2.0.0 requires rustc 1.82
#14 4.957   idna_adapter@1.2.1 requires rustc 1.82
#14 4.957   litemap@0.8.0 requires rustc 1.82
#14 4.957   native-tls@0.2.14 requires rustc 1.80.0
#14 4.957   native-tls@0.2.14 requires rustc 1.80.0
#14 4.957   native-tls@0.2.14 requires rustc 1.80.0
#14 4.957   potential_utf@0.1.2 requires rustc 1.81
#14 4.957   rayon@1.11.0 requires rustc 1.80
#14 4.957   rayon-core@1.13.0 requires rustc 1.80
#14 4.957   rayon-core@1.13.0 requires rustc 1.80
#14 4.957   rayon-core@1.13.0 requires rustc 1.80
#14 4.957   tinystr@0.8.1 requires rustc 1.81
#14 4.957   writeable@0.6.1 requires rustc 1.81
#14 4.957   yoke@0.8.0 requires rustc 1.81
#14 4.957   zerofrom@0.1.6 requires rustc 1.81
#14 4.957   zerotrie@0.2.2 requires rustc 1.82
#14 4.957   zerovec@0.11.4 requires rustc 1.82
#14 4.957 Either upgrade rustc or select compatible dependency versions with
#14 4.957 `cargo update <name>@<current-ver> --precise <compatible-ver>`
#14 4.957 where `<compatible-ver>` is the latest version supporting rustc 1.79.0
#14 4.957 
#14 ERROR: process "/bin/sh -c cargo build --release --target aarch64-unknown-linux-gnu" did not complete successfully: exit code: 101
------
 > [limitador-build 6/6] RUN cargo build --release --target aarch64-unknown-linux-gnu:
4.957   tinystr@0.8.1 requires rustc 1.81
4.957   writeable@0.6.1 requires rustc 1.81
4.957   yoke@0.8.0 requires rustc 1.81
4.957   zerofrom@0.1.6 requires rustc 1.81
4.957   zerotrie@0.2.2 requires rustc 1.82
4.957   zerovec@0.11.4 requires rustc 1.82
4.957 Either upgrade rustc or select compatible dependency versions with
4.957 `cargo update <name>@<current-ver> --precise <compatible-ver>`
4.957 where `<compatible-ver>` is the latest version supporting rustc 1.79.0
4.957 
------

 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 7)
Dockerfile.aarch64:28
--------------------
  26 |     COPY . .
  27 |     
  28 | >>> RUN cargo build --release --target aarch64-unknown-linux-gnu
  29 |     
  30 |     # ------------------------------------------------------------------------------
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c cargo build --release --target aarch64-unknown-linux-gnu" did not complete successfully: exit code: 101
```