### PR TITLE
🔥 LimitCountersKey (dead code)

### DIFF
--- a/limitador/src/limit.rs
+++ b/limitador/src/limit.rs
@@ -147,16 +147,6 @@ impl Limit {
         Ok(Some(map))
     }
 
-    #[cfg(feature = "disk_storage")]
-    pub(crate) fn variables_for_key(&self) -> Vec<&str> {
-        let mut variables = Vec::with_capacity(self.variables.len());
-        for var in &self.variables {
-            variables.push(var.source());
-        }
-        variables.sort();
-        variables
-    }
-
     pub fn has_variable(&self, var: &str) -> bool {
         self.variables
             .iter()

--- a/limitador/src/storage/keys.rs
+++ b/limitador/src/storage/keys.rs
@@ -233,32 +233,6 @@ pub mod bin {
         }
     }
 
-    #[derive(PartialEq, Debug, Serialize, Deserialize)]
-    struct LimitCountersKey<'a> {
-        ns: &'a str,
-        seconds: u64,
-        conditions: Vec<String>,
-        variables: Vec<&'a str>,
-    }
-
-    impl<'a> From<&'a Limit> for LimitCountersKey<'a> {
-        fn from(limit: &'a Limit) -> Self {
-            let set = limit.conditions();
-            let mut conditions = Vec::with_capacity(set.len());
-            for cond in &set {
-                conditions.push(cond.clone());
-            }
-            conditions.sort();
-
-            LimitCountersKey {
-                ns: limit.namespace().as_ref(),
-                seconds: limit.seconds(),
-                conditions,
-                variables: limit.variables_for_key(),
-            }
-        }
-    }
-
     pub fn key_for_counter_v2(counter: &Counter) -> Vec<u8> {
         let mut encoded_key = Vec::new();
         if counter.id().is_none() {


### PR DESCRIPTION
### What

Rustc has been upgraded to 1.90 and now Clippy complains about:

```
error: method `variables_for_key` is never used
   --> limitador/src/limit.rs:151:19
    |
 50 | impl Limit {
    | ---------- method in this implementation
...
151 |     pub(crate) fn variables_for_key(&self) -> Vec<&str> {
    |                   ^^^^^^^^^^^^^^^^^
    |
    = note: `-D dead-code` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(dead_code)]`

error: struct `LimitCountersKey` is never constructed
   --> limitador/src/storage/keys.rs:237:12
    |
237 |     struct LimitCountersKey<'a> {
    |            ^^^^^^^^^^^^^^^^

```

