### PR TITLE
fix try-in-kind test

### DIFF
--- a/limitador-server/kubernetes/kuard-deployment.yaml
+++ b/limitador-server/kubernetes/kuard-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: kuard
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: kuard
@@ -16,7 +16,10 @@ spec:
     spec:
       containers:
         - name: kuard
-          image: gcr.io/kuar-demo/kuard-amd64:blue
+          image: quay.io/kuadrant/authorino-examples:talker-api
+          env:
+            - name: PORT
+              value: "8080"
           ports:
             - containerPort: 8080
               name: http

--- a/limitador-server/kubernetes/limitador-deployment.yaml
+++ b/limitador-server/kubernetes/limitador-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: limitador
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: limitador


### PR DESCRIPTION
### What

`Try In Kind` test was using an image from a registry that is deprecated and shutting down

```
❯ docker pull gcr.io/kuar-demo/kuard-amd64:blue
Error response from daemon: Head "https://gcr.io/v2/kuar-demo/kuard-amd64/manifests/blue": unknown: Container Registry is deprecated and shutting down, please use the auto migration tool to migrate to Artifact Registry (gcloud artifacts docker upgrade migrate --projects='kuar-demo'). For more details see: https://cloud.google.com/artifact-registry/docs/transition/auto-migrate-gcr-ar
```