### PR TITLE
chore: ubi10 as dockerfile run image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN cargo build --release ${CARGO_ARGS}
 # Run Stage
 # ------------------------------------------------------------------------------
 
-FROM registry.access.redhat.com/ubi10-minimal:10.0
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1
 
 # shadow-utils is required for `useradd`
 RUN PKGS="libgcc libstdc++ shadow-utils" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@
 # Build Stage
 # ------------------------------------------------------------------------------
 
-# Use bullseye as build image instead of Bookworm as ubi9 does not not have GLIBCXX_3.4.30
-# https://access.redhat.com/solutions/6969351
-FROM mirror.gcr.io/library/rust:1.88-bullseye as limitador-build
+FROM mirror.gcr.io/library/rust:1.88 AS limitador-build
 
 RUN apt update && apt upgrade -y \
     && apt install -y protobuf-compiler clang
@@ -35,7 +33,7 @@ RUN cargo build --release ${CARGO_ARGS}
 # Run Stage
 # ------------------------------------------------------------------------------
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+FROM registry.access.redhat.com/ubi10-minimal:10.0
 
 # shadow-utils is required for `useradd`
 RUN PKGS="libgcc libstdc++ shadow-utils" \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -2,9 +2,7 @@
 # Build Stage cross compiling
 # ------------------------------------------------------------------------------
 
-# Use bullseye as build image instead of Bookworm as ubi9 does not not have GLIBCXX_3.4.30
-# https://access.redhat.com/solutions/6969351
-FROM --platform=${BUILDPLATFORM} rust:1.88-bullseye as limitador-build
+FROM --platform=${BUILDPLATFORM} mirror.gcr.io/library/rust:1.88 AS limitador-build
 
 RUN apt update && apt upgrade -y \
     && apt install -y protobuf-compiler clang g++-aarch64-linux-gnu libc6-dev-arm64-cross
@@ -31,7 +29,7 @@ RUN cargo build --release --target aarch64-unknown-linux-gnu
 # Run Stage
 # ------------------------------------------------------------------------------
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+FROM registry.access.redhat.com/ubi10-minimal:10.0
 
 # shadow-utils is required for `useradd`
 RUN PKGS="libgcc libstdc++ shadow-utils" \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -29,7 +29,7 @@ RUN cargo build --release --target aarch64-unknown-linux-gnu
 # Run Stage
 # ------------------------------------------------------------------------------
 
-FROM registry.access.redhat.com/ubi10-minimal:10.0
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1
 
 # shadow-utils is required for `useradd`
 RUN PKGS="libgcc libstdc++ shadow-utils" \


### PR DESCRIPTION
* Use ubi10 as dockerfile run stage image
  * This removes the need to use  bullseye version of rust image for building 

Successful image build at https://github.com/Kuadrant/limitador/actions/runs/18947815190/job/54103982722 and pushed to `quay.io/kuadrant/limitador:ubi10`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Rust build image to a newer stable base.
  * Upgraded runtime environment from UBI 9 to UBI 10 for improved security and stability.
  * Optimised container configurations across supported architectures for consistent builds and runtime behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->