### PR TITLE
Add additional tracing tags

### DIFF
--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -252,19 +252,23 @@ impl CheckResult {
         });
 
         if let Some(counter) = self.counters.first() {
+            let max_value = counter.max_value();
+            let remaining = counter.remaining().unwrap_or(counter.max_value());
+
             headers.insert(
                 "X-RateLimit-Limit".to_string(),
-                format!("{}{all_limits_text}", counter.max_value()),
+                format!("{}{all_limits_text}", max_value),
             );
-
-            let remaining = counter.remaining().unwrap_or(counter.max_value());
             headers.insert("X-RateLimit-Remaining".to_string(), format!("{remaining}"));
 
+            let span = tracing::Span::current();
+            span.record("ratelimit.most_restrictive.limit", max_value);
+            span.record("ratelimit.most_restrictive.remaining", remaining);
+
             if let Some(duration) = counter.expires_in() {
-                headers.insert(
-                    "X-RateLimit-Reset".to_string(),
-                    format!("{}", duration.as_secs()),
-                );
+                let reset_secs = duration.as_secs();
+                headers.insert("X-RateLimit-Reset".to_string(), format!("{}", reset_secs));
+                span.record("ratelimit.most_restrictive.reset_secs", reset_secs);
             }
         }
         headers


### PR DESCRIPTION
Added the following tags to the `should_rate_limit` span:

* `ratelimit.namespace`
* `ratelimit.hits_addend`
* `ratelimit.limited`
* `ratelimit.limit_name` (only present when limited)

The ones below are conditional on ratelimit headers being enabled
* `ratelimit.most_restrictive.limit`
* `ratelimit.most_restrictive.remaining`
* `ratelimit.most_restrictive.reset_secs` (this will show as 0 for the first request as the counter has only just been created)
* `ratelimit.num_counters` (the number of counters the request affected)

Example of a limited request with ratelimit headers enabled:

<img width="2368" height="1280" alt="image" src="https://github.com/user-attachments/assets/e38b47aa-30f3-46c3-a628-20203697b6dd" />
