### PR TITLE
Update to newer versions of actions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,13 +14,13 @@ jobs:
     name: Benchmark
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: supercharge/redis-github-action@1.1.0
+      - uses: actions/checkout@v6
+      - uses: supercharge/redis-github-action@1.8.1
         with:
           redis-version: 7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: Swatinem/rust-cache@v2
       - uses: abelfodil/protoc-action@v1
         with:
-          protoc-version: '3.19.4'
+          protoc-version: "3.19.4"
       - run: cargo bench

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -32,7 +32,7 @@ jobs:
             artifactsuffix: arm
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Docker meta

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,19 +4,19 @@ name: Coverage
 on:
   push:
     branches:
-      - 'main'
+      - "main"
 
 jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: Swatinem/rust-cache@v2
       - uses: abelfodil/protoc-action@v1
         with:
-          protoc-version: '3.19.4'
+          protoc-version: "3.19.4"
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -25,8 +25,8 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: supercharge/redis-github-action@1.1.0
+      - uses: actions/checkout@v6
+      - uses: supercharge/redis-github-action@1.8.1
         with:
           redis-version: 7
       # Nightly is required for code coverage with doctests
@@ -37,7 +37,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: abelfodil/protoc-action@v1
         with:
-          protoc-version: '3.19.4'
+          protoc-version: "3.19.4"
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Test and Generate code coverage

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,17 +3,17 @@ name: e2e tests
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   pull_request:
     branches:
-      - '*'
+      - "*"
 jobs:
   limits_file_watcher:
     name: Limits File Watcher in k8s environment
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Docker meta
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Run docker compose

--- a/.github/workflows/license-scan.yaml
+++ b/.github/workflows/license-scan.yaml
@@ -4,10 +4,10 @@ name: License Scan
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   pull_request:
     branches:
-      - '*'
+      - "*"
 
 jobs:
   fossa-scan:
@@ -15,7 +15,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: fossas/fossa-action@v1.4.0
         name: License Scan
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - uses: abelfodil/protoc-action@v1
         with:
-          protoc-version: '3.19.4'
-      - uses: supercharge/redis-github-action@1.1.0
+          protoc-version: "3.19.4"
+      - uses: supercharge/redis-github-action@1.8.1
         with:
           redis-version: 7
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: crate-v${{ github.event.inputs.version }}
       - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,48 +3,48 @@ name: Limitador
 
 on:
   push:
-    branches: ['main']
+    branches: ["main"]
   pull_request:
-    branches: ['*']
+    branches: ["*"]
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
   schedule:
-    - cron: '5 4 * * *'
+    - cron: "5 4 * * *"
 
 jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: Swatinem/rust-cache@v2
       - uses: abelfodil/protoc-action@v1
         with:
-          protoc-version: '3.19.4'
+          protoc-version: "3.19.4"
       - run: cargo check --all-features
 
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: supercharge/redis-github-action@1.1.0
+      - uses: actions/checkout@v6
+      - uses: supercharge/redis-github-action@1.8.1
         with:
           redis-version: 7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: Swatinem/rust-cache@v2
       - uses: abelfodil/protoc-action@v1
         with:
-          protoc-version: '3.19.4'
+          protoc-version: "3.19.4"
       - run: cargo test --all-features -vv
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
@@ -55,25 +55,25 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - uses: abelfodil/protoc-action@v1
         with:
-          protoc-version: '3.19.4'
+          protoc-version: "3.19.4"
       - run: cargo clippy --all-features --all-targets -- -D warnings
 
   kind:
     name: Try in kind (Kubernetes in Docker)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: engineerd/setup-kind@v0.5.0
+      - uses: actions/checkout@v6
+      - uses: helm/kind-action@v1.2.0
         with:
-          version: v0.11.1
-          skipClusterCreation: true
+          version: v0.23.0
+          install_only: true
       - run: |
           ./limitador-server/script/kind-setup.sh
           ips=$(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
@@ -92,12 +92,10 @@ jobs:
           - dockerfile: Dockerfile.aarch64
             platform: linux/arm64
     steps:
-      - uses: actions/checkout@v4
-      -
-        name: Set up Docker Buildx
+      - uses: actions/checkout@v6
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Build
+      - name: Build
         uses: docker/build-push-action@v6
         with:
           push: false
@@ -119,5 +117,5 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: echo '${{ toJSON(needs) }}' | jq -e 'all(.[]; .result == "success" or .result == "skipped")'

--- a/limitador-server/script/kind-cluster.yaml
+++ b/limitador-server/script/kind-cluster.yaml
@@ -2,5 +2,5 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
-- role: control-plane
-  image: kindest/node:v1.23.1
+  - role: control-plane
+    image: kindest/node:v1.30.0


### PR DESCRIPTION
Having some actions failing on PRs:
https://github.com/Kuadrant/limitador/actions/runs/21953108719/job/63409196176

Tried to update all of the quite old versions of the actions:

- `actions/checkout@v4` -> `v6`
- `supercharge/redis-github-action@1.1.0` -> `v1.8.1`
- `engineerd/setup-kind@v0.5.0` -> `helm/kind-action@v1.2.0` (matching our other repos)
- kind k8s version: `kindest/node:v1.23.1` -> `kindest/node:v1.30.0` (matching kuadrant-operator)