### PR TITLE
MULTIARCH-5995: add ppc64le support to the build

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -34,6 +34,10 @@ jobs:
             platform: linux/s390x
             scope: build-s390x
             artifactsuffix: s390x
+          - dockerfile: Dockerfile.ppc64le
+            platform: linux/ppc64le
+            scope: build-ppc64le
+            artifactsuffix: ppc64le
     steps:
       - name: Check out code
         uses: actions/checkout@v6
@@ -125,3 +129,4 @@ jobs:
           docker run --rm -t --platform linux/amd64 "$image" --help
           docker run --rm -t --platform linux/arm64 "$image" --help
           docker run --rm -t --platform linux/s390x "$image" --help
+          docker run --rm -t --platform linux/ppc64le "$image" --help

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,6 +93,8 @@ jobs:
             platform: linux/arm64
           - dockerfile: Dockerfile.s390x
             platform: linux/s390x
+          - dockerfile: Dockerfile.ppc64le
+            platform: linux/ppc64le
     steps:
       - uses: actions/checkout@v6
       - name: Set up Docker Buildx

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,0 +1,42 @@
+# Build Stage: cross-compile for ppc64le (IBM POWER)
+FROM --platform=${BUILDPLATFORM} rust:1.88 AS limitador-build
+
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends protobuf-compiler clang \
+    gcc-powerpc64le-linux-gnu g++-powerpc64le-linux-gnu libc6-dev-ppc64el-cross
+
+RUN rustup target add powerpc64le-unknown-linux-gnu
+
+WORKDIR /usr/src/limitador
+
+ARG GITHUB_SHA
+ENV GITHUB_SHA=${GITHUB_SHA:-unknown}
+ENV RUSTFLAGS="-C target-feature=-crt-static" \
+    CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER=powerpc64le-linux-gnu-gcc \
+    CC_powerpc64le_unknown_linux_gnu=powerpc64le-linux-gnu-gcc \
+    CXX_powerpc64le_unknown_linux_gnu=powerpc64le-linux-gnu-g++ \
+    BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/usr/powerpc64le-linux-gnu"
+
+COPY . .
+RUN cargo build --release --target powerpc64le-unknown-linux-gnu
+
+# Run Stage
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1
+
+RUN PKGS="libgcc libstdc++ shadow-utils" && \
+    microdnf --assumeyes install --nodocs $PKGS && \
+    rpm --verify --nogroup --nouser $PKGS && \
+    microdnf -y clean all
+RUN useradd -u 1000 -s /bin/sh -m -d /home/limitador limitador
+
+WORKDIR /home/limitador/bin/
+ENV PATH="/home/limitador/bin:${PATH}"
+
+COPY --from=limitador-build /usr/src/limitador/limitador-server/examples/limits.yaml ../
+COPY --from=limitador-build /usr/src/limitador/target/powerpc64le-unknown-linux-gnu/release/limitador-server ./limitador-server
+
+RUN chown -R limitador:root /home/limitador && \
+    chmod -R 750 /home/limitador
+USER limitador
+
+ENTRYPOINT ["limitador-server"]


### PR DESCRIPTION
Enable ppc64le images in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PPC64LE architecture support with automated builds and image publishing.

* **Tests**
  * Updated smoke tests and platform checks to include Linux/ppc64le alongside existing architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->