### PR TITLE
feat: add report_calls prometheus metric for Report gRPC method

### DIFF
--- a/limitador-server/src/envoy_rls/kuadrant_service.rs
+++ b/limitador-server/src/envoy_rls/kuadrant_service.rs
@@ -167,6 +167,7 @@ impl RateLimitService for KuadrantService {
             return Err(Status::unavailable("Service unavailable"));
         }
 
+        self.metrics.incr_report_calls(&namespace, &ctx);
         self.metrics
             .incr_authorized_hits(&namespace, &ctx, hits_addend);
 
@@ -616,6 +617,82 @@ mod tests {
             let response = rate_limiter.report(req).await.unwrap().into_inner();
 
             assert_eq!(response.overall_code, i32::from(Code::Ok));
+        }
+
+        #[test]
+        fn test_increments_report_calls_metric() {
+            let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+            let handle: Arc<metrics_exporter_prometheus::PrometheusHandle> =
+                recorder.handle().into();
+
+            let namespace = "report_calls_test_namespace";
+            let limit = Limit::new(
+                namespace,
+                10,
+                60,
+                vec!["descriptors[0]['req.method'] == 'GET'"
+                    .try_into()
+                    .expect("failed parsing!")],
+                vec!["descriptors[0]['app.id']"
+                    .try_into()
+                    .expect("failed parsing!")],
+            );
+
+            let limiter = RateLimiter::new(10_000);
+            limiter.add_limit(limit);
+
+            let prometheus_metrics =
+                Arc::new(PrometheusMetrics::new_with_handle(false, handle.clone()));
+            let rate_limiter = KuadrantService::new(
+                Arc::new(Limiter::Blocking(limiter)),
+                prometheus_metrics.clone(),
+            );
+
+            let req = RateLimitRequest {
+                domain: namespace.to_string(),
+                descriptors: vec![RateLimitDescriptor {
+                    entries: vec![
+                        Entry {
+                            key: "req.method".to_string(),
+                            value: "GET".to_string(),
+                        },
+                        Entry {
+                            key: "app.id".to_string(),
+                            value: "1".to_string(),
+                        },
+                    ],
+                    limit: None,
+                }],
+                hits_addend: 1,
+            };
+
+            // Use a fresh runtime (not inside an existing one) so block_on works
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap();
+
+            metrics::with_local_recorder(&recorder, || {
+                rt.block_on(async {
+                    rate_limiter
+                        .report(req.clone().into_request())
+                        .await
+                        .unwrap();
+                    rate_limiter
+                        .report(req.clone().into_request())
+                        .await
+                        .unwrap();
+                });
+            });
+
+            let metrics_output = handle.render();
+            assert!(
+                metrics_output.contains(&format!(
+                    "report_calls{{limitador_namespace=\"{}\"}} 2",
+                    namespace
+                )),
+                "Expected report_calls counter to be 2, got:\n{}",
+                metrics_output
+            );
         }
 
         #[tokio::test]

--- a/limitador-server/src/prometheus_metrics.rs
+++ b/limitador-server/src/prometheus_metrics.rs
@@ -66,6 +66,7 @@ impl PrometheusMetrics {
         );
         describe_counter!("authorized_calls", "Authorized calls");
         describe_counter!("limited_calls", "Limited calls");
+        describe_counter!("report_calls", "Report calls");
         describe_gauge!("limitador_up", "Limitador is running");
         gauge!("limitador_up").set(1);
         describe_gauge!(
@@ -94,6 +95,12 @@ impl PrometheusMetrics {
         let mut labels: Vec<(String, String)> = self.labels(cel_ctx);
         labels.push((NAMESPACE_LABEL.to_string(), namespace.as_ref().to_string()));
         counter!("authorized_calls", &labels).increment(1);
+    }
+
+    pub fn incr_report_calls(&self, namespace: &Namespace, cel_ctx: &Context) {
+        let mut labels: Vec<(String, String)> = self.labels(cel_ctx);
+        labels.push((NAMESPACE_LABEL.to_string(), namespace.as_ref().to_string()));
+        counter!("report_calls", &labels).increment(1);
     }
 
     pub fn incr_authorized_hits(&self, namespace: &Namespace, cel_ctx: &Context, hits_addend: u64) {
@@ -397,6 +404,40 @@ mod tests {
                 "{}",
                 metrics_output
             );
+        });
+    }
+
+    #[test]
+    fn shows_report_calls_by_namespace() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle: Arc<PrometheusHandle> = recorder.handle().into();
+
+        with_local_recorder(&recorder, || {
+            let prometheus_metrics = PrometheusMetrics::new_with_handle(false, handle.clone());
+            let namespaces_with_report_counts = [
+                ("report_calls_by_namespace".into(), 2),
+                ("report_calls_by_namespace_two".into(), 4),
+            ];
+
+            namespaces_with_report_counts
+                .iter()
+                .for_each(|(namespace, report_count)| {
+                    for _ in 0..*report_count {
+                        prometheus_metrics.incr_report_calls(namespace, &Context::default());
+                    }
+                });
+
+            let metrics_output = prometheus_metrics.gather_metrics();
+
+            namespaces_with_report_counts
+                .iter()
+                .for_each(|(namespace, report_count)| {
+                    assert!(metrics_output.contains(&formatted_counter_with_namespace(
+                        "report_calls",
+                        *report_count,
+                        namespace
+                    )));
+                });
         });
     }
 


### PR DESCRIPTION

Fixes #440

Adds a new `report_calls` Prometheus counter to track calls to the `Report` gRPC method introduced in #439.

The new metric follows the same pattern as the existing `authorized_calls` and `limited_calls` counters:

```
# HELP report_calls Report calls
# TYPE report_calls counter
report_calls{limitador_namespace="test_namespace"} 5
```

### Changes

- Register `report_calls` counter with `describe_counter!` in `PrometheusMetrics`
- Add `incr_report_calls()` helper on `PrometheusMetrics`
- Call `incr_report_calls()` in `KuadrantService::report()` after a successful `update_counters` call
- Add unit tests in `prometheus_metrics.rs` and `kuadrant_service.rs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved system observability by introducing new Prometheus metrics to track reporting activity by namespace, providing enhanced visibility into performance patterns and resource utilisation across different environments.

* **Tests**
  * Added unit tests to validate the accuracy of new metrics tracking and ensure correct namespace-based measurement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->