### PR TITLE
Backport patch-safe fixes for server v2.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
@@ -2374,9 +2374,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -3719,30 +3719,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,9 +677,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytestring"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2468,15 +2468,14 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.9.3",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2509,9 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.11.1"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cceded2fb55f3c4b67068fa64962e2ca59614edc5b03167de9ff82ae803da0"
+checksum = "93acb4a42f64936f9b8cae4a433b237599dd6eb6ed06124eb67132ef8cc90662"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -49,7 +49,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.10.1",
  "sha1",
  "smallvec",
  "tokio",
@@ -597,7 +597,7 @@ dependencies = [
  "bitflags 2.9.3",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -635,11 +635,11 @@ checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -747,6 +747,17 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -858,6 +869,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const_format"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,9 +923,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1008,12 +1025,11 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1062,11 +1078,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -1307,16 +1324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,8 +1342,22 @@ checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1530,6 +1551,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,7 +1646,7 @@ dependencies = [
  "hyper 1.7.0",
  "libc",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1733,6 +1763,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1777,6 +1813,7 @@ checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
+ "serde",
 ]
 
 [[package]]
@@ -1833,7 +1870,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1941,6 +1978,12 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -3030,6 +3073,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "r2d2"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3059,6 +3108,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3098,6 +3158,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xoshiro"
@@ -3473,9 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -4179,9 +4245,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicase"
@@ -4302,6 +4368,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4357,6 +4441,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.11.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.9.3",
+ "hashbrown 0.15.5",
+ "indexmap 2.11.0",
+ "semver",
 ]
 
 [[package]]
@@ -4731,12 +4849,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.3",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.11.0",
+ "prettyplease",
+ "syn 2.0.106",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.3",
+ "indexmap 2.11.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.11.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -46,7 +46,7 @@ const_format = "0.2.31"
 lazy_static = "1.4.0"
 clap = "4.3"
 sysinfo = "0.32"
-openssl = { version = "0.10.66", features = ["vendored"] }
+openssl = { version = "0.10.79", features = ["vendored"] }
 metrics = "0.24.2"
 metrics-exporter-prometheus = { version = "0.17.2", default-features = false, features = ["http-listener"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/limitador-server/src/envoy_rls/server.rs
+++ b/limitador-server/src/envoy_rls/server.rs
@@ -369,13 +369,20 @@ pub mod tests {
             .unwrap()
             .into_inner();
         assert_eq!(response.overall_code, i32::from(Code::Ok));
-        assert_eq!(
-            response.response_headers_to_add,
-            vec![
-                header_value("X-RateLimit-Limit", "1, 1;w=60"),
-                header_value("X-RateLimit-Remaining", "0"),
-            ],
-        );
+        assert_eq!(response.response_headers_to_add.len(), 3);
+        assert!(response
+            .response_headers_to_add
+            .contains(&header_value("X-RateLimit-Limit", "1, 1;w=60")));
+        assert!(response
+            .response_headers_to_add
+            .contains(&header_value("X-RateLimit-Remaining", "0")));
+        let reset_header = response
+            .response_headers_to_add
+            .iter()
+            .find(|h| h.key == "X-RateLimit-Reset")
+            .unwrap();
+        let reset_val: u64 = reset_header.value.parse().unwrap();
+        assert!(reset_val <= 60);
 
         let response = rate_limiter
             .should_rate_limit(req.clone().into_request())
@@ -383,13 +390,20 @@ pub mod tests {
             .unwrap()
             .into_inner();
         assert_eq!(response.overall_code, i32::from(Code::OverLimit));
-        assert_eq!(
-            response.response_headers_to_add,
-            vec![
-                header_value("X-RateLimit-Limit", "1, 1;w=60"),
-                header_value("X-RateLimit-Remaining", "0"),
-            ],
-        );
+        assert_eq!(response.response_headers_to_add.len(), 3);
+        assert!(response
+            .response_headers_to_add
+            .contains(&header_value("X-RateLimit-Limit", "1, 1;w=60")));
+        assert!(response
+            .response_headers_to_add
+            .contains(&header_value("X-RateLimit-Remaining", "0")));
+        let reset_header = response
+            .response_headers_to_add
+            .iter()
+            .find(|h| h.key == "X-RateLimit-Reset")
+            .unwrap();
+        let reset_val: u64 = reset_header.value.parse().unwrap();
+        assert!(reset_val <= 60);
     }
 
     #[tokio::test]
@@ -541,13 +555,20 @@ pub mod tests {
             .into_inner();
 
         assert_eq!(response.overall_code, i32::from(Code::OverLimit));
-        assert_eq!(
-            response.response_headers_to_add,
-            vec![
-                header_value("X-RateLimit-Limit", "0, 0;w=60, 10;w=60"),
-                header_value("X-RateLimit-Remaining", "0"),
-            ],
-        );
+        assert_eq!(response.response_headers_to_add.len(), 3);
+        assert!(response
+            .response_headers_to_add
+            .contains(&header_value("X-RateLimit-Limit", "0, 0;w=60, 10;w=60")));
+        assert!(response
+            .response_headers_to_add
+            .contains(&header_value("X-RateLimit-Remaining", "0")));
+        let reset_header = response
+            .response_headers_to_add
+            .iter()
+            .find(|h| h.key == "X-RateLimit-Reset")
+            .unwrap();
+        let reset_val: u64 = reset_header.value.parse().unwrap();
+        assert!(reset_val <= 60);
     }
 
     #[tokio::test]
@@ -602,13 +623,20 @@ pub mod tests {
             .unwrap()
             .into_inner();
         assert_eq!(response.overall_code, i32::from(Code::Ok));
-        assert_eq!(
-            response.response_headers_to_add,
-            vec![
-                header_value("X-RateLimit-Limit", "10, 10;w=60"),
-                header_value("X-RateLimit-Remaining", "4"),
-            ],
-        );
+        assert_eq!(response.response_headers_to_add.len(), 3);
+        assert!(response
+            .response_headers_to_add
+            .contains(&header_value("X-RateLimit-Limit", "10, 10;w=60")));
+        assert!(response
+            .response_headers_to_add
+            .contains(&header_value("X-RateLimit-Remaining", "4")));
+        let reset_header = response
+            .response_headers_to_add
+            .iter()
+            .find(|h| h.key == "X-RateLimit-Reset")
+            .unwrap();
+        let reset_val: u64 = reset_header.value.parse().unwrap();
+        assert!(reset_val <= 60);
 
         let response = rate_limiter
             .should_rate_limit(req.clone().into_request())
@@ -616,13 +644,20 @@ pub mod tests {
             .unwrap()
             .into_inner();
         assert_eq!(response.overall_code, i32::from(Code::OverLimit));
-        assert_eq!(
-            response.response_headers_to_add,
-            vec![
-                header_value("X-RateLimit-Limit", "10, 10;w=60"),
-                header_value("X-RateLimit-Remaining", "0"),
-            ],
-        );
+        assert_eq!(response.response_headers_to_add.len(), 3);
+        assert!(response
+            .response_headers_to_add
+            .contains(&header_value("X-RateLimit-Limit", "10, 10;w=60")));
+        assert!(response
+            .response_headers_to_add
+            .contains(&header_value("X-RateLimit-Remaining", "0")));
+        let reset_header = response
+            .response_headers_to_add
+            .iter()
+            .find(|h| h.key == "X-RateLimit-Reset")
+            .unwrap();
+        let reset_val: u64 = reset_header.value.parse().unwrap();
+        assert!(reset_val <= 60);
     }
 
     #[tokio::test]
@@ -679,13 +714,20 @@ pub mod tests {
             .unwrap()
             .into_inner();
         assert_eq!(response.overall_code, i32::from(Code::Ok));
-        assert_eq!(
-            response.response_headers_to_add,
-            vec![
-                header_value("X-RateLimit-Limit", "1, 1;w=60"),
-                header_value("X-RateLimit-Remaining", "0"),
-            ],
-        );
+        assert_eq!(response.response_headers_to_add.len(), 3);
+        assert!(response
+            .response_headers_to_add
+            .contains(&header_value("X-RateLimit-Limit", "1, 1;w=60")));
+        assert!(response
+            .response_headers_to_add
+            .contains(&header_value("X-RateLimit-Remaining", "0")));
+        let reset_header = response
+            .response_headers_to_add
+            .iter()
+            .find(|h| h.key == "X-RateLimit-Reset")
+            .unwrap();
+        let reset_val: u64 = reset_header.value.parse().unwrap();
+        assert!(reset_val <= 60);
 
         let response = rate_limiter
             .should_rate_limit(req.clone().into_request())
@@ -693,12 +735,19 @@ pub mod tests {
             .unwrap()
             .into_inner();
         assert_eq!(response.overall_code, i32::from(Code::OverLimit));
-        assert_eq!(
-            response.response_headers_to_add,
-            vec![
-                header_value("X-RateLimit-Limit", "1, 1;w=60"),
-                header_value("X-RateLimit-Remaining", "0"),
-            ],
-        );
+        assert_eq!(response.response_headers_to_add.len(), 3);
+        assert!(response
+            .response_headers_to_add
+            .contains(&header_value("X-RateLimit-Limit", "1, 1;w=60")));
+        assert!(response
+            .response_headers_to_add
+            .contains(&header_value("X-RateLimit-Remaining", "0")));
+        let reset_header = response
+            .response_headers_to_add
+            .iter()
+            .find(|h| h.key == "X-RateLimit-Reset")
+            .unwrap();
+        let reset_val: u64 = reset_header.value.parse().unwrap();
+        assert!(reset_val <= 60);
     }
 }

--- a/limitador/src/counter.rs
+++ b/limitador/src/counter.rs
@@ -115,7 +115,7 @@ impl Counter {
         for (var, value) in &self.set_variables {
             variables.push((var.as_str(), value.as_str()));
         }
-        variables.sort_by(|(key1, _), (key2, _)| key1.cmp(key2));
+        variables.sort_by_key(|(key1, _)| *key1);
         variables
     }
 }

--- a/limitador/src/storage/disk/rocksdb_storage.rs
+++ b/limitador/src/storage/disk/rocksdb_storage.rs
@@ -68,12 +68,7 @@ impl CounterStorage for RocksDbStorage {
 
             if load_counters {
                 counter.set_expires_in(ttl);
-                counter.set_remaining(
-                    counter
-                        .max_value()
-                        .checked_sub(val + delta)
-                        .unwrap_or_default(),
-                );
+                counter.set_remaining(counter.max_value().saturating_sub(val + delta));
             }
 
             if counter.max_value() < val + delta {

--- a/limitador/src/storage/distributed/grpc/mod.rs
+++ b/limitador/src/storage/distributed/grpc/mod.rs
@@ -586,8 +586,8 @@ impl Broker {
             let state = self.replication_state.read().await;
             state
                 .peer_trackers
-                .iter()
-                .filter_map(|(_, peer_tracker)| {
+                .values()
+                .filter_map(|peer_tracker| {
                     if peer_tracker.session.is_none() {
                         // first try to connect to the configured URL
                         let mut urls: Vec<_> = peer_tracker.url.iter().cloned().collect();

--- a/limitador/src/storage/in_memory.rs
+++ b/limitador/src/storage/in_memory.rs
@@ -111,6 +111,9 @@ impl CounterStorage for InMemoryStorage {
                     return Ok(limited);
                 }
             }
+            if load_counters {
+                counter.set_expires_in(atomic_expiring_value.ttl());
+            }
             counter_values_to_update.push((atomic_expiring_value, counter.window()));
         }
 
@@ -127,6 +130,9 @@ impl CounterStorage for InMemoryStorage {
                 if !load_counters {
                     return Ok(limited);
                 }
+            }
+            if load_counters {
+                counter.set_expires_in(value.ttl());
             }
 
             qualified_counter_values_to_updated.push((value, counter.window()));

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -88,11 +88,7 @@ impl AsyncCounterStorage for CachedRedisStorage {
                         first_limited = Some(a);
                     }
                     if load_counters {
-                        counter.set_remaining(
-                            val.remaining(counter)
-                                .checked_sub(delta)
-                                .unwrap_or_default(),
-                        );
+                        counter.set_remaining(val.remaining(counter).saturating_sub(delta));
                         counter.set_expires_in(val.ttl());
                     }
                 }


### PR DESCRIPTION
## Summary

Cherry-picked patch-safe fixes from `main` for the server v2.3.1 patch release (Kuadrant 1.4.4).

The `release-2.3` branch was created from the `server-v2.3.0` tag for this purpose — limitador previously used per-patch branches.

## Bug fix
- **Set counter expires_in for in-memory storage** — `X-RateLimit-Reset` header was missing when using the in-memory backend because `expires_in` was never populated on the counter. Includes updated tests.

## Code quality
- **clippy: use saturating_sub** — replaces manual checked subtraction with `saturating_sub`
- **address clippy issues for rustc 1.95.0** — compiler compatibility

## Dependency upgrades
- openssl 0.10.73 → 0.10.79 (security)
- actix-http 3.11.1 → 3.12.1
- time 0.3.41 → 0.3.47
- bytes 1.10.1 → 1.11.1

## Skipped (not patch-safe)
- s390x support (feature, new Dockerfiles + workflow changes)
- Additional tracing tags (feature, new span fields)
- ubi10 base image (base image change)
- Dev version bump (conflicts with release versioning)

## Test plan
- [ ] CI passes on the release-2.3 branch
- [ ] Verify `X-RateLimit-Reset` header present with in-memory storage backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)