### PR TITLE
Prepare release server v2.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "limitador-server"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limitador-server"
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Alex Snaps <asnaps@redhat.com>", "Eguzki Astiz Lezaun <eguzki@redhat.com>", "David Ortiz <z.david.ortiz@gmail.com>"]
 license = "Apache-2.0"
 keywords = ["rate-limiting", "rate", "limiter", "envoy", "rls"]


### PR DESCRIPTION
Bump limitador-server version to 2.3.1 for Kuadrant 1.4.4 patch release.