### PR TITLE
[post-release] Bump Crate to 0.13.0-dev and Server to 2.5.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,7 +2041,7 @@ dependencies = [
 
 [[package]]
 name = "limitador"
-version = "0.12.0-dev"
+version = "0.13.0-dev"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "limitador-server"
-version = "2.4.0-dev"
+version = "2.5.0-dev"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limitador-server"
-version = "2.4.0"
+version = "2.5.0-dev"
 authors = ["Alex Snaps <asnaps@redhat.com>", "Eguzki Astiz Lezaun <eguzki@redhat.com>", "David Ortiz <z.david.ortiz@gmail.com>"]
 license = "Apache-2.0"
 keywords = ["rate-limiting", "rate", "limiter", "envoy", "rls"]

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limitador-server"
-version = "2.4.0-dev"
+version = "2.4.0"
 authors = ["Alex Snaps <asnaps@redhat.com>", "Eguzki Astiz Lezaun <eguzki@redhat.com>", "David Ortiz <z.david.ortiz@gmail.com>"]
 license = "Apache-2.0"
 keywords = ["rate-limiting", "rate", "limiter", "envoy", "rls"]

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limitador"
-version = "0.12.0-dev"
+version = "0.12.0"
 authors = ["David Ortiz <z.david.ortiz@gmail.com>", "Eguzki Astiz Lezaun <eguzki@redhat.com>", "Alex Snaps <asnaps@redhat.com>"]
 license = "Apache-2.0"
 keywords = ["rate-limiting", "rate", "limiter"]

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limitador"
-version = "0.12.0"
+version = "0.13.0-dev"
 authors = ["David Ortiz <z.david.ortiz@gmail.com>", "Eguzki Astiz Lezaun <eguzki@redhat.com>", "Alex Snaps <asnaps@redhat.com>"]
 license = "Apache-2.0"
 keywords = ["rate-limiting", "rate", "limiter"]


### PR DESCRIPTION
Automated version bump after v2.4.0 release.

This PR bumps the versions of the Crate to 0.13.0-dev and the Server to 2.5.0-dev  for continued development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package versions: limitador-server to 2.5.0-dev and limitador to 0.13.0-dev. No other manifest fields, dependencies or public APIs were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->