### PR TITLE
Prepare release server v2.4.1 / crate v0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,7 +2041,7 @@ dependencies = [
 
 [[package]]
 name = "limitador"
-version = "0.12.0-dev"
+version = "0.12.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "limitador-server"
-version = "2.4.0-dev"
+version = "2.4.1"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limitador-server"
-version = "2.4.0"
+version = "2.4.1"
 authors = ["Alex Snaps <asnaps@redhat.com>", "Eguzki Astiz Lezaun <eguzki@redhat.com>", "David Ortiz <z.david.ortiz@gmail.com>"]
 license = "Apache-2.0"
 keywords = ["rate-limiting", "rate", "limiter", "envoy", "rls"]

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limitador"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["David Ortiz <z.david.ortiz@gmail.com>", "Eguzki Astiz Lezaun <eguzki@redhat.com>", "Alex Snaps <asnaps@redhat.com>"]
 license = "Apache-2.0"
 keywords = ["rate-limiting", "rate", "limiter"]


### PR DESCRIPTION
## Summary

Fixes the Cargo.lock version mismatch from the v2.4.0 release that is causing downstream build failures.

## Problem

The v2.4.0 release commit updated `Cargo.toml` (removing `-dev` suffix) but did not update `Cargo.lock`. Result: `Cargo.toml` says `2.4.0` / `0.12.0` but `Cargo.lock` says `2.4.0-dev` / `0.12.0-dev`.

Compare the correct v2.3.0 release ([`0e50bb9`](https://github.com/Kuadrant/limitador/commit/0e50bb99b141b99ca489472804c52081231254eb)) which updated all 3 files, vs the broken v2.4.0 release ([`90bba7d`](https://github.com/Kuadrant/limitador/commit/90bba7da06caffa92f3af068a14ad6f99f59639f)) which missed `Cargo.lock`.

## Fix

Bump to v2.4.1 / v0.12.1 with correctly synced `Cargo.lock`.

## Note on release-2.4 branch

This branch was created from the current `v2.4.0` tag commit (which was re-tagged from main on May 28, not from the original `release-v2.4` branch). This follows RFC 0018 naming (`release-X.Y` without `v` prefix).

## Follow-up needed

After this merges and is tagged:
- limitador-operator: update `LIMITADOR_VERSION` to `2.4.1`, release v0.18.2
- kuadrant-operator: update `release.yaml`, release v1.5.0-rc2

🤖 Generated with [Claude Code](https://claude.com/claude-code)