### PR TITLE
Backport patch-safe fixes for v2.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ dependencies = [
  "bitflags 2.9.3",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1646,7 +1646,7 @@ dependencies = [
  "hyper 1.7.0",
  "libc",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -1870,7 +1870,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2467,9 +2467,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.9.3",
  "cfg-if",
@@ -2507,9 +2507,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -46,7 +46,7 @@ const_format = "0.2.31"
 lazy_static = "1.4.0"
 clap = "4.3"
 sysinfo = "0.32"
-openssl = { version = "0.10.79", features = ["vendored"] }
+openssl = { version = "0.10.80", features = ["vendored"] }
 metrics = "0.24.2"
 metrics-exporter-prometheus = { version = "0.17.2", default-features = false, features = ["http-listener"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/limitador-server/src/config.rs
+++ b/limitador-server/src/config.rs
@@ -81,6 +81,7 @@ pub mod env {
         pub static ref RATE_LIMIT_HEADERS: Option<&'static str> = value_for("RATE_LIMIT_HEADERS");
     }
 
+    #[allow(dead_code)] // used by lazy_static! initializers; flagged in test-only builds
     fn value_for(env_key: &'static str) -> Option<&'static str> {
         match std::env::var(env_key) {
             Ok(s) => Some(Box::leak(s.into_boxed_str())),
@@ -88,6 +89,7 @@ pub mod env {
         }
     }
 
+    #[allow(dead_code)] // used by lazy_static! initializers; flagged in test-only builds
     fn env_option_is_enabled(env_name: &str) -> bool {
         match env::var(env_name) {
             Ok(value) => value == "1",

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -393,15 +393,10 @@ impl RateLimiter {
         // stop on first errors
         // stop on first counter not withing limits
         for counter in counters.iter() {
-            match self.storage.is_within_limits(counter, delta) {
-                Ok(within_limits) => {
-                    if !within_limits {
-                        return Ok(Authorization::Limited(
-                            counter.limit().name().map(|n| n.to_owned()),
-                        ));
-                    }
-                }
-                Err(e) => return Err(e),
+            if !self.storage.is_within_limits(counter, delta)? {
+                return Ok(Authorization::Limited(
+                    counter.limit().name().map(|n| n.to_owned()),
+                ));
             }
         }
 

--- a/limitador/src/storage/distributed/mod.rs
+++ b/limitador/src/storage/distributed/mod.rs
@@ -185,7 +185,7 @@ impl CounterStorage for CrInMemoryStorage {
     fn get_counters(&self, limits: &HashSet<Arc<Limit>>) -> Result<HashSet<Counter>, StorageErr> {
         let mut res = HashSet::new();
         let limits_map = self.limits.read().unwrap();
-        for (_, counter_entry) in limits_map.iter() {
+        for counter_entry in limits_map.values() {
             if limits.contains(counter_entry.counter.limit()) {
                 let mut counter: Counter = counter_entry.counter.clone();
                 counter.set_remaining(counter.max_value() - counter_entry.value.read());


### PR DESCRIPTION
## Summary

Cherry-picked 3 patch-safe fixes from main for a v2.4.2 release.

- `58af0f5` — Fix: suppress `dead_code` false positives on lazy_static helpers
- `0436fdb` — Fix: resolve Clippy lint errors from Rust 1.97 lint promotions
- `9467913` — Deps: bump openssl from 0.10.79 to 0.10.80 (security)

**Excluded:**
- `254a277` — Post-release dev version bump (0.13.0-dev / 2.5.0-dev) — not appropriate for patch

## Test plan
- [x] `cargo check` passes
- [x] CI passes on this PR