### PR TITLE
Prepare release server v2.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "limitador-server"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limitador-server"
-version = "2.4.1"
+version = "2.4.2"
 authors = ["Alex Snaps <asnaps@redhat.com>", "Eguzki Astiz Lezaun <eguzki@redhat.com>", "David Ortiz <z.david.ortiz@gmail.com>"]
 license = "Apache-2.0"
 keywords = ["rate-limiting", "rate", "limiter", "envoy", "rls"]


### PR DESCRIPTION
Bump limitador-server version from 2.4.1 to 2.4.2.

Crate version unchanged at 0.12.1 — no crate release needed (changes are server-side only: lint fixes + openssl security bump).

Once merged, tag `v2.4.2` from the release branch and create the GitHub release.