### PR TITLE
Add two-phase release process with automated workflows

### DIFF
--- a/.github/actions/install-yq/action.yaml
+++ b/.github/actions/install-yq/action.yaml
@@ -1,0 +1,18 @@
+name: Install yq
+description: Install mikefarah/yq at a pinned version
+
+inputs:
+  version:
+    description: "yq version to install"
+    required: false
+    default: "4.53.3"
+
+runs:
+  using: composite
+  steps:
+    - name: Install yq v${{ inputs.version }}
+      shell: bash
+      run: |
+        sudo wget -qO /usr/local/bin/yq \
+          "https://github.com/mikefarah/yq/releases/download/v${{ inputs.version }}/yq_linux_amd64"
+        sudo chmod +x /usr/local/bin/yq

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -146,3 +146,89 @@ EOF
 # ::error::Dependency 'some-repo' targets version '99.99.99', but release v99.99.99 does not exist in Kuadrant/some-repo
 # exit code: 1
 ```
+
+## sync-release-yaml.sh
+
+Reads package versions from `Cargo.toml` via `cargo metadata` and writes them into `release.yaml`. If the Cargo.toml versions end in `-dev` (as on `main`), writes `0.0.0` sentinel values instead. This keeps `release.yaml` as a generated mirror of the authoritative `Cargo.toml` versions.
+
+### Usage
+
+```sh
+.github/scripts/sync-release-yaml.sh [path-to-release-yaml]
+```
+
+### Examples
+
+After setting release versions in Cargo.toml:
+
+```sh
+cargo set-version --offline -p limitador 0.13.0
+cargo set-version --offline -p limitador-server 2.5.0
+.github/scripts/sync-release-yaml.sh
+cat release.yaml
+# limitador:
+#   version: "2.5.0"
+#   crate-version: "0.13.0"
+# dependencies: {}
+```
+
+On main with dev versions (`0.13.0-dev`, `2.5.0-dev`):
+
+```sh
+.github/scripts/sync-release-yaml.sh
+cat release.yaml
+# limitador:
+#   version: "0.0.0"
+#   crate-version: "0.0.0"
+# dependencies: {}
+```
+
+## check-versions.sh
+
+Validates that `release.yaml` and `Cargo.toml` versions agree. On `main`, `release.yaml` at `0.0.0` is valid if and only if the corresponding `Cargo.toml` version ends in `-dev`. Otherwise, versions must match exactly.
+
+### Usage
+
+```sh
+.github/scripts/check-versions.sh [path-to-release-yaml]
+```
+
+### Examples
+
+On main (sentinel + dev versions — passes):
+
+```sh
+# release.yaml has 0.0.0/0.0.0, Cargo.toml has 2.5.0-dev/0.13.0-dev
+.github/scripts/check-versions.sh
+# Version consistency check passed: release.yaml and Cargo.toml agree
+#   Server: release.yaml=0.0.0 Cargo.toml=2.5.0-dev
+#   Crate:  release.yaml=0.0.0 Cargo.toml=0.13.0-dev
+```
+
+On a release branch (exact match required — passes):
+
+```sh
+# release.yaml has 2.5.0/0.13.0, Cargo.toml has 2.5.0/0.13.0
+.github/scripts/check-versions.sh
+# Version consistency check passed
+```
+
+### Error cases
+
+Mismatch on a release branch:
+
+```sh
+# release.yaml has 2.5.0 but Cargo.toml has 2.5.1
+.github/scripts/check-versions.sh
+# ::error::Server version mismatch: release.yaml has '2.5.0' but Cargo.toml has '2.5.1'
+# exit code: 1
+```
+
+Sentinel 0.0.0 without -dev in Cargo.toml:
+
+```sh
+# release.yaml has 0.0.0 but Cargo.toml has 2.5.0 (no -dev)
+.github/scripts/check-versions.sh
+# ::error::release.yaml version is 0.0.0 but limitador-server Cargo.toml version '2.5.0' does not end in -dev
+# exit code: 1
+```

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,148 @@
+# Release Scripts
+
+Helper scripts used by the release workflows. Both require [yq](https://github.com/mikefarah/yq) to be installed.
+
+## parse-version.sh
+
+Reads `release.yaml`, validates that both `version` and `crate-version` are valid semver, and outputs version components. In CI it writes to `$GITHUB_OUTPUT`; locally it prints to stdout.
+
+### Usage
+
+```sh
+.github/scripts/parse-version.sh [path-to-release-yaml]
+```
+
+### Examples
+
+Using the default `release.yaml` at the repo root:
+
+```sh
+.github/scripts/parse-version.sh
+```
+
+Using a custom file:
+
+```sh
+cat > /tmp/test-release.yaml <<'EOF'
+limitador:
+  version: "2.5.0"
+  crate-version: "0.13.0"
+
+dependencies: {}
+EOF
+
+.github/scripts/parse-version.sh /tmp/test-release.yaml
+```
+
+Expected output:
+
+```text
+version=2.5.0
+major=2
+minor=5
+patch=0
+release-branch=release-2.5
+crate-version=0.13.0
+crate-major=0
+crate-minor=13
+crate-patch=0
+```
+
+### Error cases
+
+Invalid semver:
+
+```sh
+cat > /tmp/bad.yaml <<'EOF'
+limitador:
+  version: "not-a-version"
+  crate-version: "0.13.0"
+dependencies: {}
+EOF
+
+.github/scripts/parse-version.sh /tmp/bad.yaml
+# ::error::Invalid semver for version: not-a-version
+# exit code: 1
+```
+
+## validate-release-yaml.sh
+
+Validates version gating rules for the version-gate CI check. On release branches it rejects `0.0.0` sentinel values and `-dev` suffixed versions. For any declared dependencies, it verifies the corresponding GitHub Release exists.
+
+### Usage
+
+```sh
+.github/scripts/validate-release-yaml.sh <branch-name> [org] [path-to-release-yaml]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `branch-name` | yes | | The branch name to validate against (e.g. `main`, `release-2.5`) |
+| `org` | no | `Kuadrant` | GitHub organization for dependency release lookups |
+| `path-to-release-yaml` | no | `release.yaml` | Path to the release.yaml file |
+
+### Examples
+
+Validating on `main` (sentinel `0.0.0` is allowed):
+
+```sh
+.github/scripts/validate-release-yaml.sh main
+# release.yaml validation passed
+```
+
+Validating on a release branch with the default `release.yaml` (should fail because versions are `0.0.0` on main):
+
+```sh
+.github/scripts/validate-release-yaml.sh release-2.5
+# ::error::release.yaml version is 0.0.0 on branch 'release-2.5' ...
+# exit code: 1
+```
+
+Validating on a release branch with proper versions:
+
+```sh
+cat > /tmp/release-test.yaml <<'EOF'
+limitador:
+  version: "2.5.0"
+  crate-version: "0.13.0"
+
+dependencies: {}
+EOF
+
+.github/scripts/validate-release-yaml.sh release-2.5 Kuadrant /tmp/release-test.yaml
+# release.yaml validation passed
+```
+
+### Error cases
+
+Dev version on a release branch:
+
+```sh
+cat > /tmp/dev.yaml <<'EOF'
+limitador:
+  version: "2.5.0-dev"
+  crate-version: "0.13.0"
+dependencies: {}
+EOF
+
+.github/scripts/validate-release-yaml.sh release-2.5 Kuadrant /tmp/dev.yaml
+# ::error::release.yaml version '2.5.0-dev' is a dev version on branch 'release-2.5' ...
+# exit code: 1
+```
+
+Missing dependency release (requires `gh` CLI and authentication):
+
+```sh
+cat > /tmp/deps.yaml <<'EOF'
+limitador:
+  version: "2.5.0"
+  crate-version: "0.13.0"
+
+dependencies:
+  some-repo: "99.99.99"
+EOF
+
+.github/scripts/validate-release-yaml.sh release-2.5 Kuadrant /tmp/deps.yaml
+# ::error::Dependency 'some-repo' targets version '99.99.99', but release v99.99.99 does not exist in Kuadrant/some-repo
+# exit code: 1
+```

--- a/.github/scripts/check-versions.sh
+++ b/.github/scripts/check-versions.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RELEASE_YAML="${1:-release.yaml}"
+
+if [[ ! -f "$RELEASE_YAML" ]]; then
+  echo "::error::File not found: $RELEASE_YAML"
+  exit 1
+fi
+
+YAML_VERSION=$(yq '.limitador.version' "$RELEASE_YAML")
+YAML_CRATE_VERSION=$(yq '.limitador."crate-version"' "$RELEASE_YAML")
+
+CARGO_SERVER_VERSION=$(cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(.name=="limitador-server") | .version')
+CARGO_CRATE_VERSION=$(cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(.name=="limitador") | .version')
+
+ERRORS=0
+
+# Special case: release.yaml 0.0.0 is valid alongside Cargo.toml -dev versions
+if [[ "$YAML_VERSION" == "0.0.0" ]]; then
+  if [[ "$CARGO_SERVER_VERSION" != *-dev* ]]; then
+    echo "::error::release.yaml version is 0.0.0 but limitador-server Cargo.toml version '${CARGO_SERVER_VERSION}' does not end in -dev"
+    ERRORS=$((ERRORS + 1))
+  fi
+else
+  if [[ "$YAML_VERSION" != "$CARGO_SERVER_VERSION" ]]; then
+    echo "::error::Server version mismatch: release.yaml has '${YAML_VERSION}' but Cargo.toml has '${CARGO_SERVER_VERSION}'"
+    ERRORS=$((ERRORS + 1))
+  fi
+fi
+
+if [[ "$YAML_CRATE_VERSION" == "0.0.0" ]]; then
+  if [[ "$CARGO_CRATE_VERSION" != *-dev* ]]; then
+    echo "::error::release.yaml crate-version is 0.0.0 but limitador Cargo.toml version '${CARGO_CRATE_VERSION}' does not end in -dev"
+    ERRORS=$((ERRORS + 1))
+  fi
+else
+  if [[ "$YAML_CRATE_VERSION" != "$CARGO_CRATE_VERSION" ]]; then
+    echo "::error::Crate version mismatch: release.yaml has '${YAML_CRATE_VERSION}' but Cargo.toml has '${CARGO_CRATE_VERSION}'"
+    ERRORS=$((ERRORS + 1))
+  fi
+fi
+
+if [[ "$ERRORS" -gt 0 ]]; then
+  echo "::error::Version consistency check failed with ${ERRORS} error(s)"
+  exit 1
+fi
+
+echo "Version consistency check passed: release.yaml and Cargo.toml agree"
+echo "  Server: release.yaml=${YAML_VERSION} Cargo.toml=${CARGO_SERVER_VERSION}"
+echo "  Crate:  release.yaml=${YAML_CRATE_VERSION} Cargo.toml=${CARGO_CRATE_VERSION}"

--- a/.github/scripts/parse-version.sh
+++ b/.github/scripts/parse-version.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RELEASE_YAML="${1:-release.yaml}"
+
+if [[ ! -f "$RELEASE_YAML" ]]; then
+  echo "::error::File not found: $RELEASE_YAML"
+  exit 1
+fi
+
+VERSION=$(yq '.limitador.version' "$RELEASE_YAML")
+if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+  echo "::error::No version found in $RELEASE_YAML under limitador.version"
+  exit 1
+fi
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+  echo "::error::Invalid semver for version: $VERSION"
+  exit 1
+fi
+
+CRATE_VERSION=$(yq '.limitador."crate-version"' "$RELEASE_YAML")
+if [[ -z "$CRATE_VERSION" || "$CRATE_VERSION" == "null" ]]; then
+  echo "::error::No crate-version found in $RELEASE_YAML under limitador.crate-version"
+  exit 1
+fi
+
+if ! [[ "$CRATE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+  echo "::error::Invalid semver for crate-version: $CRATE_VERSION"
+  exit 1
+fi
+
+MAJOR=$(echo "$VERSION" | cut --delimiter=. --fields=1)
+MINOR=$(echo "$VERSION" | cut --delimiter=. --fields=2)
+PATCH=$(echo "$VERSION" | cut --delimiter=. --fields=3 | cut --delimiter=- --fields=1)
+RELEASE_BRANCH="release-${MAJOR}.${MINOR}"
+
+CRATE_MAJOR=$(echo "$CRATE_VERSION" | cut --delimiter=. --fields=1)
+CRATE_MINOR=$(echo "$CRATE_VERSION" | cut --delimiter=. --fields=2)
+CRATE_PATCH=$(echo "$CRATE_VERSION" | cut --delimiter=. --fields=3 | cut --delimiter=- --fields=1)
+
+echo "version=$VERSION" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+echo "major=$MAJOR" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+echo "minor=$MINOR" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+echo "patch=$PATCH" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+echo "release-branch=$RELEASE_BRANCH" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+echo "crate-version=$CRATE_VERSION" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+echo "crate-major=$CRATE_MAJOR" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+echo "crate-minor=$CRATE_MINOR" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+echo "crate-patch=$CRATE_PATCH" >> "${GITHUB_OUTPUT:-/dev/stdout}"

--- a/.github/scripts/sync-release-yaml.sh
+++ b/.github/scripts/sync-release-yaml.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RELEASE_YAML="${1:-release.yaml}"
+
+CRATE_VERSION=$(cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(.name=="limitador") | .version')
+SERVER_VERSION=$(cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(.name=="limitador-server") | .version')
+
+if [[ -z "$CRATE_VERSION" || "$CRATE_VERSION" == "null" ]]; then
+  echo "::error::Could not read limitador version from cargo metadata"
+  exit 1
+fi
+
+if [[ -z "$SERVER_VERSION" || "$SERVER_VERSION" == "null" ]]; then
+  echo "::error::Could not read limitador-server version from cargo metadata"
+  exit 1
+fi
+
+# On main, Cargo.toml has -dev versions but release.yaml uses 0.0.0 sentinel.
+# Strip -dev suffix: if present, write 0.0.0 instead.
+if [[ "$SERVER_VERSION" == *-dev* ]]; then
+  SERVER_VERSION="0.0.0"
+fi
+if [[ "$CRATE_VERSION" == *-dev* ]]; then
+  CRATE_VERSION="0.0.0"
+fi
+
+yq --inplace ".limitador.version = \"${SERVER_VERSION}\"" "$RELEASE_YAML"
+yq --inplace ".limitador.\"crate-version\" = \"${CRATE_VERSION}\"" "$RELEASE_YAML"
+
+echo "release.yaml synced: version=${SERVER_VERSION}, crate-version=${CRATE_VERSION}"

--- a/.github/scripts/validate-release-yaml.sh
+++ b/.github/scripts/validate-release-yaml.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BRANCH="${1:?Branch name required}"
+ORG="${2:-Kuadrant}"
+RELEASE_YAML="${3:-release.yaml}"
+
+if [[ ! -f "$RELEASE_YAML" ]]; then
+  echo "::error::File not found: $RELEASE_YAML"
+  exit 1
+fi
+
+VERSION=$(yq '.limitador.version' "$RELEASE_YAML")
+CRATE_VERSION=$(yq '.limitador."crate-version"' "$RELEASE_YAML")
+
+if [[ "$BRANCH" =~ ^release- ]]; then
+  if [[ "$VERSION" == "0.0.0" ]]; then
+    echo "::error::release.yaml version is 0.0.0 on branch '$BRANCH' -- must specify a release version on release branches"
+    exit 1
+  fi
+
+  if [[ "$VERSION" == *-dev* ]]; then
+    echo "::error::release.yaml version '${VERSION}' is a dev version on branch '$BRANCH' -- release versions must not contain '-dev'"
+    exit 1
+  fi
+
+  if [[ "$CRATE_VERSION" == "0.0.0" ]]; then
+    echo "::error::release.yaml crate-version is 0.0.0 on branch '$BRANCH' -- must specify a crate version on release branches"
+    exit 1
+  fi
+
+  if [[ "$CRATE_VERSION" == *-dev* ]]; then
+    echo "::error::release.yaml crate-version '${CRATE_VERSION}' is a dev version on branch '$BRANCH' -- release versions must not contain '-dev'"
+    exit 1
+  fi
+fi
+
+DEPS=$(yq '.dependencies | keys | .[]' "$RELEASE_YAML" 2>/dev/null || true)
+for dep in $DEPS; do
+  dep_version=$(yq ".dependencies.${dep}" "$RELEASE_YAML")
+  if [[ "$dep_version" != "0.0.0" && "$dep_version" != "null" && -n "$dep_version" ]]; then
+    if ! gh release view "v${dep_version}" --repo "${ORG}/${dep}" &>/dev/null; then
+      echo "::error::Dependency '${dep}' targets version '${dep_version}', but release v${dep_version} does not exist in ${ORG}/${dep}"
+      exit 1
+    fi
+  fi
+done
+
+echo "release.yaml validation passed"

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -2,12 +2,20 @@
 name: Build Image
 
 on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to check out"
+        required: true
+        type: string
+      tag:
+        description: "Image tag to apply"
+        required: true
+        type: string
   workflow_dispatch:
   push:
     branches:
       - main
-    tags:
-      - "*"
 
 env:
   IMG_REGISTRY_HOST: quay.io
@@ -37,6 +45,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Docker meta
@@ -99,12 +109,14 @@ jobs:
           images: |
             ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/limitador
           tags: |
+            # When called from release workflow, use the provided tag
+            type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
             # SHA tag for main branch
-            type=raw,value=${{ github.sha }},enable=${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+            type=raw,value=${{ github.sha }},enable=${{ inputs.tag == '' && github.ref_name == env.MAIN_BRANCH_NAME }}
             # set latest tag for main branch
-            type=raw,value=latest,enable=${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+            type=raw,value=latest,enable=${{ inputs.tag == '' && github.ref_name == env.MAIN_BRANCH_NAME }}
             # set ref name tag for non-main branches
-            type=raw,value=${{ github.ref_name }},enable=${{ github.ref_name != env.MAIN_BRANCH_NAME }}
+            type=raw,value=${{ github.ref_name }},enable=${{ inputs.tag == '' && github.ref_name != env.MAIN_BRANCH_NAME }}
       - name: Login to container registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -55,6 +55,9 @@ jobs:
         with:
           images: |
             ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/limitador
+      - name: Resolve checked-out SHA
+        id: sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Login to container registry
         uses: docker/login-action@v2
         with:
@@ -68,7 +71,7 @@ jobs:
           context: .
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            GITHUB_SHA=${{ github.sha }}
+            GITHUB_SHA=${{ steps.sha.outputs.sha }}
           cache-from: type=gha,scope=${{ matrix.scope }}
           cache-to: type=gha,mode=max,scope=${{ matrix.scope}}
           outputs: type=image,name=${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/limitador,push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,0 +1,281 @@
+---
+name: Pre-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Server release version (semver, e.g. 2.5.0)"
+        required: true
+        type: string
+      crate-version:
+        description: "Crate release version (semver, e.g. 0.13.0)"
+        required: true
+        type: string
+      source-branch:
+        description: "Branch to base the pre-release on (default: main for new releases, release branch for patches)"
+        required: false
+        type: string
+        default: "main"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pre-release
+  cancel-in-progress: false
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.validate.outputs.version }}
+      crate-version: ${{ steps.validate.outputs.crate-version }}
+      release-branch: ${{ steps.validate.outputs.release-branch }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.source-branch }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate version format
+        id: validate
+        env:
+          VERSION: ${{ inputs.version }}
+          CRATE_VERSION: ${{ inputs.crate-version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid semver for server version: $VERSION"
+            exit 1
+          fi
+
+          if ! [[ "$CRATE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid semver for crate version: $CRATE_VERSION"
+            exit 1
+          fi
+
+          MAJOR=$(echo "$VERSION" | cut --delimiter=. --fields=1)
+          MINOR=$(echo "$VERSION" | cut --delimiter=. --fields=2)
+          RELEASE_BRANCH="release-${MAJOR}.${MINOR}"
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "crate-version=$CRATE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "release-branch=$RELEASE_BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Create or verify release branch
+        env:
+          RELEASE_BRANCH: ${{ steps.validate.outputs.release-branch }}
+        run: |
+          if git ls-remote --exit-code origin "refs/heads/${RELEASE_BRANCH}" >/dev/null 2>&1; then
+            echo "Release branch '${RELEASE_BRANCH}' already exists"
+          else
+            echo "Creating release branch '${RELEASE_BRANCH}'"
+            git switch --create "${RELEASE_BRANCH}"
+            git push origin "${RELEASE_BRANCH}"
+          fi
+
+  prepare-release:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.setup.outputs.release-branch }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - uses: abelfodil/protoc-action@v1
+        with:
+          protoc-version: "3.19.4"
+
+      - uses: ./.github/actions/install-yq
+
+      - name: Create pre-release branch
+        env:
+          VERSION: ${{ needs.setup.outputs.version }}
+        run: |
+          PRE_RELEASE_BRANCH="pre-release-v${VERSION}"
+          if git ls-remote --exit-code origin "refs/heads/${PRE_RELEASE_BRANCH}" >/dev/null 2>&1; then
+            echo "::error::Pre-release branch '${PRE_RELEASE_BRANCH}' already exists. Delete it first or use a different version."
+            exit 1
+          fi
+          git switch --create "${PRE_RELEASE_BRANCH}"
+
+      - name: Update release.yaml
+        env:
+          VERSION: ${{ needs.setup.outputs.version }}
+          CRATE_VERSION: ${{ needs.setup.outputs.crate-version }}
+        run: |
+          yq --inplace ".limitador.version = \"${VERSION}\"" release.yaml
+          yq --inplace ".limitador.\"crate-version\" = \"${CRATE_VERSION}\"" release.yaml
+
+      - name: Update Cargo.toml versions
+        env:
+          VERSION: ${{ needs.setup.outputs.version }}
+          CRATE_VERSION: ${{ needs.setup.outputs.crate-version }}
+        run: |
+          sed --in-place '/^\[package\]/,/^\[/{s/^version = ".*"/version = "'"${CRATE_VERSION}"'"/}' limitador/Cargo.toml
+          sed --in-place '/^\[package\]/,/^\[/{s/^version = ".*"/version = "'"${VERSION}"'"/}' limitador-server/Cargo.toml
+
+      - name: Update Cargo.lock
+        run: cargo check
+
+      - name: Commit and push changes
+        env:
+          VERSION: ${{ needs.setup.outputs.version }}
+          CRATE_VERSION: ${{ needs.setup.outputs.crate-version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add --all
+          if git diff --cached --quiet; then
+            echo "::error::No changes detected. Versions may already be set to the target values."
+            exit 1
+          fi
+          git commit --message "chore: prepare release server v${VERSION} / crate v${CRATE_VERSION}"
+          git push origin "pre-release-v${VERSION}"
+
+  open-pr:
+    needs: [setup, prepare-release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Open pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.setup.outputs.version }}
+          CRATE_VERSION: ${{ needs.setup.outputs.crate-version }}
+          RELEASE_BRANCH: ${{ needs.setup.outputs.release-branch }}
+        run: |
+          BODY=$(cat <<EOF
+          ## Release server v${VERSION} / crate v${CRATE_VERSION}
+
+          This PR prepares the release of limitador-server v${VERSION} and limitador crate v${CRATE_VERSION}.
+
+          ### Pre-release changes
+          - Updated \`release.yaml\` with version \`${VERSION}\` and crate-version \`${CRATE_VERSION}\`
+          - Set \`limitador/Cargo.toml\` version to \`${CRATE_VERSION}\`
+          - Set \`limitador-server/Cargo.toml\` version to \`${VERSION}\`
+          - Updated \`Cargo.lock\`
+
+          ### Checklist
+          - [ ] Version numbers are correct in both Cargo.toml files
+          - [ ] \`release.yaml\` versions match Cargo.toml versions
+          - [ ] CI checks pass
+          - [ ] Version gate check passes
+
+          ### Next steps
+          After merging this PR, run the **Release** workflow with branch \`${RELEASE_BRANCH}\`.
+          EOF
+          )
+
+          gh pr create \
+            --base "${RELEASE_BRANCH}" \
+            --head "pre-release-v${VERSION}" \
+            --title "Release server v${VERSION} / crate v${CRATE_VERSION}" \
+            --body "$BODY"
+
+  post-release:
+    if: inputs.source-branch == 'main'
+    needs: [setup, open-pr]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - uses: abelfodil/protoc-action@v1
+        with:
+          protoc-version: "3.19.4"
+
+      - name: Compute next dev versions
+        id: next
+        env:
+          VERSION: ${{ needs.setup.outputs.version }}
+          CRATE_VERSION: ${{ needs.setup.outputs.crate-version }}
+        run: |
+          MAJOR=$(echo "$VERSION" | cut --delimiter=. --fields=1)
+          MINOR=$(echo "$VERSION" | cut --delimiter=. --fields=2)
+          NEXT_MINOR=$((MINOR + 1))
+          NEXT_VERSION="${MAJOR}.${NEXT_MINOR}.0-dev"
+
+          CRATE_MAJOR=$(echo "$CRATE_VERSION" | cut --delimiter=. --fields=1)
+          CRATE_MINOR=$(echo "$CRATE_VERSION" | cut --delimiter=. --fields=2)
+          NEXT_CRATE_MINOR=$((CRATE_MINOR + 1))
+          NEXT_CRATE_VERSION="${CRATE_MAJOR}.${NEXT_CRATE_MINOR}.0-dev"
+
+          echo "version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "crate-version=${NEXT_CRATE_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Create post-release branch
+        env:
+          VERSION: ${{ needs.setup.outputs.version }}
+        run: |
+          POST_RELEASE_BRANCH="post-release-v${VERSION}"
+          if git ls-remote --exit-code origin "refs/heads/${POST_RELEASE_BRANCH}" >/dev/null 2>&1; then
+            echo "::error::Post-release branch '${POST_RELEASE_BRANCH}' already exists. Delete it first or use a different version."
+            exit 1
+          fi
+          git switch --create "${POST_RELEASE_BRANCH}"
+
+      - name: Update Cargo.toml versions
+        env:
+          NEXT_VERSION: ${{ steps.next.outputs.version }}
+          NEXT_CRATE_VERSION: ${{ steps.next.outputs.crate-version }}
+        run: |
+          sed --in-place '/^\[package\]/,/^\[/{s/^version = ".*"/version = "'"${NEXT_CRATE_VERSION}"'"/}' limitador/Cargo.toml
+          sed --in-place '/^\[package\]/,/^\[/{s/^version = ".*"/version = "'"${NEXT_VERSION}"'"/}' limitador-server/Cargo.toml
+
+      - name: Update Cargo.lock
+        run: cargo check
+
+      - name: Commit and push changes
+        id: commit
+        env:
+          VERSION: ${{ needs.setup.outputs.version }}
+          NEXT_VERSION: ${{ steps.next.outputs.version }}
+          NEXT_CRATE_VERSION: ${{ steps.next.outputs.crate-version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add --all
+          if git diff --cached --quiet; then
+            echo "Versions already at next dev. Skipping post-release PR."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git commit --message "chore: bump to server v${NEXT_VERSION} / crate v${NEXT_CRATE_VERSION}"
+          git push origin "post-release-v${VERSION}"
+
+      - name: Open post-release pull request
+        if: steps.commit.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.setup.outputs.version }}
+          NEXT_VERSION: ${{ steps.next.outputs.version }}
+          NEXT_CRATE_VERSION: ${{ steps.next.outputs.crate-version }}
+        run: |
+          BODY=$(cat <<EOF
+          ## Post-release version bump after server v${VERSION}
+
+          Bumps development versions:
+          - \`limitador/Cargo.toml\` → \`${NEXT_CRATE_VERSION}\`
+          - \`limitador-server/Cargo.toml\` → \`${NEXT_VERSION}\`
+
+          > **Do not merge this PR until the release of server v${VERSION} is complete.**
+          EOF
+          )
+
+          gh pr create \
+            --base main \
+            --head "post-release-v${VERSION}" \
+            --title "Post-release: bump to server v${NEXT_VERSION} / crate v${NEXT_CRATE_VERSION}" \
+            --body "$BODY"

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -88,11 +88,15 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      - uses: Swatinem/rust-cache@v2
+
       - uses: abelfodil/protoc-action@v1
         with:
           protoc-version: "3.19.4"
 
       - uses: ./.github/actions/install-yq
+
+      - run: cargo install cargo-edit --version 0.13.13
 
       - name: Create pre-release branch
         env:
@@ -105,21 +109,37 @@ jobs:
           fi
           git switch --create "${PRE_RELEASE_BRANCH}"
 
-      - name: Update release.yaml
-        env:
-          VERSION: ${{ needs.setup.outputs.version }}
-          CRATE_VERSION: ${{ needs.setup.outputs.crate-version }}
-        run: |
-          yq --inplace ".limitador.version = \"${VERSION}\"" release.yaml
-          yq --inplace ".limitador.\"crate-version\" = \"${CRATE_VERSION}\"" release.yaml
-
       - name: Update Cargo.toml versions
         env:
           VERSION: ${{ needs.setup.outputs.version }}
           CRATE_VERSION: ${{ needs.setup.outputs.crate-version }}
         run: |
-          sed --in-place '/^\[package\]/,/^\[/{s/^version = ".*"/version = "'"${CRATE_VERSION}"'"/}' limitador/Cargo.toml
-          sed --in-place '/^\[package\]/,/^\[/{s/^version = ".*"/version = "'"${VERSION}"'"/}' limitador-server/Cargo.toml
+          cargo set-version --offline -p limitador "$CRATE_VERSION"
+          cargo set-version --offline -p limitador-server "$VERSION"
+
+      - name: Verify Cargo.toml versions
+        env:
+          VERSION: ${{ needs.setup.outputs.version }}
+          CRATE_VERSION: ${{ needs.setup.outputs.crate-version }}
+        run: |
+          ACTUAL_CRATE=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name=="limitador") | .version')
+          ACTUAL_SERVER=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name=="limitador-server") | .version')
+          FAIL=0
+          if [ "$ACTUAL_CRATE" != "$CRATE_VERSION" ]; then
+            echo "::error::Expected limitador version $CRATE_VERSION, got $ACTUAL_CRATE"
+            FAIL=1
+          fi
+          if [ "$ACTUAL_SERVER" != "$VERSION" ]; then
+            echo "::error::Expected limitador-server version $VERSION, got $ACTUAL_SERVER"
+            FAIL=1
+          fi
+          if [ "$FAIL" -ne 0 ]; then exit 1; fi
+          echo "Cargo.toml versions verified: limitador=$ACTUAL_CRATE, limitador-server=$ACTUAL_SERVER"
+
+      - name: Generate release.yaml from Cargo.toml
+        run: |
+          chmod +x .github/scripts/sync-release-yaml.sh
+          .github/scripts/sync-release-yaml.sh
 
       - name: Update Cargo.lock
         run: cargo check
@@ -192,9 +212,13 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      - uses: Swatinem/rust-cache@v2
+
       - uses: abelfodil/protoc-action@v1
         with:
           protoc-version: "3.19.4"
+
+      - uses: ./.github/actions/install-yq
 
       - name: Compute next dev versions
         id: next
@@ -226,13 +250,20 @@ jobs:
           fi
           git switch --create "${POST_RELEASE_BRANCH}"
 
+      - run: cargo install cargo-edit --version 0.13.13
+
       - name: Update Cargo.toml versions
         env:
           NEXT_VERSION: ${{ steps.next.outputs.version }}
           NEXT_CRATE_VERSION: ${{ steps.next.outputs.crate-version }}
         run: |
-          sed --in-place '/^\[package\]/,/^\[/{s/^version = ".*"/version = "'"${NEXT_CRATE_VERSION}"'"/}' limitador/Cargo.toml
-          sed --in-place '/^\[package\]/,/^\[/{s/^version = ".*"/version = "'"${NEXT_VERSION}"'"/}' limitador-server/Cargo.toml
+          cargo set-version --offline -p limitador "$NEXT_CRATE_VERSION"
+          cargo set-version --offline -p limitador-server "$NEXT_VERSION"
+
+      - name: Generate release.yaml from Cargo.toml
+        run: |
+          chmod +x .github/scripts/sync-release-yaml.sh
+          .github/scripts/sync-release-yaml.sh
 
       - name: Update Cargo.lock
         run: cargo check

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,18 @@ jobs:
         with:
           ref: ${{ inputs.release-branch }}
 
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - uses: abelfodil/protoc-action@v1
+        with:
+          protoc-version: "3.19.4"
+
       - uses: ./.github/actions/install-yq
+
+      - name: Verify Cargo.toml and release.yaml agree
+        run: |
+          chmod +x .github/scripts/check-versions.sh
+          .github/scripts/check-versions.sh
 
       - name: Parse version from release.yaml
         id: parse

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,33 +1,205 @@
 ---
-name: Release crate
+name: Release
 
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "version (no `v` prefix)"
+      release-branch:
+        description: "Release branch (e.g. release-2.5)"
         required: true
-        default: "1.0.0"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ inputs.release-branch }}
+  cancel-in-progress: false
 
 jobs:
-  publish:
-    name: Publish Limitador crate to crates.io
+  read-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.parse.outputs.version }}
+      crate-version: ${{ steps.parse.outputs.crate-version }}
+      major: ${{ steps.parse.outputs.major }}
+      minor: ${{ steps.parse.outputs.minor }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.release-branch }}
+
+      - uses: ./.github/actions/install-yq
+
+      - name: Parse version from release.yaml
+        id: parse
+        run: |
+          chmod +x .github/scripts/parse-version.sh
+          .github/scripts/parse-version.sh
+
+      - name: Validate versions are not sentinel
+        env:
+          VERSION: ${{ steps.parse.outputs.version }}
+          CRATE_VERSION: ${{ steps.parse.outputs.crate-version }}
+        run: |
+          if [[ "$VERSION" == "0.0.0" ]]; then
+            echo "::error::Version is 0.0.0 -- has the pre-release PR been merged?"
+            exit 1
+          fi
+          if [[ "$CRATE_VERSION" == "0.0.0" ]]; then
+            echo "::error::Crate version is 0.0.0 -- has the pre-release PR been merged?"
+            exit 1
+          fi
+
+      - name: Validate branch matches version
+        env:
+          RELEASE_BRANCH: ${{ inputs.release-branch }}
+          MAJOR: ${{ steps.parse.outputs.major }}
+          MINOR: ${{ steps.parse.outputs.minor }}
+          VERSION: ${{ steps.parse.outputs.version }}
+        run: |
+          EXPECTED_BRANCH="release-${MAJOR}.${MINOR}"
+          if [[ "$RELEASE_BRANCH" != "$EXPECTED_BRANCH" ]]; then
+            echo "::error::Branch '${RELEASE_BRANCH}' does not match version ${VERSION} (expected branch: $EXPECTED_BRANCH)"
+            exit 1
+          fi
+
+      - name: Check for existing release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.parse.outputs.version }}
+        run: |
+          if gh release view "v${VERSION}" &>/dev/null; then
+            echo "::error::GitHub Release v${VERSION} already exists"
+            exit 1
+          fi
+
+  smoke-tests:
+    needs: read-version
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.release-branch }}
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
       - uses: abelfodil/protoc-action@v1
         with:
           protoc-version: "3.19.4"
+
       - uses: supercharge/redis-github-action@1.8.1
         with:
           redis-version: 7
+
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --locked --all-features --all-targets -- -D warnings
+
+      - name: Check
+        run: cargo check --locked --all-features
+
+      - name: Test
+        run: cargo test --locked --all-features
+
+      - name: Publish dry-run
+        run: cargo publish --dry-run --package limitador
+
+  tag:
+    needs: [read-version, smoke-tests]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
       - uses: actions/checkout@v6
         with:
-          ref: crate-v${{ github.event.inputs.version }}
-      - name: Build
-        run: cargo build --verbose --release
-      - name: Check
-        run: cargo fmt --all -- --check && cargo clippy -- -D warnings
-      - name: Run tests
-        run: cargo test --verbose
-      - name: Publish
-        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p limitador:${{ github.event.inputs.version }}
+          ref: ${{ inputs.release-branch }}
+          fetch-depth: 0
+
+      - name: Create and push tags
+        env:
+          VERSION: ${{ needs.read-version.outputs.version }}
+          CRATE_VERSION: ${{ needs.read-version.outputs.crate-version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          for TAG in "v${VERSION}" "server-v${VERSION}" "crate-v${CRATE_VERSION}"; do
+            if git tag --list "$TAG" | grep --quiet .; then
+              echo "::error::Tag $TAG already exists"
+              exit 1
+            fi
+            git tag --annotate "$TAG" --message "Release $TAG"
+          done
+
+          git push origin "v${VERSION}" "server-v${VERSION}" "crate-v${CRATE_VERSION}"
+
+  publish-crate:
+    needs: [read-version, tag]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.release-branch }}
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - uses: abelfodil/protoc-action@v1
+        with:
+          protoc-version: "3.19.4"
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --package limitador
+
+  build-images:
+    needs: [read-version, tag]
+    uses: ./.github/workflows/build-image.yaml
+    with:
+      ref: ${{ inputs.release-branch }}
+      tag: v${{ needs.read-version.outputs.version }}
+    secrets: inherit
+
+  create-release:
+    needs: [read-version, publish-crate, build-images]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.release-branch }}
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.read-version.outputs.version }}
+          CRATE_VERSION: ${{ needs.read-version.outputs.crate-version }}
+        run: |
+          TAG="v${VERSION}"
+
+          NOTES=$(cat <<EOF
+          ## Artifacts
+
+          - **Crate**: [limitador v${CRATE_VERSION} on crates.io](https://crates.io/crates/limitador/${CRATE_VERSION})
+          - **Container image**: \`quay.io/kuadrant/limitador:v${VERSION}\`
+
+          ## Tags
+
+          - \`v${VERSION}\` (primary)
+          - \`server-v${VERSION}\`
+          - \`crate-v${CRATE_VERSION}\`
+          EOF
+          )
+
+          gh release create "$TAG" \
+            --title "Release v${VERSION}" \
+            --generate-notes \
+            --notes "$NOTES"

--- a/.github/workflows/version-gate.yaml
+++ b/.github/workflows/version-gate.yaml
@@ -1,0 +1,29 @@
+---
+name: Version Gate
+
+on:
+  pull_request:
+    branches:
+      - "release-*"
+    paths:
+      - "release.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-release-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/install-yq
+
+      - name: Validate release.yaml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ github.base_ref }}
+          ORG: ${{ github.repository_owner }}
+        run: |
+          chmod +x .github/scripts/validate-release-yaml.sh
+          .github/scripts/validate-release-yaml.sh "$BASE_REF" "$ORG"

--- a/.github/workflows/version-gate.yaml
+++ b/.github/workflows/version-gate.yaml
@@ -3,16 +3,35 @@ name: Version Gate
 
 on:
   pull_request:
-    branches:
-      - "release-*"
     paths:
       - "release.yaml"
+      - "limitador/Cargo.toml"
+      - "limitador-server/Cargo.toml"
 
 permissions:
   contents: read
 
 jobs:
+  check-version-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - uses: abelfodil/protoc-action@v1
+        with:
+          protoc-version: "3.19.4"
+
+      - uses: ./.github/actions/install-yq
+
+      - name: Check Cargo.toml and release.yaml agree
+        run: |
+          chmod +x .github/scripts/check-versions.sh
+          .github/scripts/check-versions.sh
+
   validate-release-yaml:
+    if: startsWith(github.base_ref, 'release-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,8 +11,9 @@ Limitador maintains two independent version numbers:
 - **Server version** (e.g. `2.5.0`) — used for container image tags and as the primary release version
 - **Crate version** (e.g. `0.13.0`) — used for the `limitador` library crate on crates.io
 
-Both are tracked in `release.yaml` at the repository root.
-On `main`, versions are `0.0.0` (sentinel for "under development").
+**Source of truth: `Cargo.toml`.** The `limitador/Cargo.toml` and `limitador-server/Cargo.toml` package versions are authoritative. `release.yaml` at the repo root is a generated mirror that `kuadrant-operator` and other cross-repo tooling reads for a uniform version file regardless of language.
+
+On `main`, `Cargo.toml` versions end in `-dev` (e.g. `0.13.0-dev`) and `release.yaml` uses `0.0.0` sentinel values. On release branches, both files must agree exactly.
 
 ### Tag conventions
 
@@ -53,18 +54,18 @@ The following secrets must be configured in **Settings > Secrets and variables >
 4. The workflow will:
    - Create the release branch `release-X.Y` from the source branch (if it doesn't exist)
    - Create a `pre-release-vX.Y.Z` working branch
-   - Update `release.yaml` with both versions
-   - Set `limitador/Cargo.toml` version to the crate version
-   - Set `limitador-server/Cargo.toml` version to the server version
+   - Set `limitador/Cargo.toml` version via `cargo set-version` and verify with `cargo metadata`
+   - Set `limitador-server/Cargo.toml` version via `cargo set-version` and verify with `cargo metadata`
+   - Generate `release.yaml` from Cargo.toml values
    - Update `Cargo.lock`
    - Open a PR against the release branch
-   - Open a **post-release PR** to `main` bumping versions to the next `-dev` (do not merge until after the release)
+   - Open a **post-release PR** to `main` bumping versions to the next `-dev` and resetting `release.yaml` to `0.0.0` (do not merge until after the release)
 
 ### Review gate
 
 5. Review the PR. CI will run:
    - Standard CI checks (fmt, clippy, test, image build)
-   - **Version gate** — validates `release.yaml` versions are non-zero and any dependency releases exist
+   - **Version gate** — validates `release.yaml` and `Cargo.toml` agree, and on release branches rejects sentinel/dev versions
 6. Approve and merge the PR
 
 ### Phase 2: Release
@@ -125,10 +126,14 @@ If the release workflow fails partway through:
 
 | File | Purpose |
 |------|---------|
-| `release.yaml` | Version and dependency declaration (source of truth) |
-| `.github/workflows/pre-release.yaml` | Phase 1: prepare release PR |
+| `limitador/Cargo.toml` | Crate version (source of truth) |
+| `limitador-server/Cargo.toml` | Server version (source of truth) |
+| `release.yaml` | Generated mirror for cross-repo tooling (`kuadrant-operator`) |
+| `.github/workflows/pre-release.yaml` | Phase 1: set Cargo.toml versions, generate release.yaml, open PR |
 | `.github/workflows/release.yaml` | Phase 2: test, tag, build, publish, release |
-| `.github/workflows/version-gate.yaml` | CI check on release branch PRs |
+| `.github/workflows/version-gate.yaml` | CI check: release.yaml/Cargo.toml consistency (all branches) |
 | `.github/workflows/build-image.yaml` | Multi-arch container image build (reusable) |
 | `.github/scripts/parse-version.sh` | Parse and validate versions from release.yaml |
-| `.github/scripts/validate-release-yaml.sh` | Version gate validation logic |
+| `.github/scripts/sync-release-yaml.sh` | Generate release.yaml from Cargo.toml via cargo metadata |
+| `.github/scripts/check-versions.sh` | Validate release.yaml and Cargo.toml agree |
+| `.github/scripts/validate-release-yaml.sh` | Version gate: reject sentinel/dev versions on release branches |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,101 +1,134 @@
 # How to release Limitador
 
-## Process
+Limitador uses a two-phase release process.
+A **pre-release** workflow prepares code changes and opens a pull request.
+A **release** workflow builds artifacts and creates the GitHub Release after the PR is merged.
 
-### `limitador` crate to crates.io
+## Version conventions
 
- - Create a local branch, whatever the name, e.g. `release`
+Limitador maintains two independent version numbers:
 
-```sh
-git checkout -b release
-```
+- **Server version** (e.g. `2.5.0`) — used for container image tags and as the primary release version
+- **Crate version** (e.g. `0.13.0`) — used for the `limitador` library crate on crates.io
 
- - Remove the `-dev` suffix from both `Cargo.toml`
+Both are tracked in `release.yaml` at the repository root.
+On `main`, versions are `0.0.0` (sentinel for "under development").
 
- ```diff
-diff --git a/limitador-server/Cargo.toml b/limitador-server/Cargo.toml
-index dd2f311..b555df8 100644
---- a/limitador-server/Cargo.toml
-+++ b/limitador-server/Cargo.toml
-@@ -1,6 +1,6 @@
- [package]
- name = "limitador-server"
--version = "1.3.0-dev"
-+version = "1.3.0"
-diff --git a/limitador/Cargo.toml b/limitador/Cargo.toml
-index 3aebf9d..d17b92b 100644
---- a/limitador/Cargo.toml
-+++ b/limitador/Cargo.toml
-@@ -1,6 +1,6 @@
- [package]
- name = "limitador"
--version = "0.5.0-dev"
-+version = "0.5.0"
- ```
+### Tag conventions
 
- - Commit the changes
+Each release creates three git tags:
 
-```sh
-git commit -am "[release] Releasing Crate 0.5.0 and Server 1.3.0"
-```
+- `vX.Y.Z` — primary tag (server version), used by other Kuadrant components
+- `server-vX.Y.Z` — server-specific tag (backward compatibility)
+- `crate-vX.Y.Z` — crate-specific tag (backward compatibility)
 
- - Create a tag named after the version, with the `crate-v` prefix 
+### Branch conventions
 
-```sh
-git tag -a crate-v0.5.0 -m "[tag] Limitador crate v0.5.0"
-```
+Release branches follow the `release-X.Y` pattern (e.g. `release-2.5` for server version `2.5.0`).
+Patch releases reuse the same branch (e.g. `2.5.1` releases from `release-2.5`).
 
- - Push the tag to remote
+## Prerequisites
 
-```sh
-git push origin crate-v0.5.0
-```
+### Repository secrets
 
- - Manually run the `Release crate` workflow action on [Github](https://github.com/Kuadrant/limitador/actions/workflows/release.yaml) providing the version to release in the input box, e.g. `0.5.0`, if all is correct, this should push the release to [crates.io](https://crates.io/crates/limitador/versions)
- - Create the release and release notes on [Github](https://github.com/Kuadrant/limitador/releases/new) using the tag from above, named: `Limitador crate vM.m.d`
+The following secrets must be configured in **Settings > Secrets and variables > Actions > Repository secrets**:
 
+| Secret | Purpose | Used by |
+|--------|---------|---------|
+| `CARGO_REGISTRY_TOKEN` | crates.io API token with publish permission for the `limitador` crate | Release workflow (`cargo publish`) |
+| `IMG_REGISTRY_USERNAME` | quay.io robot account username (e.g. `kuadrant+ci`) | Build Image workflow (docker login) |
+| `IMG_REGISTRY_TOKEN` | quay.io robot account token | Build Image workflow (docker login) |
 
-### `limitador-server` container image to quay.io
+> `GITHUB_TOKEN` is provided automatically by GitHub Actions and does not need to be configured.
+> It is used for creating tags, GitHub Releases, and opening pull requests.
 
- - Create a branch for your version with the `v` prefix, e.g. `v1.3.0`
- - Make sure your `Cargo.toml` is reflecting the proper version, see above
- - Push the branch to remote, which should create a matching release to quay.io with the tag name based of your branch, i.e. in this case `v1.3.0`
- - Create a tag with the `server-v` prefix, e.g. `server-v1.3.0`
- - Push the tag to Github
- - Create the release and release notes on [Github](https://github.com/Kuadrant/limitador/releases/new) using the tag from above, named: `vM.m.d`
- - Delete the branch, only keep the tag used for the release
+## Minor release
+
+### Phase 1: Pre-release
+
+1. Go to **Actions > Pre-release** and click **Run workflow**
+2. Enter the **server version** (e.g. `2.5.0`) and **crate version** (e.g. `0.13.0`)
+3. Optionally set the **source branch** (defaults to `main`).
+   For patch releases, set this to the existing release branch.
+4. The workflow will:
+   - Create the release branch `release-X.Y` from the source branch (if it doesn't exist)
+   - Create a `pre-release-vX.Y.Z` working branch
+   - Update `release.yaml` with both versions
+   - Set `limitador/Cargo.toml` version to the crate version
+   - Set `limitador-server/Cargo.toml` version to the server version
+   - Update `Cargo.lock`
+   - Open a PR against the release branch
+   - Open a **post-release PR** to `main` bumping versions to the next `-dev` (do not merge until after the release)
+
+### Review gate
+
+5. Review the PR. CI will run:
+   - Standard CI checks (fmt, clippy, test, image build)
+   - **Version gate** — validates `release.yaml` versions are non-zero and any dependency releases exist
+6. Approve and merge the PR
+
+### Phase 2: Release
+
+7. Go to **Actions > Release** and click **Run workflow**
+8. Enter the **release branch** (e.g. `release-2.5`)
+9. The workflow will (in strict order):
+   - **Read version** from `release.yaml` and verify no existing GitHub Release
+   - **Smoke tests** — fmt, clippy, check, full test suite, `cargo publish --dry-run`
+   - **Tag** — create and push three tags (`vX.Y.Z`, `server-vX.Y.Z`, `crate-vX.Y.Z`)
+   - **Publish crate** — `cargo publish -p limitador` to crates.io
+   - **Build images** — multi-arch container images (amd64, arm64, s390x) pushed to quay.io
+   - **Create GitHub Release** — only after all artifacts succeed
+
+### Verify
+
+10. Confirm the release artifacts:
+   - [GitHub Release](https://github.com/Kuadrant/limitador/releases) exists with correct tag
+   - [limitador on crates.io](https://crates.io/crates/limitador) shows the new version
+   - Container image `quay.io/kuadrant/limitador:vX.Y.Z` is available
+
+## Patch release
+
+The process is identical to a minor release, except:
+
+- The release branch (`release-X.Y`) already exists
+- Enter the patch version (e.g. `2.5.1`) and corresponding crate version
+- Set the **source branch** to the existing release branch (e.g. `release-2.5`)
+- Before running the pre-release workflow, backport any fixes to the release branch.
+  Create a branch, cherry-pick the commits, and open a PR against the release branch.
+  Branch protections prevent pushing directly to release branches.
 
 ## After the release
 
- - Create a `next` branch off `main` 
- - Update the _both_ Cargo.toml to point to the next `-dev` release
- - Create PR
- - Merge to `main`
+When the source branch is `main` (i.e. a minor release), the pre-release workflow automatically opens a **post-release PR** to `main`.
+This PR bumps both `Cargo.toml` files to the next minor `-dev` version (e.g. `2.5.0` → `2.6.0-dev`, `0.13.0` → `0.14.0-dev`).
+It is created alongside the release PR but should only be merged after the release is complete.
 
-```diff
- diff --git a/limitador-server/Cargo.toml b/limitador-server/Cargo.toml
-index d2bcd36..3724132 100644
---- a/limitador-server/Cargo.toml
-+++ b/limitador-server/Cargo.toml
-@@ -1,6 +1,6 @@
- [package]
- name = "limitador-server"
--version = "2.0.0-dev"
-+version = "2.1.0-dev"
- authors = ["Alex Snaps <asnaps@redhat.com>", "Eguzki Astiz Lezaun <eguzki@redhat.com>", "David Ortiz <z.david.ortiz@gmail.com>"]
- license = "Apache-2.0"
- keywords = ["rate-limiting", "rate", "limiter", "envoy", "rls"]
-diff --git a/limitador/Cargo.toml b/limitador/Cargo.toml
-index ed822b1..baf50c7 100644
---- a/limitador/Cargo.toml
-+++ b/limitador/Cargo.toml
-@@ -1,6 +1,6 @@
- [package]
- name = "limitador"
--version = "0.8.0-dev"
-+version = "0.9.0-dev"
- authors = ["David Ortiz <z.david.ortiz@gmail.com>", "Eguzki Astiz Lezaun <eguzki@redhat.com>", "Alex Snaps <asnaps@redhat.com>"]
- license = "Apache-2.0"
- keywords = ["rate-limiting", "rate", "limiter"]
-```
+For patch releases (source branch is a release branch), the post-release job is skipped.
 
+## Rollback
+
+If the release workflow fails partway through:
+
+- **Failed during smoke tests**: No artifacts created. Fix the issue and re-run.
+- **Failed during tag**: No artifacts created. Fix the issue and re-run.
+- **Failed during crate publish**: Tags exist but no GitHub Release.
+  The crate may or may not have been published — check crates.io.
+  If the crate was published, you cannot re-publish the same version.
+  Delete the tags manually if needed, fix the issue, and re-run with a patch version.
+- **Failed during image build**: Tags exist and crate is published, but no GitHub Release.
+  Delete the tags, yank the crate version on crates.io if needed, fix the issue, and re-run with a patch version.
+  Alternatively, fix the image build and re-run only the release workflow (the tag and crate steps will detect existing artifacts and fail — manual intervention may be needed).
+- **Failed during GitHub Release creation**: All artifacts exist.
+  Create the GitHub Release manually via `gh release create`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `release.yaml` | Version and dependency declaration (source of truth) |
+| `.github/workflows/pre-release.yaml` | Phase 1: prepare release PR |
+| `.github/workflows/release.yaml` | Phase 2: test, tag, build, publish, release |
+| `.github/workflows/version-gate.yaml` | CI check on release branch PRs |
+| `.github/workflows/build-image.yaml` | Multi-arch container image build (reusable) |
+| `.github/scripts/parse-version.sh` | Parse and validate versions from release.yaml |
+| `.github/scripts/validate-release-yaml.sh` | Version gate validation logic |

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "limitador-server"
 version = "2.5.0-dev"
+publish = false
 authors = ["Alex Snaps <asnaps@redhat.com>", "Eguzki Astiz Lezaun <eguzki@redhat.com>", "David Ortiz <z.david.ortiz@gmail.com>"]
 license = "Apache-2.0"
 keywords = ["rate-limiting", "rate", "limiter", "envoy", "rls"]

--- a/release.yaml
+++ b/release.yaml
@@ -1,0 +1,5 @@
+limitador:
+  version: "0.0.0"
+  crate-version: "0.0.0"
+
+dependencies: {}


### PR DESCRIPTION
# Summary

Replaces the manual, multi-step release process with an automated two-phase workflow driven by GitHub Actions and a `release.yaml` version manifest.

- **Phase 1 (Pre-release)**: A `workflow_dispatch` workflow creates a release branch, bumps versions in `release.yaml` and both `Cargo.toml` files, and opens a PR against the release branch. For minor releases it also opens a post-release PR to `main` with the next `-dev` versions.
- **Phase 2 (Release)**: A second `workflow_dispatch` workflow reads versions from `release.yaml`, runs smoke tests (fmt, clippy, full test suite, publish dry-run), creates annotated git tags, publishes the crate to crates.io, builds multi-arch container images, and creates the GitHub Release only after all artifacts succeed.
- **Version gate**: A new CI check on PRs targeting `release-*` branches validates that `release.yaml` contains non-sentinel, non-dev versions and that any declared dependency releases exist.
- **Reusable image build**: The existing `build-image.yaml` workflow now accepts `ref` and `tag` inputs via `workflow_call`, allowing the release workflow to trigger image builds for a specific ref and tag while preserving the existing push-on-main behavior.
- Adds `publish = false` to `limitador-server/Cargo.toml` to prevent accidental publication of the server binary crate.
- Introduces `release.yaml` at the repo root as the single source of truth for version numbers, using `0.0.0` as the sentinel value on `main`.
- Adds helper scripts (`parse-version.sh`, `validate-release-yaml.sh`) with documentation covering usage and error cases.
- Rewrites `RELEASE.md` to document the new process including minor releases, patch releases, rollback procedures, and file inventory.

## Examples
Pre-release Workflow: https://github.com/Boomatang/limitador/actions/runs/28022410045
PR to release branch: https://github.com/Boomatang/limitador/pull/5
PR to main (dev version bump): https://github.com/Boomatang/limitador/pull/6
Release Workflow: https://github.com/Boomatang/limitador/actions/runs/28028029786
GitHub release: https://github.com/Boomatang/limitador/releases




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated pre-release and release workflows with semver parsing, version/branch validation, tagging, crates.io dry-run, image builds, and GitHub Release creation.
  - Introduced a version-gate workflow for pull requests to keep `release.yaml` and Cargo versions in sync.
  - Added reusable image-build support with optional tagging.
  - Added release helper scripts and a composite action to install `yq`.
- **Documentation**
  - Updated `RELEASE.md` with the new two-phase process, conventions, and staged rollback guidance.
  - Added documentation for the release helper scripts.
- **Configuration**
  - Disabled publication of the server crate.
  - Added initial `release.yaml` metadata configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->