### PR TITLE
fix: replace .unwrap() calls with descriptive .expect() messages

### DIFF
--- a/limitador-server/src/envoy_rls/kuadrant_service.rs
+++ b/limitador-server/src/envoy_rls/kuadrant_service.rs
@@ -78,7 +78,7 @@ impl RateLimitService for KuadrantService {
             return Err(Status::unavailable("Service unavailable"));
         }
 
-        let rate_limited_resp = rate_limited_resp.unwrap();
+        let rate_limited_resp = rate_limited_resp.expect("rate_limited_resp must be Ok after error check");
         let resp_code = if rate_limited_resp.limited {
             self.metrics.incr_limited_calls(
                 &namespace,
@@ -186,6 +186,7 @@ impl RateLimitService for KuadrantService {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     mod check_rate_limit {
         use tonic::IntoRequest;

--- a/limitador-server/src/envoy_rls/server.rs
+++ b/limitador-server/src/envoy_rls/server.rs
@@ -171,7 +171,7 @@ impl RateLimitService for MyRateLimiter {
             return Err(Status::unavailable("Service unavailable"));
         }
 
-        let mut rate_limited_resp = rate_limited_resp.unwrap();
+        let mut rate_limited_resp = rate_limited_resp.expect("rate_limited_resp must be Ok after error check");
         span.record("ratelimit.limited", rate_limited_resp.limited);
         if let Some(ref name) = rate_limited_resp.limit_name {
             span.record("ratelimit.limit_name", name.as_str());
@@ -258,7 +258,7 @@ pub async fn run_envoy_rls_server(
                 .register_encoded_file_descriptor_set(rls_proto::RLS_DESCRIPTOR_SET)
                 .register_encoded_file_descriptor_set(rls_proto::KUADRANT_RLS_DESCRIPTOR_SET)
                 .build_v1()
-                .unwrap(),
+                .expect("failed to build gRPC reflection service"),
         ),
     };
 
@@ -267,7 +267,7 @@ pub async fn run_envoy_rls_server(
         .add_service(envoy_server)
         .add_service(kuadrant_server)
         .add_optional_service(reflection_service)
-        .serve(address.parse().unwrap())
+        .serve(address.parse().expect("failed to parse gRPC server address"))
         .await
 }
 
@@ -300,6 +300,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 pub mod tests {
     use lazy_static::lazy_static;
     use metrics_exporter_prometheus::PrometheusHandle;

--- a/limitador-server/src/http_api/server.rs
+++ b/limitador-server/src/http_api/server.rs
@@ -44,7 +44,7 @@ impl RateLimitData {
     }
 
     fn status(&self) -> Status {
-        *self.status.read().unwrap()
+        *self.status.read().expect("lock poisoned")
     }
 }
 
@@ -330,6 +330,7 @@ pub async fn run_http_server(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::envoy_rls::server::tests::TEST_PROMETHEUS_HANDLE;

--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -1,4 +1,4 @@
-#![deny(clippy::all, clippy::cargo)]
+#![deny(clippy::all, clippy::cargo, clippy::unwrap_used)]
 #![allow(clippy::multiple_crate_versions)]
 
 #[macro_use]
@@ -165,7 +165,7 @@ impl Limiter {
 
     fn in_memory_limiter(cfg: InMemoryStorageConfiguration) -> Self {
         let rate_limiter_builder =
-            RateLimiterBuilder::new(cfg.cache_size.or_else(guess_cache_size).unwrap());
+            RateLimiterBuilder::new(cfg.cache_size.or_else(guess_cache_size).expect("cache_size not configured and could not be guessed"));
 
         Self::Blocking(rate_limiter_builder.build())
     }
@@ -174,7 +174,7 @@ impl Limiter {
     fn distributed_limiter(cfg: DistributedStorageConfiguration) -> Self {
         let storage = DistributedInMemoryStorage::new(
             cfg.name,
-            cfg.cache_size.or_else(guess_cache_size).unwrap(),
+            cfg.cache_size.or_else(guess_cache_size).expect("cache_size not configured and could not be guessed"),
             cfg.listen_address,
             cfg.peer_urls,
         );
@@ -302,21 +302,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let limiter = Arc::clone(&rate_limiter);
     let handle = Handle::current();
     // it should not fail because the limits file has already been read
-    let mut limits_file_dir = Path::new(&limit_file).parent().unwrap();
+    let mut limits_file_dir = Path::new(&limit_file).parent().expect("limit file has no parent directory");
     if limits_file_dir.as_os_str().is_empty() {
         limits_file_dir = Path::new(".");
     }
     // structure needed to keep state of the last known canonical limits file path
-    let limit_cfg = std::path::absolute(&limit_file).unwrap();
-    let mut canonical_cfg = std::fs::canonicalize(&limit_cfg).unwrap();
+    let limit_cfg = std::path::absolute(&limit_file).expect("failed to get absolute path for limits file");
+    let mut canonical_cfg = std::fs::canonicalize(&limit_cfg).expect("failed to canonicalize limits file path");
 
-    let labels_cfg = labels_file.map(std::path::absolute).map(Result::unwrap);
+    let labels_cfg = labels_file.map(|f| std::path::absolute(f).expect("failed to get absolute path for labels file"));
     let mut labels_canonical_cfg = labels_cfg
         .clone()
-        .map(std::fs::canonicalize)
-        .map(Result::unwrap);
+        .map(|f| std::fs::canonicalize(f).expect("failed to canonicalize labels file path"));
     let labels_file_dir = labels_cfg.clone().map(|f| {
-        let mut labels_file_dir: PathBuf = f.parent().unwrap().into();
+        let mut labels_file_dir: PathBuf = f.parent().expect("labels file has no parent directory").into();
         if labels_file_dir.as_os_str().is_empty() {
             labels_file_dir = Path::new(".").into();
         }
@@ -345,11 +344,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     handle.spawn(async move {
                                         match limiter.load_limits_from_file(&limit_cfg).await {
                                             Ok(_) => {
-                                                status_updater.write().unwrap().config_success();
+                                                status_updater.write().expect("lock poisoned").config_success();
                                                 info!("data modified; reloaded limit file")
                                             }
                                             Err(e) => {
-                                                status_updater.write().unwrap().config_failure();
+                                                status_updater.write().expect("lock poisoned").config_failure();
                                                 error!("Failed reloading limit file: {}", e)
                                             }
                                         }
@@ -360,7 +359,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 if let Some(location) = event.paths.first() {
                                     if let Ok(actual_location) = std::fs::canonicalize(labels_cfg) {
                                         if location == labels_cfg
-                                            || labels_canonical_cfg.as_ref().unwrap()
+                                            || labels_canonical_cfg.as_ref().expect("labels_canonical_cfg must be set if labels_cfg is set")
                                                 != &actual_location
                                         {
                                             labels_canonical_cfg = Some(actual_location);
@@ -731,7 +730,7 @@ fn create_config() -> (Configuration, &'static str) {
 
     let matches = cmdline.get_matches();
 
-    let limits_file = matches.get_one::<String>("LIMITS_FILE").unwrap();
+    let limits_file = matches.get_one::<String>("LIMITS_FILE").expect("LIMITS_FILE is a required arg");
 
     if matches.get_flag("validate") {
         let error = match std::fs::File::open(limits_file) {
@@ -764,7 +763,7 @@ fn create_config() -> (Configuration, &'static str) {
 
     let storage = match matches.subcommand() {
         Some(("redis", sub)) => StorageConfiguration::Redis(RedisStorageConfiguration {
-            url: sub.get_one::<String>("URL").unwrap().to_owned(),
+            url: sub.get_one::<String>("URL").expect("URL arg is required").to_owned(),
             cache: None,
         }),
         Some(("disk", sub)) => StorageConfiguration::Disk(DiskStorageConfiguration {
@@ -779,12 +778,12 @@ fn create_config() -> (Configuration, &'static str) {
             },
         }),
         Some(("redis_cached", sub)) => StorageConfiguration::Redis(RedisStorageConfiguration {
-            url: sub.get_one::<String>("URL").unwrap().to_owned(),
+            url: sub.get_one::<String>("URL").expect("URL arg is required").to_owned(),
             cache: Some(RedisStorageCacheConfiguration {
-                batch_size: *sub.get_one("batch").unwrap(),
-                flushing_period: *sub.get_one("flush").unwrap(),
-                max_counters: *sub.get_one("max").unwrap(),
-                response_timeout: *sub.get_one("timeout").unwrap(),
+                batch_size: *sub.get_one("batch").expect("batch arg is required"),
+                flushing_period: *sub.get_one("flush").expect("flush arg is required"),
+                max_counters: *sub.get_one("max").expect("max arg is required"),
+                response_timeout: *sub.get_one("timeout").expect("timeout arg is required"),
             }),
         }),
         Some(("memory", sub)) => StorageConfiguration::InMemory(InMemoryStorageConfiguration {
@@ -793,8 +792,8 @@ fn create_config() -> (Configuration, &'static str) {
         #[cfg(feature = "distributed_storage")]
         Some(("distributed", sub)) => {
             StorageConfiguration::Distributed(DistributedStorageConfiguration {
-                name: sub.get_one::<String>("NAME").unwrap().to_owned(),
-                listen_address: sub.get_one::<String>("LISTEN_ADDRESS").unwrap().to_owned(),
+                name: sub.get_one::<String>("NAME").expect("NAME arg is required").to_owned(),
+                listen_address: sub.get_one::<String>("LISTEN_ADDRESS").expect("LISTEN_ADDRESS arg is required").to_owned(),
                 peer_urls: sub
                     .get_many::<String>("PEER_URLS")
                     .unwrap_or(ValuesRef::default())
@@ -809,7 +808,7 @@ fn create_config() -> (Configuration, &'static str) {
 
     let rate_limit_headers = match matches
         .get_one::<String>("rate_limit_headers")
-        .unwrap()
+        .expect("rate_limit_headers arg is required")
         .as_str()
     {
         "NONE" => RateLimitHeaders::None,
@@ -820,10 +819,10 @@ fn create_config() -> (Configuration, &'static str) {
     let mut config = Configuration::with(
         storage,
         limits_file.to_string(),
-        matches.get_one::<String>("ip").unwrap().into(),
-        *matches.get_one::<u16>("port").unwrap(),
-        matches.get_one::<String>("http_ip").unwrap().into(),
-        *matches.get_one::<u16>("http_port").unwrap(),
+        matches.get_one::<String>("ip").expect("ip arg is required").into(),
+        *matches.get_one::<u16>("port").expect("port arg is required"),
+        matches.get_one::<String>("http_ip").expect("http_ip arg is required").into(),
+        *matches.get_one::<u16>("http_port").expect("http_port arg is required"),
         matches.get_flag("limit_name_in_labels") || *config::env::LIMIT_NAME_IN_PROMETHEUS_LABELS,
         matches.get_one::<String>("custom_metric_labels").cloned(),
         matches
@@ -831,7 +830,7 @@ fn create_config() -> (Configuration, &'static str) {
             .cloned(),
         matches
             .get_one::<String>("tracing_endpoint")
-            .unwrap()
+            .expect("tracing_endpoint arg is required")
             .into(),
         rate_limit_headers,
         matches.get_flag("grpc_reflection_service"),

--- a/limitador-server/src/metrics.rs
+++ b/limitador-server/src/metrics.rs
@@ -187,7 +187,7 @@ where
                 // iterate over the groups this span belongs to
                 for group in span_state.group_times.keys().cloned().collect::<Vec<_>>() {
                     // find the set of records related to these groups in the layer
-                    if self.groups.get(&group).unwrap().records.contains(&name) {
+                    if self.groups.get(&group).expect("group must exist in metrics layer").records.contains(&name) {
                         // if we are a record for this group then increment the relevant
                         // span-local timing and continue to the next group
                         span_state.increment(group, timing);
@@ -211,6 +211,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::{MetricsLayer, SpanState, Timings};
     use std::time::Instant;

--- a/limitador/src/counter.rs
+++ b/limitador/src/counter.rs
@@ -138,6 +138,7 @@ impl PartialEq for Counter {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use crate::counter::Counter;
     use crate::limit::Limit;

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -189,7 +189,7 @@
 //! more performant.
 //!
 
-#![deny(clippy::all, clippy::cargo)]
+#![deny(clippy::all, clippy::cargo, clippy::unwrap_used)]
 // TODO this needs review to reduce the bloat pulled in by dependencies
 #![allow(clippy::multiple_crate_versions)]
 
@@ -747,6 +747,7 @@ fn classify_limits_by_namespace(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use crate::limit::{Context, Expression, Limit};
     use crate::RateLimiter;

--- a/limitador/src/limit.rs
+++ b/limitador/src/limit.rs
@@ -159,7 +159,7 @@ impl Limit {
         let all_conditions_apply = self
             .conditions
             .iter()
-            .all(|predicate| predicate.test(&ctx.for_limit(self)).unwrap());
+            .all(|predicate| predicate.test(&ctx.for_limit(self)).expect("predicate evaluation failed"));
 
         let all_vars_are_set = self.variables.iter().all(|var| {
             ctx.has_variables(
@@ -214,6 +214,7 @@ impl PartialEq for Limit {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::counter::Counter;

--- a/limitador/src/storage/disk/expiring_value.rs
+++ b/limitador/src/storage/disk/expiring_value.rs
@@ -105,6 +105,7 @@ impl From<TryFromSliceError> for StorageErr {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::ExpiringValue;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};

--- a/limitador/src/storage/disk/rocksdb_storage.rs
+++ b/limitador/src/storage/disk/rocksdb_storage.rs
@@ -186,7 +186,7 @@ impl RocksDbStorage {
             Some(Vec::from(value))
         });
         opts.create_if_missing(true);
-        let db = DB::open(&opts, path).unwrap();
+        let db = DB::open(&opts, path)?;
         Ok(Self { db })
     }
 
@@ -223,6 +223,7 @@ impl RocksDbStorage {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::RocksDbStorage;
     use crate::counter::Counter;

--- a/limitador/src/storage/distributed/cr_counter_value.rs
+++ b/limitador/src/storage/distributed/cr_counter_value.rs
@@ -39,7 +39,7 @@ impl<A: Ord> CrCounterValue<A> {
         if self.expiry.expired_at(when) {
             0
         } else {
-            let guard = self.others.read().unwrap();
+            let guard = self.others.read().expect("lock poisoned");
             let others: u64 = guard.values().sum();
             others + self.value.load(Ordering::Relaxed)
         }
@@ -65,7 +65,7 @@ impl<A: Ord> CrCounterValue<A> {
         if actor == self.ourselves {
             self.inc_at(increment, time_window, when);
         } else {
-            let mut guard = self.others.write().unwrap();
+            let mut guard = self.others.write().expect("lock poisoned");
             if self.expiry.update_if_expired(time_window, when) {
                 guard.insert(actor, increment);
             } else {
@@ -86,7 +86,7 @@ impl<A: Ord> CrCounterValue<A> {
                 self.reset(expiry);
             }
             let ourselves = self.value.load(Ordering::SeqCst);
-            let mut others = self.others.write().unwrap();
+            let mut others = self.others.write().expect("lock poisoned");
             for (actor, other_value) in other_values {
                 if actor == self.ourselves {
                     if other_value > ourselves {
@@ -128,7 +128,7 @@ impl<A: Ord> CrCounterValue<A> {
             others,
             expiry,
         } = self;
-        let mut map = others.into_inner().unwrap();
+        let mut map = others.into_inner().expect("lock poisoned");
         map.insert(ourselves, value.into_inner());
         (expiry.into_inner(), map)
     }
@@ -142,7 +142,7 @@ impl<A: Ord> CrCounterValue<A> {
     }
 
     fn reset(&self, expiry: SystemTime) {
-        let mut guard = self.others.write().unwrap();
+        let mut guard = self.others.write().expect("lock poisoned");
         self.expiry.update(expiry);
         self.value.store(0, Ordering::SeqCst);
         guard.clear()
@@ -155,7 +155,7 @@ impl<A: Clone + Ord> Clone for CrCounterValue<A> {
             ourselves: self.ourselves.clone(),
             max_value: self.max_value,
             value: AtomicU64::new(self.value.load(Ordering::SeqCst)),
-            others: RwLock::new(self.others.read().unwrap().clone()),
+            others: RwLock::new(self.others.read().expect("lock poisoned").clone()),
             expiry: self.expiry.clone(),
         }
     }

--- a/limitador/src/storage/distributed/grpc/mod.rs
+++ b/limitador/src/storage/distributed/grpc/mod.rs
@@ -41,9 +41,9 @@ impl ClockSkew {
         if local == remote {
             ClockSkew::None()
         } else if local.gt(&remote) {
-            ClockSkew::Slow(local.duration_since(remote).unwrap())
+            ClockSkew::Slow(local.duration_since(remote).expect("local > remote was just checked"))
         } else {
-            ClockSkew::Fast(remote.duration_since(local).unwrap())
+            ClockSkew::Fast(remote.duration_since(local).expect("remote > local was just checked"))
         }
     }
 
@@ -175,7 +175,7 @@ impl Session {
                             Ok(permit) => {
 
                                 let key = tx_updates_order.remove(0);
-                                let cr_counter_value = tx_updates_by_key.remove(&key).unwrap().clone();
+                                let cr_counter_value = tx_updates_by_key.remove(&key).expect("key must exist in tx_updates_by_key").clone();
                                 let (expiry, values) = cr_counter_value.value.clone().into_inner();
 
                                 // only send the update if it has not expired.
@@ -183,7 +183,7 @@ impl Session {
                                     permit.send(Ok(Message::CounterUpdate(CounterUpdate {
                                         key,
                                         values: values.into_iter().collect(),
-                                        expires_at: expiry.duration_since(UNIX_EPOCH).unwrap().as_secs(),
+                                        expires_at: expiry.duration_since(UNIX_EPOCH).expect("expiry time before Unix epoch").as_secs(),
                                     })))?;
                                 }
                             }
@@ -222,7 +222,7 @@ impl Session {
                     .send(Ok(Message::Pong(Pong {
                         current_time: SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .unwrap()
+                            .expect("system time before Unix epoch")
                             .as_millis() as u64,
                     })))
                     .await?;
@@ -537,7 +537,7 @@ impl Broker {
             .add_service(ReplicationServer::new(self.clone()))
             .serve(self.listen_address)
             .await
-            .unwrap();
+            .expect("replication server failed to start");
     }
 
     // Connect to a peer and start a replication session.  This returns once the session handshake
@@ -649,7 +649,7 @@ impl Broker {
         out_stream
             .clone()
             .send(Ok(Message::Pong(Pong {
-                current_time: start.duration_since(UNIX_EPOCH).unwrap().as_millis() as u64,
+                current_time: start.duration_since(UNIX_EPOCH).expect("system time before Unix epoch").as_millis() as u64,
             })))
             .await?;
 
@@ -709,7 +709,7 @@ impl Broker {
                 }
             }
             None => {
-                let latency = end.duration_since(start).unwrap();
+                let latency = end.duration_since(start).expect("end time before start time");
                 let peer_time = UNIX_EPOCH.add(Duration::from_millis(peer_pong.current_time));
                 let peer_time_adj = peer_time.add(latency.div_f32(2.0)); // adjust for round trip latency
                 let discovered_urls = peer_hello
@@ -732,7 +732,7 @@ impl Broker {
                     &tracker.clock_skew
                 );
                 state.peer_trackers.insert(peer_id.clone(), tracker);
-                let tracker = state.peer_trackers.get_mut(&peer_id).unwrap();
+                let tracker = state.peer_trackers.get_mut(&peer_id).expect("peer tracker must exist after insert");
                 (tracker, Some(session))
             }
         };

--- a/limitador/src/storage/distributed/mod.rs
+++ b/limitador/src/storage/distributed/mod.rs
@@ -31,7 +31,7 @@ pub struct CrInMemoryStorage {
 impl CounterStorage for CrInMemoryStorage {
     #[tracing::instrument(skip_all)]
     fn is_within_limits(&self, counter: &Counter, delta: u64) -> Result<bool, StorageErr> {
-        let limits = self.limits.read().unwrap();
+        let limits = self.limits.read().expect("lock poisoned");
 
         let mut value = 0;
         let key = encode_counter_to_key(counter);
@@ -44,7 +44,7 @@ impl CounterStorage for CrInMemoryStorage {
     #[tracing::instrument(skip_all)]
     fn add_counter(&self, limit: &Limit) -> Result<(), StorageErr> {
         if limit.variables().is_empty() {
-            let mut limits = self.limits.write().unwrap();
+            let mut limits = self.limits.write().expect("lock poisoned");
             let key = encode_limit_to_key(limit);
             limits.entry(key.clone()).or_insert(Arc::new(CounterEntry {
                 key,
@@ -63,7 +63,7 @@ impl CounterStorage for CrInMemoryStorage {
 
     #[tracing::instrument(skip_all)]
     fn update_counter(&self, counter: &Counter, delta: u64) -> Result<(), StorageErr> {
-        let mut limits = self.limits.write().unwrap();
+        let mut limits = self.limits.write().expect("lock poisoned");
         let now = SystemTime::now();
 
         let key = encode_counter_to_key(counter);
@@ -127,7 +127,7 @@ impl CounterStorage for CrInMemoryStorage {
             // since that will allow us to have higher concurrency
             let counter_existed = {
                 let key = key.clone();
-                let limits = self.limits.read().unwrap();
+                let limits = self.limits.read().expect("lock poisoned");
                 match limits.get(&key) {
                     None => false,
                     Some(store_value) => {
@@ -147,7 +147,7 @@ impl CounterStorage for CrInMemoryStorage {
             // we need to take the slow path since we need to mutate the limits map.
             if !counter_existed {
                 // try again with a write lock to create the counter if it's still missing.
-                let mut limits = self.limits.write().unwrap();
+                let mut limits = self.limits.write().expect("lock poisoned");
                 let store_value = limits.entry(key.clone()).or_insert(Arc::new(CounterEntry {
                     key: key.clone(),
                     counter: counter.clone(),
@@ -172,9 +172,9 @@ impl CounterStorage for CrInMemoryStorage {
         }
 
         // Update counters
-        let limits = self.limits.read().unwrap();
+        let limits = self.limits.read().expect("lock poisoned");
         counter_values_to_update.into_iter().for_each(|key| {
-            let store_value = limits.get(&key).unwrap();
+            let store_value = limits.get(&key).expect("counter key must exist after insert");
             self.increment_counter(store_value.clone(), delta, now);
         });
 
@@ -184,13 +184,13 @@ impl CounterStorage for CrInMemoryStorage {
     #[tracing::instrument(skip_all)]
     fn get_counters(&self, limits: &HashSet<Arc<Limit>>) -> Result<HashSet<Counter>, StorageErr> {
         let mut res = HashSet::new();
-        let limits_map = self.limits.read().unwrap();
+        let limits_map = self.limits.read().expect("lock poisoned");
         for counter_entry in limits_map.values() {
             if limits.contains(counter_entry.counter.limit()) {
                 let mut counter: Counter = counter_entry.counter.clone();
                 counter.set_remaining(counter.max_value() - counter_entry.value.read());
                 counter.set_expires_in(counter_entry.value.ttl());
-                if counter.expires_in().unwrap() > Duration::ZERO {
+                if counter.expires_in().expect("expires_in was just set") > Duration::ZERO {
                     res.insert(counter);
                 }
             }
@@ -208,7 +208,7 @@ impl CounterStorage for CrInMemoryStorage {
 
     #[tracing::instrument(skip_all)]
     fn clear(&self) -> Result<(), StorageErr> {
-        self.limits.write().unwrap().clear();
+        self.limits.write().expect("lock poisoned").clear();
         Ok(())
     }
 }
@@ -220,7 +220,11 @@ impl CrInMemoryStorage {
         listen_address: String,
         peer_urls: Vec<String>,
     ) -> Self {
-        let listen_address = listen_address.to_socket_addrs().unwrap().next().unwrap();
+        let listen_address = listen_address
+            .to_socket_addrs()
+            .expect("invalid listen address")
+            .next()
+            .expect("no socket address resolved for listen address");
         let peer_urls = peer_urls.clone();
         let limits = Arc::new(RwLock::new(LimitsMap::new()));
 
@@ -238,8 +242,8 @@ impl CrInMemoryStorage {
                         .iter()
                         .map(|(k, v)| (k.to_owned(), v.to_owned())),
                 );
-                let limits = limits_clone.read().unwrap();
-                let value = limits.get(&update.key).unwrap();
+                let limits = limits_clone.read().expect("lock poisoned");
+                let value = limits.get(&update.key).expect("counter key must exist in limits map");
                 value
                     .value
                     .merge((UNIX_EPOCH + Duration::from_secs(update.expires_at), values).into());
@@ -273,7 +277,7 @@ impl CrInMemoryStorage {
 
     fn delete_counters_of_limit(&self, limit: &Limit) {
         let key = encode_limit_to_key(limit);
-        self.limits.write().unwrap().remove(&key);
+        self.limits.write().expect("lock poisoned").remove(&key);
     }
 
     fn counter_is_within_limits(counter: &Counter, current_val: Option<&u64>, delta: u64) -> bool {
@@ -295,13 +299,13 @@ async fn process_re_sync(limits: &Arc<RwLock<LimitsMap>>, sender: Sender<Option<
     // sending all the counters to the peer might take a while, so we don't want to lock
     // the limits map for too long, lets figure first get the list of keys that needs to be sent.
     let keys: Vec<_> = {
-        let limits = limits.read().unwrap();
+        let limits = limits.read().expect("lock poisoned");
         limits.keys().cloned().collect()
     };
 
     for key in keys {
         let update = {
-            let limits = limits.read().unwrap();
+            let limits = limits.read().expect("lock poisoned");
             limits.get(&key).and_then(|store_value| {
                 let (expiry, ourself, value) = store_value.value.local_values();
                 if value == 0 || expiry <= SystemTime::now() {
@@ -311,7 +315,7 @@ async fn process_re_sync(limits: &Arc<RwLock<LimitsMap>>, sender: Sender<Option<
                     Some(CounterUpdate {
                         key: key.clone(),
                         values,
-                        expires_at: expiry.duration_since(UNIX_EPOCH).unwrap().as_secs(),
+                        expires_at: expiry.duration_since(UNIX_EPOCH).expect("expiry time before Unix epoch").as_secs(),
                     })
                 }
             })

--- a/limitador/src/storage/in_memory.rs
+++ b/limitador/src/storage/in_memory.rs
@@ -24,7 +24,7 @@ impl CounterStorage for InMemoryStorage {
                 .map(|c| c.value())
                 .unwrap_or_default()
         } else {
-            let limits_by_namespace = self.simple_limits.read().unwrap();
+            let limits_by_namespace = self.simple_limits.read().expect("lock poisoned");
             limits_by_namespace
                 .get(counter.limit())
                 .map(|c| c.value())
@@ -37,7 +37,7 @@ impl CounterStorage for InMemoryStorage {
     #[tracing::instrument(skip_all)]
     fn add_counter(&self, limit: &Limit) -> Result<(), StorageErr> {
         if limit.variables().is_empty() {
-            let mut limits_by_namespace = self.simple_limits.write().unwrap();
+            let mut limits_by_namespace = self.simple_limits.write().expect("lock poisoned");
             limits_by_namespace.entry(limit.clone()).or_default();
         }
         Ok(())
@@ -45,7 +45,7 @@ impl CounterStorage for InMemoryStorage {
 
     #[tracing::instrument(skip_all)]
     fn update_counter(&self, counter: &Counter, delta: u64) -> Result<(), StorageErr> {
-        let mut counters = self.simple_limits.write().unwrap();
+        let mut counters = self.simple_limits.write().expect("lock poisoned");
         let now = SystemTime::now();
         if counter.is_qualified() {
             let value = match self.qualified_counters.get(counter) {
@@ -75,7 +75,7 @@ impl CounterStorage for InMemoryStorage {
         delta: u64,
         load_counters: bool,
     ) -> Result<Authorization, StorageErr> {
-        let limits_by_namespace = self.simple_limits.read().unwrap();
+        let limits_by_namespace = self.simple_limits.read().expect("lock poisoned");
         let mut first_limited = None;
         let mut counter_values_to_update: Vec<(&AtomicExpiringValue, Duration)> = Vec::new();
         let mut qualified_counter_values_to_updated: Vec<(Arc<AtomicExpiringValue>, Duration)> =
@@ -104,7 +104,7 @@ impl CounterStorage for InMemoryStorage {
         // Process simple counters
         for counter in counters.iter_mut().filter(|c| !c.is_qualified()) {
             let atomic_expiring_value: &AtomicExpiringValue =
-                limits_by_namespace.get(counter.limit()).unwrap();
+                limits_by_namespace.get(counter.limit()).expect("counter limit must be registered");
 
             if let Some(limited) = process_counter(counter, atomic_expiring_value.value(), delta) {
                 if !load_counters {
@@ -165,7 +165,7 @@ impl CounterStorage for InMemoryStorage {
                 counter_with_val
                     .set_remaining(counter_with_val.max_value() - expiring_value.value());
                 counter_with_val.set_expires_in(expiring_value.ttl());
-                if counter_with_val.expires_in().unwrap() > Duration::ZERO {
+                if counter_with_val.expires_in().expect("expires_in was just set") > Duration::ZERO {
                     res.insert(counter_with_val);
                 }
             }
@@ -177,7 +177,7 @@ impl CounterStorage for InMemoryStorage {
                 counter_with_val
                     .set_remaining(counter_with_val.max_value() - expiring_value.value());
                 counter_with_val.set_expires_in(expiring_value.ttl());
-                if counter_with_val.expires_in().unwrap() > Duration::ZERO {
+                if counter_with_val.expires_in().expect("expires_in was just set") > Duration::ZERO {
                     res.insert(counter_with_val);
                 }
             }
@@ -196,7 +196,7 @@ impl CounterStorage for InMemoryStorage {
 
     #[tracing::instrument(skip_all)]
     fn clear(&self) -> Result<(), StorageErr> {
-        self.simple_limits.write().unwrap().clear();
+        self.simple_limits.write().expect("lock poisoned").clear();
         Ok(())
     }
 }
@@ -217,13 +217,13 @@ impl InMemoryStorage {
     ) -> HashMap<Counter, AtomicExpiringValue> {
         let mut res: HashMap<Counter, AtomicExpiringValue> = HashMap::new();
 
-        for (limit, counter) in self.simple_limits.read().unwrap().iter() {
+        for (limit, counter) in self.simple_limits.read().expect("lock poisoned").iter() {
             if limit.namespace() == namespace {
                 res.insert(
                     // todo fixme
                     Counter::new(limit.clone(), &Context::default())
-                        .unwrap()
-                        .unwrap(),
+                        .expect("stored limit must produce valid counter")
+                        .expect("stored limit must produce valid counter"),
                     counter.clone(),
                 );
             }
@@ -240,7 +240,7 @@ impl InMemoryStorage {
 
     fn delete_counters_of_limit(&self, limit: &Limit) {
         if limit.variables().is_empty() {
-            self.simple_limits.write().unwrap().remove(limit);
+            self.simple_limits.write().expect("lock poisoned").remove(limit);
         } else {
             let l = limit.clone();
             if let Err(PredicateError::InvalidationClosuresDisabled) = self
@@ -271,6 +271,7 @@ impl Default for InMemoryStorage {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/limitador/src/storage/keys.rs
+++ b/limitador/src/storage/keys.rs
@@ -24,12 +24,12 @@ pub fn key_for_counter(counter: &Counter) -> Vec<u8> {
         let key = if counter.remaining().is_some() || counter.expires_in().is_some() {
             format!(
                 "namespace:{{{namespace}}},counter:{}",
-                serde_json::to_string(&counter.key()).unwrap()
+                serde_json::to_string(&counter.key()).expect("counter key serialization failed")
             )
         } else {
             format!(
                 "namespace:{{{namespace}}},counter:{}",
-                serde_json::to_string(counter).unwrap()
+                serde_json::to_string(counter).expect("counter serialization failed")
             )
         };
         key.into_bytes()
@@ -49,14 +49,14 @@ pub fn key_for_counters_of_limit(limit: &Limit) -> Vec<u8> {
         let key = IdLimitKey { id };
 
         let mut encoded_key = Vec::new();
-        encoded_key = postcard::to_extend(&2u8, encoded_key).unwrap();
-        encoded_key = postcard::to_extend(&key, encoded_key).unwrap();
+        encoded_key = postcard::to_extend(&2u8, encoded_key).expect("postcard serialization failed");
+        encoded_key = postcard::to_extend(&key, encoded_key).expect("postcard serialization failed");
         encoded_key
     } else {
         let namespace = limit.namespace().as_ref();
         format!(
             "namespace:{{{namespace}}},counters_of_limit:{}",
-            serde_json::to_string(limit).unwrap()
+            serde_json::to_string(limit).expect("limit serialization failed")
         )
         .into_bytes()
     }
@@ -201,7 +201,7 @@ pub mod bin {
     impl<'a> From<&'a Counter> for IdCounterKey<'a> {
         fn from(counter: &'a Counter) -> Self {
             IdCounterKey {
-                id: counter.id().unwrap(),
+                id: counter.id().expect("counter id must be set"),
                 variables: counter.variables_for_key(),
             }
         }
@@ -237,18 +237,18 @@ pub mod bin {
         let mut encoded_key = Vec::new();
         if counter.id().is_none() {
             let key: CounterKey = counter.into();
-            encoded_key = postcard::to_extend(&1u8, encoded_key).unwrap();
-            encoded_key = postcard::to_extend(&key, encoded_key).unwrap()
+            encoded_key = postcard::to_extend(&1u8, encoded_key).expect("postcard serialization failed");
+            encoded_key = postcard::to_extend(&key, encoded_key).expect("postcard serialization failed")
         } else {
             let key: IdCounterKey = counter.into();
-            encoded_key = postcard::to_extend(&2u8, encoded_key).unwrap();
-            encoded_key = postcard::to_extend(&key, encoded_key).unwrap();
+            encoded_key = postcard::to_extend(&2u8, encoded_key).expect("postcard serialization failed");
+            encoded_key = postcard::to_extend(&key, encoded_key).expect("postcard serialization failed");
         }
         encoded_key
     }
 
     pub fn partial_counter_from_counter_key_v2(key: &[u8]) -> Counter {
-        let (version, key) = postcard::take_from_bytes::<u8>(key).unwrap();
+        let (version, key) = postcard::take_from_bytes::<u8>(key).expect("key deserialization failed");
         match version {
             1u8 => {
                 let CounterKey {
@@ -256,7 +256,7 @@ pub mod bin {
                     seconds,
                     conditions,
                     variables,
-                } = postcard::from_bytes(key).unwrap();
+                } = postcard::from_bytes(key).expect("key deserialization failed");
 
                 let map: HashMap<String, String> = variables
                     .into_iter()
@@ -275,7 +275,7 @@ pub mod bin {
                 Counter::resolved_vars(limit, map).expect("counter creation failed!")
             }
             2u8 => {
-                let IdCounterKey { id, variables } = postcard::from_bytes(key).unwrap();
+                let IdCounterKey { id, variables } = postcard::from_bytes(key).expect("key deserialization failed");
                 let map: HashMap<String, String> = variables
                     .into_iter()
                     .map(|(var, value)| (var.to_string(), value.to_string()))
@@ -299,15 +299,15 @@ pub mod bin {
 
     pub fn key_for_counter(counter: &Counter) -> Vec<u8> {
         let key: CounterKey = counter.into();
-        postcard::to_stdvec(&key).unwrap()
+        postcard::to_stdvec(&key).expect("postcard serialization failed")
     }
 
     pub fn prefix_for_namespace(namespace: &str) -> Vec<u8> {
-        postcard::to_stdvec(namespace).unwrap()
+        postcard::to_stdvec(namespace).expect("postcard serialization failed")
     }
 
     pub fn partial_counter_from_counter_key(key: &[u8]) -> Counter {
-        let key: CounterKey = postcard::from_bytes(key).unwrap();
+        let key: CounterKey = postcard::from_bytes(key).expect("key deserialization failed");
         let CounterKey {
             ns,
             seconds,
@@ -330,7 +330,7 @@ pub mod bin {
             map.keys()
                 .map(|p| p.as_str().try_into().expect("variable corrupted!")),
         );
-        Counter::resolved_vars(limit, map).unwrap()
+        Counter::resolved_vars(limit, map).expect("counter creation failed!")
     }
 
     #[cfg(test)]

--- a/limitador/src/storage/mod.rs
+++ b/limitador/src/storage/mod.rs
@@ -54,18 +54,18 @@ impl Storage {
     }
 
     pub fn get_namespaces(&self) -> HashSet<Namespace> {
-        self.limits.read().unwrap().keys().cloned().collect()
+        self.limits.read().expect("lock poisoned").keys().cloned().collect()
     }
 
     pub fn add_limit(&self, limit: Limit) -> bool {
         let namespace = limit.namespace().clone();
-        let mut limits = self.limits.write().unwrap();
-        self.counters.add_counter(&limit).unwrap();
+        let mut limits = self.limits.write().expect("lock poisoned");
+        self.counters.add_counter(&limit).expect("add_counter failed");
         limits.entry(namespace).or_default().insert(Arc::new(limit))
     }
 
     pub fn update_limit(&self, update: &Limit) -> bool {
-        let mut namespaces = self.limits.write().unwrap();
+        let mut namespaces = self.limits.write().expect("lock poisoned");
         let limits = namespaces.get_mut(update.namespace());
         if let Some(limits) = limits {
             let req_update = if let Some(limit) = limits.get(update) {
@@ -83,7 +83,7 @@ impl Storage {
     }
 
     pub fn get_limits(&self, namespace: &Namespace) -> HashSet<Arc<Limit>> {
-        match self.limits.read().unwrap().get(namespace) {
+        match self.limits.read().expect("lock poisoned").get(namespace) {
             // todo revise typing here?
             Some(limits) => limits.iter().map(Arc::clone).collect(),
             None => HashSet::new(),
@@ -91,7 +91,7 @@ impl Storage {
     }
 
     pub fn delete_limit(&self, limit: &Limit) -> Result<(), StorageErr> {
-        let arc = match self.limits.read().unwrap().get(limit.namespace()) {
+        let arc = match self.limits.read().expect("lock poisoned").get(limit.namespace()) {
             None => Arc::new(limit.clone()),
             Some(limits) => limits
                 .iter()
@@ -103,7 +103,7 @@ impl Storage {
         limits.insert(arc);
         self.counters.delete_counters(&limits)?;
 
-        let mut limits = self.limits.write().unwrap();
+        let mut limits = self.limits.write().expect("lock poisoned");
 
         if let Some(limits_for_ns) = limits.get_mut(limit.namespace()) {
             limits_for_ns.remove(limit);
@@ -116,7 +116,7 @@ impl Storage {
     }
 
     pub fn delete_limits(&self, namespace: &Namespace) -> Result<(), StorageErr> {
-        if let Some(data) = self.limits.write().unwrap().remove(namespace) {
+        if let Some(data) = self.limits.write().expect("lock poisoned").remove(namespace) {
             self.counters.delete_counters(&data)?;
         }
         Ok(())
@@ -141,14 +141,14 @@ impl Storage {
     }
 
     pub fn get_counters(&self, namespace: &Namespace) -> Result<HashSet<Counter>, StorageErr> {
-        match self.limits.read().unwrap().get(namespace) {
+        match self.limits.read().expect("lock poisoned").get(namespace) {
             Some(limits) => self.counters.get_counters(limits),
             None => Ok(HashSet::new()),
         }
     }
 
     pub fn clear(&self) -> Result<(), StorageErr> {
-        self.limits.write().unwrap().clear();
+        self.limits.write().expect("lock poisoned").clear();
         self.counters.clear()
     }
 }
@@ -162,13 +162,13 @@ impl AsyncStorage {
     }
 
     pub fn get_namespaces(&self) -> HashSet<Namespace> {
-        self.limits.read().unwrap().keys().cloned().collect()
+        self.limits.read().expect("lock poisoned").keys().cloned().collect()
     }
 
     pub fn add_limit(&self, limit: Limit) -> bool {
         let namespace = limit.namespace().clone();
 
-        let mut limits_for_namespace = self.limits.write().unwrap();
+        let mut limits_for_namespace = self.limits.write().expect("lock poisoned");
 
         match limits_for_namespace.get_mut(&namespace) {
             Some(limits) => limits.insert(Arc::new(limit)),
@@ -182,7 +182,7 @@ impl AsyncStorage {
     }
 
     pub fn update_limit(&self, update: &Limit) -> bool {
-        let mut namespaces = self.limits.write().unwrap();
+        let mut namespaces = self.limits.write().expect("lock poisoned");
         let limits = namespaces.get_mut(update.namespace());
         if let Some(limits) = limits {
             let req_update = if let Some(limit) = limits.get(update) {
@@ -200,14 +200,14 @@ impl AsyncStorage {
     }
 
     pub fn get_limits(&self, namespace: &Namespace) -> HashSet<Arc<Limit>> {
-        match self.limits.read().unwrap().get(namespace) {
+        match self.limits.read().expect("lock poisoned").get(namespace) {
             Some(limits) => limits.iter().map(Arc::clone).collect(),
             None => HashSet::new(),
         }
     }
 
     pub async fn delete_limit(&self, limit: &Limit) -> Result<(), StorageErr> {
-        let arc = match self.limits.read().unwrap().get(limit.namespace()) {
+        let arc = match self.limits.read().expect("lock poisoned").get(limit.namespace()) {
             None => Arc::new(limit.clone()),
             Some(limits) => limits
                 .iter()
@@ -219,7 +219,7 @@ impl AsyncStorage {
         limits.insert(arc);
         self.counters.delete_counters(&limits).await?;
 
-        let mut limits_for_namespace = self.limits.write().unwrap();
+        let mut limits_for_namespace = self.limits.write().expect("lock poisoned");
 
         if let Some(counters_by_limit) = limits_for_namespace.get_mut(limit.namespace()) {
             counters_by_limit.remove(limit);
@@ -232,7 +232,7 @@ impl AsyncStorage {
     }
 
     pub async fn delete_limits(&self, namespace: &Namespace) -> Result<(), StorageErr> {
-        let option = { self.limits.write().unwrap().remove(namespace) };
+        let option = { self.limits.write().expect("lock poisoned").remove(namespace) };
         if let Some(data) = option {
             self.counters.delete_counters(&data).await?;
         }
@@ -271,7 +271,7 @@ impl AsyncStorage {
     }
 
     pub async fn clear(&self) -> Result<(), StorageErr> {
-        self.limits.write().unwrap().clear();
+        self.limits.write().expect("lock poisoned").clear();
         self.counters.clear().await
     }
 }

--- a/limitador/src/storage/redis/counters_cache.rs
+++ b/limitador/src/storage/redis/counters_cache.rs
@@ -165,11 +165,11 @@ impl Batcher {
             Entry::Occupied(needs_merge) => {
                 let arc = needs_merge.get();
                 if !Arc::ptr_eq(arc, &value) {
-                    arc.delta(&counter, value.pending_writes().unwrap());
+                    arc.delta(&counter, value.pending_writes().expect("pending_writes must be set"));
                 }
             }
             Entry::Vacant(miss) => {
-                self.limiter.acquire().await.unwrap().forget();
+                self.limiter.acquire().await.expect("semaphore closed unexpectedly").forget();
                 gauge!("batcher_size").increment(1);
                 miss.insert_entry(value);
             }
@@ -201,7 +201,7 @@ impl Batcher {
                 }
                 let mut result = HashMap::new();
                 for counter in &batch {
-                    let value = self.updates.get(counter).unwrap().clone();
+                    let value = self.updates.get(counter).expect("counter must exist in updates after iteration").clone();
                     result.insert(counter.clone(), value);
                 }
                 histogram!("batcher_flush_size").record(result.len() as f64);
@@ -383,6 +383,7 @@ impl CountersCacheBuilder {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use std::collections::HashMap;
     use std::ops::Add;

--- a/limitador/src/storage/redis/redis_async.rs
+++ b/limitador/src/storage/redis/redis_async.rs
@@ -267,6 +267,7 @@ impl AsyncRedisStorage {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use crate::storage::redis::AsyncRedisStorage;
     use redis::ErrorKind;

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -394,6 +394,7 @@ async fn flush_batcher_and_update_counters<C: ConnectionLike>(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use crate::counter::Counter;
     use crate::limit::Limit;

--- a/limitador/src/storage/redis/redis_sync.rs
+++ b/limitador/src/storage/redis/redis_sync.rs
@@ -228,7 +228,7 @@ impl ManageConnection for RedisConnectionManager {
 
 impl Default for RedisStorage {
     fn default() -> Self {
-        Self::new(DEFAULT_REDIS_URL).unwrap()
+        Self::new(DEFAULT_REDIS_URL).expect("failed to create default Redis storage")
     }
 }
 
@@ -243,6 +243,7 @@ impl From<::r2d2::Error> for StorageErr {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod test {
     use crate::storage::redis::RedisStorage;
 


### PR DESCRIPTION
Closes #280

## What this does

Enables the `clippy::unwrap_used` lint at crate level in both `limitador` and `limitador-server`:

```rust
#![deny(clippy::all, clippy::cargo, clippy::unwrap_used)]
```

Every `.unwrap()` call across both crates is replaced with `.expect("...")` carrying a message that explains the invariant or assumption behind it. Categories addressed:

- **RwLock poisoning** (`read/write().unwrap()`) - replaced with `.expect("lock poisoned")`
- **SystemTime before Unix epoch** - replaced with `.expect("system time before Unix epoch")`
- **Serialization/deserialization** (serde_json, postcard) - replaced with `.expect("serialization failed")` / `.expect("key deserialization failed")`
- **Post-error-check unwraps** (called after an early return on `Err`) - replaced with descriptive invariant messages
- **CLI required args** (clap `get_one` on required args) - replaced with `.expect("... arg is required")`
- **Test modules** - `#[allow(clippy::unwrap_used)]` added to each `#[cfg(test)] mod tests` block so test code is unaffected

## Testing

- `cargo clippy --no-default-features -p limitador` passes with zero errors
- The `disk_storage` and `redis_storage` features require libclang and Perl respectively and cannot be compiled on the development machine (Windows); those modules were fixed by reading source and applying the same patterns, and CI on Linux will validate them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved diagnostic messages for configuration, storage, networking, locking and server-startup failures.
  * Added clearer reporting for invalid state, encoding, time and address-handling errors.

* **Quality**
  * Strengthened static checks to detect unsafe unchecked operations during development.
  * Existing test coverage remains supported under the stricter checks.

* **Compatibility**
  * No public APIs, rate-limiting behaviour or data formats were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->