### PR TITLE
Prepare release v2.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "limitador-server"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limitador-server"
-version = "2.3.1"
+version = "2.3.2"
 authors = ["Alex Snaps <asnaps@redhat.com>", "Eguzki Astiz Lezaun <eguzki@redhat.com>", "David Ortiz <z.david.ortiz@gmail.com>"]
 license = "Apache-2.0"
 keywords = ["rate-limiting", "rate", "limiter", "envoy", "rls"]


### PR DESCRIPTION
Bump limitador-server version to 2.3.2. Crate version unchanged (no API changes).

Includes: openssl 0.10.80, Rust 1.97 Clippy fixes, dead_code suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)