### PR TITLE
fix: remove vendored OpenSSL to enable FIPS compliance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,15 +2470,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-src"
-version = "300.5.2+3.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d270b79e2926f5150189d475bc7e9d2c69f9c4697b185fa917d5a32b792d21b4"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2486,7 +2477,6 @@ checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -4,8 +4,10 @@
 
 FROM --platform=${BUILDPLATFORM} mirror.gcr.io/library/rust:1.88 AS limitador-build
 
-RUN apt update && apt upgrade -y \
-    && apt install -y protobuf-compiler clang g++-aarch64-linux-gnu libc6-dev-arm64-cross
+RUN dpkg --add-architecture arm64 \
+    && apt update && apt upgrade -y \
+    && apt install -y protobuf-compiler clang g++-aarch64-linux-gnu libc6-dev-arm64-cross \
+       libssl-dev:arm64 pkg-config
 
 RUN rustup target add aarch64-unknown-linux-gnu \
     && rustup toolchain install stable-aarch64-unknown-linux-gnu --force-non-host
@@ -19,7 +21,12 @@ ENV RUSTFLAGS="-C target-feature=-crt-static" \
     CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
     CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
     # https://github.com/rust-lang/rust-bindgen/issues/1229
-    BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/usr/aarch64-linux-gnu"
+    BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/usr/aarch64-linux-gnu" \
+    OPENSSL_LIB_DIR=/usr/lib/aarch64-linux-gnu \
+    OPENSSL_INCLUDE_DIR=/usr/include/aarch64-linux-gnu \
+    PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu \
+    PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig \
+    PKG_CONFIG_ALLOW_CROSS=1
 
 COPY . .
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,9 +1,11 @@
 # Build Stage: cross-compile for ppc64le (IBM POWER)
 FROM --platform=${BUILDPLATFORM} rust:1.88 AS limitador-build
 
-RUN apt-get update && apt-get upgrade -y && \
+RUN dpkg --add-architecture ppc64el \
+    && apt-get update && apt-get upgrade -y && \
     apt-get install -y --no-install-recommends protobuf-compiler clang \
-    gcc-powerpc64le-linux-gnu g++-powerpc64le-linux-gnu libc6-dev-ppc64el-cross
+    gcc-powerpc64le-linux-gnu g++-powerpc64le-linux-gnu libc6-dev-ppc64el-cross \
+    libssl-dev:ppc64el pkg-config
 
 RUN rustup target add powerpc64le-unknown-linux-gnu
 
@@ -15,7 +17,12 @@ ENV RUSTFLAGS="-C target-feature=-crt-static" \
     CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER=powerpc64le-linux-gnu-gcc \
     CC_powerpc64le_unknown_linux_gnu=powerpc64le-linux-gnu-gcc \
     CXX_powerpc64le_unknown_linux_gnu=powerpc64le-linux-gnu-g++ \
-    BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/usr/powerpc64le-linux-gnu"
+    BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/usr/powerpc64le-linux-gnu" \
+    OPENSSL_LIB_DIR=/usr/lib/powerpc64le-linux-gnu \
+    OPENSSL_INCLUDE_DIR=/usr/include/powerpc64le-linux-gnu \
+    PKG_CONFIG_SYSROOT_DIR=/usr/powerpc64le-linux-gnu \
+    PKG_CONFIG_PATH=/usr/lib/powerpc64le-linux-gnu/pkgconfig \
+    PKG_CONFIG_ALLOW_CROSS=1
 
 COPY . .
 RUN cargo build --release --target powerpc64le-unknown-linux-gnu

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -4,9 +4,11 @@
 
 FROM --platform=${BUILDPLATFORM} rust:1.88 AS limitador-build
 
-RUN apt-get update && apt-get upgrade -y \
+RUN dpkg --add-architecture s390x \
+    && apt-get update && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends protobuf-compiler clang \
-        gcc-s390x-linux-gnu g++-s390x-linux-gnu libc6-dev-s390x-cross
+        gcc-s390x-linux-gnu g++-s390x-linux-gnu libc6-dev-s390x-cross \
+        libssl-dev:s390x pkg-config
 
 RUN rustup target add s390x-unknown-linux-gnu
 
@@ -18,7 +20,12 @@ ENV RUSTFLAGS="-C target-feature=-crt-static" \
     CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER=s390x-linux-gnu-gcc \
     CC_s390x_unknown_linux_gnu=s390x-linux-gnu-gcc \
     CXX_s390x_unknown_linux_gnu=s390x-linux-gnu-g++ \
-    BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/usr/s390x-linux-gnu"
+    BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/usr/s390x-linux-gnu" \
+    OPENSSL_LIB_DIR=/usr/lib/s390x-linux-gnu \
+    OPENSSL_INCLUDE_DIR=/usr/include/s390x-linux-gnu \
+    PKG_CONFIG_SYSROOT_DIR=/usr/s390x-linux-gnu \
+    PKG_CONFIG_PATH=/usr/lib/s390x-linux-gnu/pkgconfig \
+    PKG_CONFIG_ALLOW_CROSS=1
 
 COPY . .
 

--- a/limitador-server/Cargo.toml
+++ b/limitador-server/Cargo.toml
@@ -46,7 +46,7 @@ const_format = "0.2.31"
 lazy_static = "1.4.0"
 clap = "4.3"
 sysinfo = "0.32"
-openssl = { version = "0.10.80", features = ["vendored"] }
+openssl = "0.10.80"
 metrics = "0.24.2"
 metrics-exporter-prometheus = { version = "0.17.2", default-features = false, features = ["http-listener"] }
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
## Summary

Remove `features = ["vendored"]` from the `openssl` dependency in `limitador-server/Cargo.toml` so the binary links against the system `libcrypto.so` instead of a statically compiled upstream OpenSSL.

## Why this is needed — FIPS compliance for RHOAI

Red Hat OpenShift AI (RHOAI) requires all productized images to be "Designed for FIPS". This means: when deployed on a FIPS-enabled OpenShift cluster, cryptographic operations must use the FIPS-validated cryptographic modules provided by the underlying RHEL operating system.

### What `features = ["vendored"]` does

The `vendored` feature causes `cargo` to pull in `openssl-src` and compile OpenSSL 3.5.2 **from upstream source** at build time, then statically link the resulting `libcrypto.a` directly into the `limitador-server` binary. The binary carries its own private copy of OpenSSL inside it.

This means:
- `ldd limitador-server` shows no `libcrypto.so` dependency
- `/proc/1/maps` shows no `libcrypto.so` mapped at runtime
- The binary uses upstream OpenSSL 3.5.2, **not** the RHEL FIPS-validated OpenSSL (CMVP certificate #4746)
- The host kernel's FIPS mode flag (`/proc/sys/crypto/fips_enabled`) is ignored by the bundled OpenSSL
- The `check-payload` tool passes (it only checks for dynamic library issues) but the binary is still not using validated crypto

### What removing `vendored` does

Without `vendored`, cargo links against the system `libcrypto.so` via `openssl-sys` pkg-config. On UBI 9 / RHEL 9:
- The build stage already installs `openssl-devel` (line 7 of the product Containerfile), providing the pkg-config paths
- The runtime image needs `openssl-libs` added so `libcrypto.so.3.x.x` is present at runtime
- The binary will dynamically load the RHEL FIPS-validated OpenSSL at startup
- On a FIPS-enabled host, OpenSSL 3's FIPS provider activates automatically

### Verification

All other RHCL Go operator components have been updated with equivalent FIPS flags and runtime-verified on an OpenShift 4.20 FIPS cluster:
- `libcrypto.so.3.5.5` present in `/proc/1/maps`
- Zero startup panics
- `fips_enabled=1` confirmed inside each pod

Limitador is the only RHCL component where the operand binary currently uses non-validated crypto.

## Changes

- `limitador-server/Cargo.toml`: remove `features = ["vendored"]` from `openssl` dependency

The product build Containerfile (`limitador-product-build`) will also need `openssl-libs` added to the runtime stage — that change is tracked separately in the product build repo.

## Draft status

This PR is a draft pending:
- [ ] Confirmation that limitador-server actually compiles and passes tests without `vendored` (the build stage installs `openssl-devel` so pkg-config should resolve, but this needs CI verification)
- [ ] Agreement from the limitador team on the approach
- [ ] Corresponding change in `rh-api-management/limitador-product-build` to add `openssl-libs` to the runtime stage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved build support for ARM64, PowerPC 64-bit, and IBM Z platforms.
  - Cross-platform builds now use the appropriate system libraries and compilation settings for each target architecture.
  - Updated build configuration to improve reliability when producing server binaries for these platforms.
  - Standardised cryptographic library handling across supported cross-compilation environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->