### PR TITLE
release workflow enhancement

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -242,6 +242,9 @@ jobs:
           echo "version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
           echo "crate-version=${NEXT_CRATE_VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Fetch crate sources and registry index entries
+        run: cargo fetch --locked
+
       - name: Create post-release branch
         env:
           VERSION: ${{ needs.setup.outputs.version }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -72,8 +72,9 @@ The following secrets must be configured in **Settings > Secrets and variables >
 ### Phase 2: Release
 
 1. Go to [Actions > Release](https://github.com/Kuadrant/limitador/actions/workflows/release.yaml) and click **Run workflow**
-2. Enter the **release branch** (e.g. `release-2.5`)
-3. The workflow will (in strict order):
+2. Use workflow from **release branch** (e.g. `release-2.5`).
+3. Enter the **release branch** (e.g. `release-2.5`) input field.
+4. The workflow will (in strict order):
    - **Read version** from `release.yaml` and verify no existing GitHub Release
    - **Smoke tests** — fmt, clippy, check, full test suite, `cargo publish --dry-run`
    - **Tag** — create and push three tags (`vX.Y.Z`, `server-vX.Y.Z`, `crate-vX.Y.Z`)


### PR DESCRIPTION
*in post-release,  --offline forces cargo-edit to run cargo metadata using only what's already in the local Cargo registry cache, without hitting crates.io. Nothing in the job populates that cache beforehand
* Update RELEASE.md with missing steps. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified release instructions to specify using the workflow from the release branch and where to provide the branch input.

* **Chores**
  * Improved the release workflow’s preparation step to fetch locked crate sources and registry data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->