### PR TITLE
CI check for stale Cargo.lock

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,12 +12,17 @@ on:
   schedule:
     - cron: "5 4 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: Swatinem/rust-cache@v2
       - uses: abelfodil/protoc-action@v1
@@ -30,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: Swatinem/rust-cache@v2
       - uses: abelfodil/protoc-action@v1
@@ -42,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: supercharge/redis-github-action@1.8.1
         with:
           redis-version: 7
@@ -57,6 +66,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
@@ -68,6 +79,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
@@ -82,6 +95,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: helm/kind-action@v1.2.0
         with:
           version: v0.23.0
@@ -109,6 +124,8 @@ jobs:
             platform: linux/ppc64le
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build
@@ -133,4 +150,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - run: echo '${{ toJSON(needs) }}' | jq -e 'all(.[]; .result == "success" or .result == "skipped")'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,18 @@ jobs:
           protoc-version: "3.19.4"
       - run: cargo check --all-features
 
+  lockfile:
+    name: Lockfile up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+      - uses: abelfodil/protoc-action@v1
+        with:
+          protoc-version: "3.19.4"
+      - run: cargo check --all-features --locked
+
   test:
     name: Test Suite
     runs-on: ubuntu-latest
@@ -116,7 +128,7 @@ jobs:
     # This check adds a list of checks to one job to simplify adding settings to the repo.
     # If a new check is added in this file, and it should be retested on entry to the merge queue,
     # it needs to be added to the list below aka needs: [ existing check 1, existing check 2, new check ].
-    needs: [check, test, fmt, clippy, image]
+    needs: [check, lockfile, test, fmt, clippy, image]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
After merge, rulesets must be updated to include this check in required check list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted workflow permissions to read-only repository contents.
  * Disabled credential persistence during source checkout.

* **CI Improvements**
  * Added verification that the dependency lockfile is up to date.
  * Included lockfile verification in the required checks before changes can be merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->