### PR TITLE
Pin github actions with ratchet

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,13 +14,13 @@ jobs:
     name: Benchmark
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: supercharge/redis-github-action@1.8.1
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
+      - uses: supercharge/redis-github-action@bc274cb7238cd63a45029db04ee48c07a72609fd # ratchet:supercharge/redis-github-action@1.8.1
         with:
           redis-version: 7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
-      - uses: abelfodil/protoc-action@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # ratchet:actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # ratchet:Swatinem/rust-cache@v2
+      - uses: abelfodil/protoc-action@b540a249a18feedb02bfbfa655afa15255cf3dc6 # ratchet:abelfodil/protoc-action@v1
         with:
           protoc-version: "3.19.4"
       - run: cargo bench

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -48,14 +48,14 @@ jobs:
             artifactsuffix: ppc64le
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
         with:
           images: |
             ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/limitador
@@ -63,14 +63,14 @@ jobs:
         id: sha
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Login to container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # ratchet:docker/login-action@v2
         with:
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
           registry: ${{ env.IMG_REGISTRY_HOST }}
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # ratchet:docker/build-push-action@v5
         with:
           context: .
           labels: ${{ steps.meta.outputs.labels }}
@@ -89,7 +89,7 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         with:
           name: digests-${{ matrix.artifactsuffix }}
           path: /tmp/digests/*
@@ -101,17 +101,17 @@ jobs:
       - build
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
         with:
           pattern: digests-*
           path: /tmp/digests
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # ratchet:docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
         with:
           images: |
             ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/limitador
@@ -125,7 +125,7 @@ jobs:
             # set ref name tag for non-main branches
             type=raw,value=${{ github.ref_name }},enable=${{ inputs.tag == '' && github.ref_name != env.MAIN_BRANCH_NAME }}
       - name: Login to container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # ratchet:docker/login-action@v2
         with:
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,13 +11,13 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
-      - uses: abelfodil/protoc-action@v1
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # ratchet:actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # ratchet:Swatinem/rust-cache@v2
+      - uses: abelfodil/protoc-action@b540a249a18feedb02bfbfa655afa15255cf3dc6 # ratchet:abelfodil/protoc-action@v1
         with:
           protoc-version: "3.19.4"
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # ratchet:actions-rs/cargo@v1
         with:
           command: check
 
@@ -25,28 +25,28 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: supercharge/redis-github-action@1.8.1
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
+      - uses: supercharge/redis-github-action@bc274cb7238cd63a45029db04ee48c07a72609fd # ratchet:supercharge/redis-github-action@1.8.1
         with:
           redis-version: 7
       # Nightly is required for code coverage with doctests
       # https://github.com/taiki-e/cargo-llvm-cov/issues/2
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # ratchet:actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly
-      - uses: Swatinem/rust-cache@v2
-      - uses: abelfodil/protoc-action@v1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # ratchet:Swatinem/rust-cache@v2
+      - uses: abelfodil/protoc-action@b540a249a18feedb02bfbfa655afa15255cf3dc6 # ratchet:abelfodil/protoc-action@v1
         with:
           protoc-version: "3.19.4"
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@2d2710c179509122228fa1f6bb32c8e3c78b21a9 # ratchet:taiki-e/install-action@cargo-llvm-cov
       - name: Test and Generate code coverage
         run: cargo +nightly llvm-cov --all-features --workspace --lcov --doctests --output-path lcov.info
       - name: Codecov
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         if: env.CODECOV_TOKEN != null
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # ratchet:codecov/codecov-action@v3
         with:
           verbose: true
           fail_ci_if_error: false

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
         with:
           images: |
             limitador-testing
@@ -26,7 +26,7 @@ jobs:
             type=raw,value=latest
       - name: Build Limitador Image
         id: build-image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # ratchet:docker/build-push-action@v5
         with:
           context: .
           tags: ${{ steps.meta.outputs.tags }}
@@ -34,7 +34,7 @@ jobs:
           cache-to: type=gha,mode=max
           load: true
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.8.0
+        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # ratchet:helm/kind-action@v1.8.0
         with:
           version: v0.20.0
           config: limitador-server/script/kind-cluster.yaml
@@ -60,7 +60,7 @@ jobs:
           # use 'wait' to check for Available status in .status.conditions[]
           kubectl wait deployment limitador --for condition=Available=True --timeout=300s
       - name: Read limits from HTTP endpoint
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # ratchet:nick-fields/retry@v2
         with:
           timeout_seconds: 10
           max_attempts: 10
@@ -79,7 +79,7 @@ jobs:
         run: |
           limitador-server/e2e/file-watcher/watch-pod-env.sh </dev/null 2>/dev/null &
       - name: Read new limits from HTTP endpoint
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # ratchet:nick-fields/retry@v2
         with:
           timeout_seconds: 10
           max_attempts: 10
@@ -94,21 +94,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Run docker compose
         run: |
           docker compose -f ./limitador-server/sandbox/docker-compose-limitador-memory.yaml up -d
       - name: Wait for limitador availability
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # ratchet:nick-fields/retry@v2
         with:
           timeout_seconds: 10
           max_attempts: 10
           command: |
             curl --fail -s "http://127.0.0.1:18080/status"
       - name: Read limits from HTTP endpoint
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # ratchet:nick-fields/retry@v2
         with:
           timeout_seconds: 10
           max_attempts: 10
@@ -126,7 +126,7 @@ jobs:
             variables: []
           EOF
       - name: Read new limits from HTTP endpoint
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # ratchet:nick-fields/retry@v2
         with:
           timeout_seconds: 10
           max_attempts: 10

--- a/.github/workflows/issues-workflow.yaml
+++ b/.github/workflows/issues-workflow.yaml
@@ -19,7 +19,7 @@ jobs:
     if: (github.event.pull_request.head.repo.full_name == github.repository || github.event.issue.number != '') && (github.event_name == 'issues' || github.event.pull_request.user.login != 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@31b3f3ccdc584546fc445612dec3f38ff5edb41c # ratchet:actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/Kuadrant/projects/18
           github-token: ${{ secrets.ADD_ISSUES_TOKEN }}

--- a/.github/workflows/license-scan.yaml
+++ b/.github/workflows/license-scan.yaml
@@ -15,14 +15,14 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: fossas/fossa-action@v1.4.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
+      - uses: fossas/fossa-action@09bcf127dc0ccb4b5a023f6f906728878e8610ba # ratchet:fossas/fossa-action@v1.4.0
         name: License Scan
         with:
           api-key: ${{secrets.FOSSA_API_TOKEN}}
           branch: ${{ github.head_ref || github.ref_name }}
           project: git+github.com/Kuadrant/limitador
-      - uses: fossas/fossa-action@v1.4.0
+      - uses: fossas/fossa-action@09bcf127dc0ccb4b5a023f6f906728878e8610ba # ratchet:fossas/fossa-action@v1.4.0
         name: License test for issues
         with:
           api-key: ${{secrets.FOSSA_API_TOKEN}}

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -34,7 +34,7 @@ jobs:
       crate-version: ${{ steps.validate.outputs.crate-version }}
       release-branch: ${{ steps.validate.outputs.release-branch }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           ref: ${{ inputs.source-branch }}
           fetch-depth: 0
@@ -80,17 +80,17 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           ref: ${{ needs.setup.outputs.release-branch }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # ratchet:actions-rust-lang/setup-rust-toolchain@v1
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # ratchet:Swatinem/rust-cache@v2
 
-      - uses: abelfodil/protoc-action@v1
+      - uses: abelfodil/protoc-action@b540a249a18feedb02bfbfa655afa15255cf3dc6 # ratchet:abelfodil/protoc-action@v1
         with:
           protoc-version: "3.19.4"
 
@@ -166,7 +166,7 @@ jobs:
     needs: [setup, prepare-release]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
 
       - name: Open pull request
         env:
@@ -208,16 +208,16 @@ jobs:
     needs: [setup, open-pr]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # ratchet:actions-rust-lang/setup-rust-toolchain@v1
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # ratchet:Swatinem/rust-cache@v2
 
-      - uses: abelfodil/protoc-action@v1
+      - uses: abelfodil/protoc-action@b540a249a18feedb02bfbfa655afa15255cf3dc6 # ratchet:abelfodil/protoc-action@v1
         with:
           protoc-version: "3.19.4"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,13 +25,13 @@ jobs:
       major: ${{ steps.parse.outputs.major }}
       minor: ${{ steps.parse.outputs.minor }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           ref: ${{ inputs.release-branch }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # ratchet:actions-rust-lang/setup-rust-toolchain@v1
 
-      - uses: abelfodil/protoc-action@v1
+      - uses: abelfodil/protoc-action@b540a249a18feedb02bfbfa655afa15255cf3dc6 # ratchet:abelfodil/protoc-action@v1
         with:
           protoc-version: "3.19.4"
 
@@ -89,21 +89,21 @@ jobs:
     needs: read-version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           ref: ${{ inputs.release-branch }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # ratchet:actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # ratchet:Swatinem/rust-cache@v2
 
-      - uses: abelfodil/protoc-action@v1
+      - uses: abelfodil/protoc-action@b540a249a18feedb02bfbfa655afa15255cf3dc6 # ratchet:abelfodil/protoc-action@v1
         with:
           protoc-version: "3.19.4"
 
-      - uses: supercharge/redis-github-action@1.8.1
+      - uses: supercharge/redis-github-action@bc274cb7238cd63a45029db04ee48c07a72609fd # ratchet:supercharge/redis-github-action@1.8.1
         with:
           redis-version: 7
 
@@ -128,7 +128,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           ref: ${{ inputs.release-branch }}
           fetch-depth: 0
@@ -155,13 +155,13 @@ jobs:
     needs: [read-version, tag]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           ref: ${{ inputs.release-branch }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # ratchet:actions-rust-lang/setup-rust-toolchain@v1
 
-      - uses: abelfodil/protoc-action@v1
+      - uses: abelfodil/protoc-action@b540a249a18feedb02bfbfa655afa15255cf3dc6 # ratchet:abelfodil/protoc-action@v1
         with:
           protoc-version: "3.19.4"
 
@@ -184,7 +184,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           ref: ${{ inputs.release-branch }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,12 +20,12 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
-      - uses: abelfodil/protoc-action@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # ratchet:actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # ratchet:Swatinem/rust-cache@v2
+      - uses: abelfodil/protoc-action@b540a249a18feedb02bfbfa655afa15255cf3dc6 # ratchet:abelfodil/protoc-action@v1
         with:
           protoc-version: "3.19.4"
       - run: cargo check --all-features
@@ -34,12 +34,12 @@ jobs:
     name: Lockfile up to date
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
-      - uses: abelfodil/protoc-action@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # ratchet:actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # ratchet:Swatinem/rust-cache@v2
+      - uses: abelfodil/protoc-action@b540a249a18feedb02bfbfa655afa15255cf3dc6 # ratchet:abelfodil/protoc-action@v1
         with:
           protoc-version: "3.19.4"
       - run: cargo check --all-features --locked
@@ -48,15 +48,15 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: supercharge/redis-github-action@1.8.1
+      - uses: supercharge/redis-github-action@bc274cb7238cd63a45029db04ee48c07a72609fd # ratchet:supercharge/redis-github-action@1.8.1
         with:
           redis-version: 7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
-      - uses: abelfodil/protoc-action@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # ratchet:actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # ratchet:Swatinem/rust-cache@v2
+      - uses: abelfodil/protoc-action@b540a249a18feedb02bfbfa655afa15255cf3dc6 # ratchet:abelfodil/protoc-action@v1
         with:
           protoc-version: "3.19.4"
       - run: cargo test --all-features -vv
@@ -65,27 +65,27 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # ratchet:actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # ratchet:Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # ratchet:actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
-      - uses: abelfodil/protoc-action@v1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # ratchet:Swatinem/rust-cache@v2
+      - uses: abelfodil/protoc-action@b540a249a18feedb02bfbfa655afa15255cf3dc6 # ratchet:abelfodil/protoc-action@v1
         with:
           protoc-version: "3.19.4"
       - run: cargo clippy --all-features --all-targets -- -D warnings
@@ -94,10 +94,10 @@ jobs:
     name: Try in kind (Kubernetes in Docker)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: helm/kind-action@v1.2.0
+      - uses: helm/kind-action@94729529f85113b88f4f819c17ce61382e6d8478 # ratchet:helm/kind-action@v1.2.0
         with:
           version: v0.23.0
           install_only: true
@@ -123,13 +123,13 @@ jobs:
           - dockerfile: Dockerfile.ppc64le
             platform: linux/ppc64le
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
         with:
           push: false
           tags: limitador:dev
@@ -149,7 +149,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
       - run: echo '${{ toJSON(needs) }}' | jq -e 'all(.[]; .result == "success" or .result == "skipped")'

--- a/.github/workflows/version-gate.yaml
+++ b/.github/workflows/version-gate.yaml
@@ -15,11 +15,11 @@ jobs:
   check-version-consistency:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # ratchet:actions-rust-lang/setup-rust-toolchain@v1
 
-      - uses: abelfodil/protoc-action@v1
+      - uses: abelfodil/protoc-action@b540a249a18feedb02bfbfa655afa15255cf3dc6 # ratchet:abelfodil/protoc-action@v1
         with:
           protoc-version: "3.19.4"
 
@@ -34,7 +34,7 @@ jobs:
     if: startsWith(github.base_ref, 'release-')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
 
       - uses: ./.github/actions/install-yq
 


### PR DESCRIPTION
## Summary
  - Pin all GitHub Action references to commit SHAs using [ratchet](https://github.com/sethvargo/ratchet)

Part of the work on https://github.com/Kuadrant/kuadrant-operator/issues/2055

## Motivation
Tags are mutable — action maintainers can force-push them, silently changing the code our CI runs. Pinning to commit SHAs makes each reference immutable, mitigating supply-chain attacks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Maintenance**
  * Pinned GitHub Actions to immutable commit references across benchmarking, build, testing, release, scanning, and validation workflows.
  * Preserved existing workflow versions and configurations while improving protection against unexpected action changes.
* **Bug Fixes**
  * No user-facing behaviour or workflow functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->