### PR TITLE
Prune expired counters from Redis index

### DIFF
--- a/limitador/src/storage/redis/mod.rs
+++ b/limitador/src/storage/redis/mod.rs
@@ -11,13 +11,19 @@ pub const DEFAULT_FLUSHING_PERIOD_SEC: u64 = 1;
 pub const DEFAULT_BATCH_SIZE: usize = 100;
 pub const DEFAULT_MAX_CACHED_COUNTERS: usize = 10000;
 pub const DEFAULT_RESPONSE_TIMEOUT_MS: u64 = 350;
+// GET_COUNTERS_AND_PRUNE is atomic, so this size decides how long every other client waits on
+// Redis's single thread.
+const COUNTERS_SCAN_BATCH_SIZE: usize = 500;
 
 use crate::counter::Counter;
+use crate::limit::Limit;
+use crate::storage::keys::counter_from_counter_key;
 use crate::storage::{Authorization, StorageErr};
 pub use redis_async::AsyncRedisStorage;
 pub use redis_cached::CachedRedisStorage;
 pub use redis_cached::CachedRedisStorageBuilder;
 pub use redis_sync::RedisStorage;
+use std::sync::Arc;
 
 impl From<RedisError> for StorageErr {
     fn from(e: RedisError) -> Self {
@@ -31,6 +37,43 @@ impl From<RedisError> for StorageErr {
             transient,
         }
     }
+}
+
+// `script_res` holds a value and a TTL (in ms) for each of `members`, in the same order. A member
+// with no value is expired (the script has already dropped it from the limit's counter set, so it
+// yields no counter here).
+fn live_counters_from_script_res(
+    limit: &Arc<Limit>,
+    members: &[Vec<u8>],
+    script_res: &[Option<i64>],
+) -> Vec<Counter> {
+    // A mismatch would make the zip below drop counters silently rather than fail
+    debug_assert_eq!(
+        script_res.len(),
+        members.len() * 2,
+        "GET_COUNTERS_AND_PRUNE must report a value and a TTL for every member"
+    );
+
+    let mut counters = Vec::new();
+
+    for (member, val_ttl_pair) in members.iter().zip(script_res.chunks_exact(2)) {
+        let Some(val) = val_ttl_pair[0] else {
+            continue;
+        };
+
+        let mut counter = counter_from_counter_key(member, Arc::clone(limit));
+        counter.set_remaining(
+            limit
+                .max_value()
+                .saturating_sub(u64::try_from(val).unwrap_or(0)),
+        );
+        counter.set_expires_in(Duration::from_millis(
+            u64::try_from(val_ttl_pair[1].unwrap_or(0)).unwrap_or(0),
+        ));
+        counters.push(counter);
+    }
+
+    counters
 }
 
 pub fn is_limited(

--- a/limitador/src/storage/redis/redis_async.rs
+++ b/limitador/src/storage/redis/redis_async.rs
@@ -1,12 +1,14 @@
 extern crate redis;
 
-use self::redis::aio::ConnectionManager;
+use self::redis::aio::{ConnectionLike, ConnectionManager};
 use self::redis::ConnectionInfo;
 use crate::counter::Counter;
 use crate::limit::Limit;
 use crate::storage::keys::*;
-use crate::storage::redis::is_limited;
-use crate::storage::redis::scripts::{SCRIPT_UPDATE_COUNTER, VALUES_AND_TTLS};
+use crate::storage::redis::scripts::{
+    GET_COUNTERS_AND_PRUNE, SCRIPT_UPDATE_COUNTER, VALUES_AND_TTLS,
+};
+use crate::storage::redis::{is_limited, live_counters_from_script_res, COUNTERS_SCAN_BATCH_SIZE};
 use crate::storage::{AsyncCounterStorage, Authorization, StorageErr};
 use async_trait::async_trait;
 use redis::{AsyncCommands, ErrorKind, RedisError};
@@ -14,7 +16,6 @@ use std::collections::HashSet;
 use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
 use tracing::{info_span, Instrument};
 
 // Note: this implementation does not guarantee exact limits. Ensuring that we
@@ -156,39 +157,30 @@ impl AsyncCounterStorage for AsyncRedisStorage {
         let mut con = self.conn_manager.clone();
 
         for limit in limits {
-            let counter_keys = {
-                con.smembers::<Vec<u8>, HashSet<Vec<u8>>>(key_for_counters_of_limit(limit))
+            let set_key = key_for_counters_of_limit(limit);
+            let mut cursor = 0u64;
+
+            loop {
+                // SSCAN can repeat a member, or skip one added mid-scan. Duplicates collapse in `res`
+                // Skipped member stays in the set, so a later get_counters returns it.
+                let (next_cursor, members): (u64, Vec<Vec<u8>>) = redis::cmd("SSCAN")
+                    .arg(&set_key)
+                    .arg(cursor)
+                    .arg("COUNT")
+                    .arg(COUNTERS_SCAN_BATCH_SIZE)
+                    .query_async(&mut con)
                     .instrument(info_span!("datastore"))
-                    .await?
-            };
+                    .await?;
 
-            for counter_key in counter_keys {
-                let mut counter: Counter =
-                    counter_from_counter_key(&counter_key, Arc::clone(limit));
-
-                // If the key does not exist, it means that the counter expired,
-                // so we don't have to return it.
-                // TODO: we should delete the counter from the set of counters
-                // associated with the limit taking into account that we should
-                // do the "get" + "delete if none" atomically.
-                // This does not cause any bugs, but consumes memory
-                // unnecessarily.
-                let option = {
-                    con.get::<Vec<u8>, Option<i64>>(counter_key.clone())
-                        .instrument(info_span!("datastore"))
-                        .await?
-                };
-                if let Some(val) = option {
-                    counter.set_remaining(limit.max_value() - u64::try_from(val).unwrap_or(0));
-                    let ttl: i64 = {
-                        con.ttl(&counter_key)
-                            .instrument(info_span!("datastore"))
-                            .await?
-                    };
-                    counter.set_expires_in(Duration::from_secs(u64::try_from(ttl).unwrap_or(0)));
-
-                    res.insert(counter);
+                if !members.is_empty() {
+                    let script_res = read_and_prune_counters(&mut con, &set_key, &members).await?;
+                    res.extend(live_counters_from_script_res(limit, &members, &script_res));
                 }
+
+                if next_cursor == 0 {
+                    break;
+                }
+                cursor = next_cursor;
             }
         }
 
@@ -235,6 +227,7 @@ impl AsyncRedisStorage {
         let store = Self { conn_manager };
         store.load_script(SCRIPT_UPDATE_COUNTER).await?;
         store.load_script(VALUES_AND_TTLS).await?;
+        store.load_script(GET_COUNTERS_AND_PRUNE).await?;
         Ok(store)
     }
 
@@ -266,10 +259,65 @@ impl AsyncRedisStorage {
     }
 }
 
+async fn read_and_prune_counters<C: ConnectionLike>(
+    redis_conn: &mut C,
+    set_key: &[u8],
+    members: &[Vec<u8>],
+) -> Result<Vec<Option<i64>>, StorageErr> {
+    let script = redis::Script::new(GET_COUNTERS_AND_PRUNE);
+    let mut script_invocation = script.prepare_invoke();
+    script_invocation.key(set_key);
+    for member in members {
+        script_invocation.key(member);
+    }
+
+    Ok(script_invocation
+        .invoke_async(redis_conn)
+        .instrument(info_span!("datastore"))
+        .await?)
+}
+
 #[cfg(test)]
 mod tests {
+    use super::read_and_prune_counters;
+    use crate::storage::redis::scripts::GET_COUNTERS_AND_PRUNE;
     use crate::storage::redis::AsyncRedisStorage;
-    use redis::ErrorKind;
+    use redis::{ErrorKind, Value};
+    use redis_test::{MockCmd, MockRedisConnection};
+
+    #[tokio::test]
+    async fn read_and_prune_counters_declares_every_counter_as_a_key() {
+        let script = redis::Script::new(GET_COUNTERS_AND_PRUNE);
+        let set_key = b"namespace:{test_namespace},counters_of_limit:{}".to_vec();
+        let members = vec![
+            b"namespace:{test_namespace},counter:alive".to_vec(),
+            b"namespace:{test_namespace},counter:expired".to_vec(),
+        ];
+
+        // Every counter is declared as a key of its own, not an argument, so Redis cluster can route
+        // the script
+        let mut mock_client = MockRedisConnection::new(vec![MockCmd::new(
+            redis::cmd("EVALSHA")
+                .arg(script.get_hash())
+                .arg(3)
+                .arg(&set_key)
+                .arg(&members[0])
+                .arg(&members[1]),
+            Ok(Value::Array(vec![
+                Value::BulkString(b"3".to_vec()),
+                Value::Int(59_000),
+                Value::Nil,
+                Value::Int(-2),
+            ])),
+        )]);
+
+        let script_res = read_and_prune_counters(&mut mock_client, &set_key, &members)
+            .await
+            .expect("should have read the batch");
+
+        // A nil value marks the member the script removed, and does not shift the pairs that follow
+        assert_eq!(script_res, vec![Some(3), Some(59_000), None, Some(-2)]);
+    }
 
     #[tokio::test]
     async fn errs_on_bad_url() {

--- a/limitador/src/storage/redis/redis_sync.rs
+++ b/limitador/src/storage/redis/redis_sync.rs
@@ -4,8 +4,10 @@ use self::redis::{Commands, ConnectionInfo, ConnectionLike, IntoConnectionInfo, 
 use crate::counter::Counter;
 use crate::limit::Limit;
 use crate::storage::keys::*;
-use crate::storage::redis::is_limited;
-use crate::storage::redis::scripts::{SCRIPT_UPDATE_COUNTER, VALUES_AND_TTLS};
+use crate::storage::redis::scripts::{
+    GET_COUNTERS_AND_PRUNE, SCRIPT_UPDATE_COUNTER, VALUES_AND_TTLS,
+};
+use crate::storage::redis::{is_limited, live_counters_from_script_res, COUNTERS_SCAN_BATCH_SIZE};
 use crate::storage::{Authorization, CounterStorage, StorageErr};
 use r2d2::{ManageConnection, Pool};
 use std::collections::HashSet;
@@ -114,31 +116,35 @@ impl CounterStorage for RedisStorage {
         let mut con = self.conn_pool.get()?;
 
         for limit in limits {
-            let counter_keys =
-                con.smembers::<Vec<u8>, HashSet<Vec<u8>>>(key_for_counters_of_limit(limit))?;
+            let set_key = key_for_counters_of_limit(limit);
+            let mut cursor = 0u64;
 
-            for counter_key in counter_keys {
-                let mut counter: Counter =
-                    counter_from_counter_key(&counter_key, Arc::clone(limit));
+            loop {
+                // SSCAN can repeat a member, or skip one added mid-scan. Duplicates collapse in `res`
+                // Skipped member stays in the set, so a later get_counters returns it.
+                let (next_cursor, members): (u64, Vec<Vec<u8>>) = redis::cmd("SSCAN")
+                    .arg(&set_key)
+                    .arg(cursor)
+                    .arg("COUNT")
+                    .arg(COUNTERS_SCAN_BATCH_SIZE)
+                    .query(&mut *con)?;
 
-                // If the key does not exist, it means that the counter expired,
-                // so we don't have to return it.
-                // TODO: we should delete the counter from the set of counters
-                // associated with the limit taking into account that we should
-                // do the "get" + "delete if none" atomically.
-                // This does not cause any bugs, but consumes memory
-                // unnecessarily.
-                if let Some(val) = con.get::<Vec<u8>, Option<i64>>(counter_key.clone())? {
-                    counter.set_remaining(
-                        limit
-                            .max_value()
-                            .saturating_sub(u64::try_from(val).unwrap_or(0)),
-                    );
-                    let ttl = con.ttl(&counter_key)?;
-                    counter.set_expires_in(Duration::from_secs(ttl));
+                if !members.is_empty() {
+                    let script = redis::Script::new(GET_COUNTERS_AND_PRUNE);
+                    let mut script_invocation = script.prepare_invoke();
+                    script_invocation.key(&set_key);
+                    for member in &members {
+                        script_invocation.key(member);
+                    }
+                    let script_res: Vec<Option<i64>> = script_invocation.invoke(&mut *con)?;
 
-                    res.insert(counter);
+                    res.extend(live_counters_from_script_res(limit, &members, &script_res));
                 }
+
+                if next_cursor == 0 {
+                    break;
+                }
+                cursor = next_cursor;
             }
         }
 

--- a/limitador/src/storage/redis/scripts.rs
+++ b/limitador/src/storage/redis/scripts.rs
@@ -64,7 +64,9 @@ pub const VALUES_AND_TTLS: &str = "
 // as keys rather than as arguments so that Redis cluster can route the script.
 //
 // For a limit with no id they share the {namespace} hash tag with KEYS[1], so
-// they all live on the same shard.
+// they all live on the same shard. Keys for a limit with an id carry no hash tag at all, so on a
+// real cluster they can land on different shards. Slot-safety there needs the key encoding in
+// storage::keys to tag by id.
 //
 // A counter that no longer exists reports a nil value and is removed from the limit's counter set.
 // Nothing else ever removes those members, so without this the set grows by one entry per counter

--- a/limitador/src/storage/redis/scripts.rs
+++ b/limitador/src/storage/redis/scripts.rs
@@ -56,3 +56,33 @@ pub const VALUES_AND_TTLS: &str = "
     end
     return res
 ";
+
+// KEYS[1]: key that contains the counters that belong to the limit
+// KEYS[i], i > 1: counter keys to read
+// Returns the value and the TTL (in ms) of every counter key, in the same
+// order and with the same layout as VALUES_AND_TTLS. The counters are passed
+// as keys rather than as arguments so that Redis cluster can route the script.
+//
+// For a limit with no id they share the {namespace} hash tag with KEYS[1], so
+// they all live on the same shard.
+//
+// A counter that no longer exists reports a nil value and is removed from the limit's counter set.
+// Nothing else ever removes those members, so without this the set grows by one entry per counter
+// ever created under the limit. The get and the srem must be one script. Otherwise an update
+// recreating the counter in between finds the member still there, so its sadd no-ops and the srem
+// then unindexes a live counter.
+pub const GET_COUNTERS_AND_PRUNE: &str = "
+    local res = {}
+    for i = 2, #KEYS do
+        local val = redis.call('get', KEYS[i])
+        if val == false then
+            redis.call('srem', KEYS[1], KEYS[i])
+            table.insert(res, false)
+            table.insert(res, -2)
+        else
+            table.insert(res, val)
+            table.insert(res, redis.call('pttl', KEYS[i]))
+        end
+    end
+    return res
+";

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -1099,6 +1099,148 @@ mod test {
         assert_eq!(rate_limiter.get_counters(namespace).await.unwrap().len(), 0);
     }
 
+    #[cfg(feature = "redis_storage")]
+    fn counters_in_redis_index() -> usize {
+        let client =
+            redis::Client::open("redis://127.0.0.1:6379").expect("We need a Redis running locally");
+        let mut con = client
+            .get_connection()
+            .expect("We need a Redis running locally");
+
+        // `storage::keys` is private to the crate, so the set keys are matched by pattern.
+        // Only matches limits with no id: an id-based set key is untagged binary, so
+        // reusing this with `Limit::with_id` would silently count zero.
+        let set_keys: Vec<Vec<u8>> = redis::cmd("KEYS")
+            .arg("*counters_of_limit*")
+            .query(&mut con)
+            .unwrap();
+
+        set_keys
+            .iter()
+            .map(|set_key| {
+                redis::cmd("SCARD")
+                    .arg(set_key)
+                    .query::<usize>(&mut con)
+                    .unwrap()
+            })
+            .sum()
+    }
+
+    #[cfg(feature = "redis_storage")]
+    async fn async_redis_tests_limiter() -> TestsLimiter {
+        let storage = AsyncRedisStorage::new("redis://127.0.0.1:6379")
+            .await
+            .expect("We need a Redis running locally");
+        storage.clear().await.unwrap();
+        TestsLimiter::new_from_async_impl(AsyncRateLimiter::new_with_storage(Box::new(storage)))
+    }
+
+    #[cfg(feature = "redis_storage")]
+    fn sync_redis_tests_limiter() -> TestsLimiter {
+        let storage = RedisStorage::default();
+        storage.clear().unwrap();
+        TestsLimiter::new_from_blocking_impl(RateLimiter::new_with_storage(Box::new(storage)))
+    }
+
+    #[cfg(feature = "redis_storage")]
+    fn a_limit_of(namespace: &str, max_value: u64, seconds: u64) -> Limit {
+        Limit::new(
+            namespace,
+            max_value,
+            seconds,
+            vec!["req_method == 'GET'".try_into().expect("failed parsing!")],
+            vec!["app_id".try_into().expect("failed parsing!")],
+        )
+    }
+
+    #[cfg(feature = "redis_storage")]
+    async fn report_one_hit(rate_limiter: &TestsLimiter, namespace: &str, app_id: &str) {
+        let mut values = HashMap::new();
+        values.insert("req_method".to_string(), "GET".to_string());
+        values.insert("app_id".to_string(), app_id.to_string());
+        let ctx = values.into();
+        rate_limiter
+            .update_counters(namespace, &ctx, 1)
+            .await
+            .unwrap();
+    }
+
+    // Reading is the only thing that takes an expired counter out of its limit's counter set.
+    // Without that the set would keep one member per counter ever created, for the life of the instance.
+    #[cfg(feature = "redis_storage")]
+    #[tokio::test]
+    #[serial]
+    async fn get_counters_prunes_expired_counters_from_the_index() {
+        let namespace = "test_namespace";
+        let limit_time = 1;
+        let rate_limiter = async_redis_tests_limiter().await;
+
+        rate_limiter
+            .add_limit(&a_limit_of(namespace, 10, limit_time))
+            .await;
+        report_one_hit(&rate_limiter, namespace, "1").await;
+
+        assert_eq!(counters_in_redis_index(), 1);
+
+        sleep(Duration::from_secs(limit_time + 1));
+
+        // The counter key is gone, yet the set still lists it - expiry alone unindexes nothing
+        assert_eq!(counters_in_redis_index(), 1);
+
+        assert!(rate_limiter
+            .get_counters(namespace)
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(counters_in_redis_index(), 0);
+    }
+
+    // The sync `get_counters` re-implements the scan and. So test coverage won't let the two copies drift.
+    #[cfg(feature = "redis_storage")]
+    #[tokio::test]
+    #[serial]
+    async fn get_counters_prunes_expired_counters_from_the_index_with_sync_redis() {
+        let namespace = "test_namespace";
+        let limit_time = 1;
+        let rate_limiter = sync_redis_tests_limiter();
+
+        rate_limiter
+            .add_limit(&a_limit_of(namespace, 10, limit_time))
+            .await;
+        report_one_hit(&rate_limiter, namespace, "1").await;
+
+        assert_eq!(counters_in_redis_index(), 1);
+
+        sleep(Duration::from_secs(limit_time + 1));
+
+        // The counter key is gone, yet the set still lists it - expiry alone unindexes nothing
+        assert_eq!(counters_in_redis_index(), 1);
+
+        assert!(rate_limiter
+            .get_counters(namespace)
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(counters_in_redis_index(), 0);
+    }
+
+    // Only members whose counter key is gone should be pruned during the `get_counters` scan
+    #[cfg(feature = "redis_storage")]
+    #[tokio::test]
+    #[serial]
+    async fn get_counters_keeps_live_counters_in_the_index() {
+        let namespace = "test_namespace";
+        let rate_limiter = async_redis_tests_limiter().await;
+
+        rate_limiter.add_limit(&a_limit_of(namespace, 10, 60)).await;
+        report_one_hit(&rate_limiter, namespace, "1").await;
+
+        assert_eq!(rate_limiter.get_counters(namespace).await.unwrap().len(), 1);
+        // The load-bearing assertion. A prune that removed live members would still satisfy the assert
+        // above, because each member is read before the point where it would be removed.
+        assert_eq!(counters_in_redis_index(), 1);
+    }
+
     async fn configure_with_creates_the_given_limits(rate_limiter: &mut TestsLimiter) {
         let first_limit = Limit::new(
             "first_namespace",


### PR DESCRIPTION
# The issue

Redis memory grows without bound. A limit's `counters_of_limit` set keeps one member per counter ever created and never shrinks, for the lifetime of the instance. 

Counter keys expire, but the set entries they were `sadd`-ed to do not, and nothing else ever removed them. So a limit keyed on a high-cardinality variable (user_id, IP, API key) leaks in proportion to distinct values seen, forever. 

`redis_async.rs` carried a TODO acknowledging this.

# The fix

- `GET_COUNTERS_AND_PRUNE` reads a batch of counters and `srem`s the ones whose key is gone. `get` and `srem` share a script so executed atomically.
- `get_counters` walks the set with `SSCAN` instead of `SMEMBERS`. Pruning is lazy — it only happens on read — so the set stays arbitrarily larger than the live counter count for any deployment not polling `/counters` (which I believe is rate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Redis counter retrieval through batched scanning, reducing the overhead of reading large counter sets.
  * Expired counters are now identified and removed during retrieval.

* **Bug Fixes**
  * Improved accuracy when reporting live counters, remaining capacity and expiration times.
  * Redis counter indexes are now kept consistent after counters expire.

* **Tests**
  * Added coverage for counter pruning and index maintenance across synchronous and asynchronous Redis storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->