### PR TITLE
506 implement token rate limit reservations reservecommit rpcs

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -114,7 +114,7 @@ jobs:
           max_attempts: 10
           command: |
             curl -s "http://127.0.0.1:18080/limits/test_namespace" | tee output-limits.json
-            NUM_LIMITS=$(jq --exit-status 'length' output-limits.json) && test ${NUM_LIMITS} -eq 3
+            NUM_LIMITS=$(jq --exit-status 'length' output-limits.json) && test ${NUM_LIMITS} -eq 4
       - name: Update limits
         run: |
           cat <<EOF >> ./limitador-server/sandbox/limits.yaml

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cargo build
 
 ### Run the tests
 
-Some tests need a redis deployed in `localhost:6379`. You can run it in Docker with:
+Some tests need a Redis (>= 7.0) deployed in `localhost:6379`. You can run it in Docker with:
 ```bash
 docker run --rm -p 6379:6379 -it redis:7
 ```

--- a/limitador-server/proto/kuadrantrls.proto
+++ b/limitador-server/proto/kuadrantrls.proto
@@ -34,8 +34,10 @@ message ReserveRequest {
 
 message ReserveResponse {
   envoy.service.ratelimit.v3.RateLimitResponse.Code code = 1;
-  // Only set when code is OK. Must be passed back to Commit to resolve this reservation.
-  string reservation_id = 2;
+  // Set when code is OK and something was actually held. Must be passed back to Commit to
+  // resolve this reservation; absent means there's nothing to resolve (e.g. the amount held
+  // ended up being 0).
+  optional string reservation_id = 2;
   // Only set when code is OK. The amount actually held - can be less than the requested
   // amount if the server clamped it down; purely informational, Commit's actual_amount is
   // independent of it.
@@ -45,7 +47,9 @@ message ReserveResponse {
 message CommitRequest {
   string domain = 1;
   repeated envoy.extensions.common.ratelimit.v3.RateLimitDescriptor descriptors = 2;
-  string reservation_id = 3;
+  // Absent degrades gracefully to Report-equivalent behavior, same as an unrecognized or
+  // already-expired id.
+  optional string reservation_id = 3;
   uint64 actual_amount = 4;
 }
 

--- a/limitador-server/proto/kuadrantrls.proto
+++ b/limitador-server/proto/kuadrantrls.proto
@@ -3,11 +3,48 @@ syntax = "proto3";
 package kuadrant.service.ratelimit.v1;
 
 import "envoy/service/ratelimit/v3/rls.proto";
+import "envoy/extensions/common/ratelimit/v3/ratelimit.proto";
+import "google/protobuf/duration.proto";
 
 service RateLimitService {
   // Determine whether a request should be allowed or denied based on rate limiting rules.
-  rpc CheckRateLimit(envoy.service.ratelimit.v3.RateLimitRequest) returns (envoy.service.ratelimit.v3.RateLimitResponse); 
+  rpc CheckRateLimit(envoy.service.ratelimit.v3.RateLimitRequest) returns (envoy.service.ratelimit.v3.RateLimitResponse);
 
   // The report method modifies specific counters associated with the descriptors, incrementing each one by the amount specified in $hits_addend$
-  rpc Report(envoy.service.ratelimit.v3.RateLimitRequest) returns (envoy.service.ratelimit.v3.RateLimitResponse); 
+  rpc Report(envoy.service.ratelimit.v3.RateLimitRequest) returns (envoy.service.ratelimit.v3.RateLimitResponse);
+
+  // Reserve holds estimated capacity (e.g. estimated tokens) against the matching counters,
+  // without exceeding their limits once other outstanding reservations are accounted for.
+  // The hold lasts until Commit resolves it or it expires, whichever comes first.
+  rpc Reserve(ReserveRequest) returns (ReserveResponse);
+
+  // Commit resolves a reservation with the caller's real usage: it always applies
+  // actual_amount to the matching counters, and releases the reservation_id's hold if it is
+  // still found and live. A late or already-expired reservation_id degrades gracefully to
+  // Report-equivalent behavior.
+  rpc Commit(CommitRequest) returns (CommitResponse);
+}
+
+message ReserveRequest {
+  string domain = 1;
+  repeated envoy.extensions.common.ratelimit.v3.RateLimitDescriptor descriptors = 2;
+  uint64 amount = 3;
+  google.protobuf.Duration ttl = 4;
+}
+
+message ReserveResponse {
+  envoy.service.ratelimit.v3.RateLimitResponse.Code code = 1;
+  // Only set when code is OK. Must be passed back to Commit to resolve this reservation.
+  string reservation_id = 2;
+}
+
+message CommitRequest {
+  string domain = 1;
+  repeated envoy.extensions.common.ratelimit.v3.RateLimitDescriptor descriptors = 2;
+  string reservation_id = 3;
+  uint64 actual_amount = 4;
+}
+
+message CommitResponse {
+  bool reservation_released = 1;
 }

--- a/limitador-server/proto/kuadrantrls.proto
+++ b/limitador-server/proto/kuadrantrls.proto
@@ -36,6 +36,10 @@ message ReserveResponse {
   envoy.service.ratelimit.v3.RateLimitResponse.Code code = 1;
   // Only set when code is OK. Must be passed back to Commit to resolve this reservation.
   string reservation_id = 2;
+  // Only set when code is OK. The amount actually held - can be less than the requested
+  // amount if the server clamped it down; purely informational, Commit's actual_amount is
+  // independent of it.
+  uint64 reserved_amount = 3;
 }
 
 message CommitRequest {

--- a/limitador-server/sandbox/README.md
+++ b/limitador-server/sandbox/README.md
@@ -139,6 +139,48 @@ while :; do bin/grpcurl -plaintext -d @ 127.0.0.1:18081 envoy.service.ratelimit.
 EOM
 ```
 
+### Limitador's GRPC Reserve/Commit endpoint (token rate limit reservations)
+
+Besides the standard Envoy `RateLimitService` above, Limitador exposes a custom
+`kuadrant.service.ratelimit.v1.RateLimitService` with `Reserve` and `Commit` RPCs, for holding
+estimated capacity up front and resolving it later with the real usage.
+
+Reserve against the simple (unqualified) `GET` limit in `limits.yaml`:
+
+```bash
+bin/grpcurl -plaintext -d @ 127.0.0.1:18081 kuadrant.service.ratelimit.v1.RateLimitService.Reserve <<EOM
+{
+    "domain": "test_namespace",
+    "amount": 1,
+    "ttl": "60s",
+    "descriptors": [
+        {"entries": [
+            {"key": "req.method", "value": "GET"},
+            {"key": "req.path", "value": "/"}
+        ]}
+    ]
+}
+EOM
+```
+
+Resolve it with `Commit` once the real usage is known:
+
+```bash
+bin/grpcurl -plaintext -d @ 127.0.0.1:18081 kuadrant.service.ratelimit.v1.RateLimitService.Commit <<EOM
+{
+    "domain": "test_namespace",
+    "reservationId": "<paste the reservation_id from the Reserve response>",
+    "actualAmount": 1,
+    "descriptors": [
+        {"entries": [
+            {"key": "req.method", "value": "GET"},
+            {"key": "req.path", "value": "/"}
+        ]}
+    ]
+}
+EOM
+```
+
 ### Downstream traffic
 
 **Upstream** service implemented by [httpbin.org](https://httpbin.org/)

--- a/limitador-server/sandbox/docker-compose-limitador-redis-cached.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-redis-cached.yaml
@@ -39,4 +39,4 @@ services:
     volumes:
       - ./limits.yaml:/opt/kuadrant/limits/limits.yaml
   redis:
-    image: redis:5
+    image: redis:7

--- a/limitador-server/sandbox/docker-compose-limitador-redis-tls.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-redis-tls.yaml
@@ -30,7 +30,7 @@ services:
     volumes:
       - ./limits.yaml:/opt/kuadrant/limits/limits.yaml
   redis:
-    image: redis:6.2
+    image: redis:7
     restart: always
     ports:
       - '6379:6379'

--- a/limitador-server/sandbox/docker-compose-limitador-redis.yaml
+++ b/limitador-server/sandbox/docker-compose-limitador-redis.yaml
@@ -31,4 +31,4 @@ services:
     volumes:
       - ./limits.yaml:/opt/kuadrant/limits/limits.yaml
   redis:
-    image: redis:5
+    image: redis:7

--- a/limitador-server/sandbox/limits.yaml
+++ b/limitador-server/sandbox/limits.yaml
@@ -20,3 +20,10 @@
     - "descriptors[0]['req.method'] == 'GET'"
     - "descriptors[0]['req.path'] == '/json'"
   variables: []
+- namespace: test_namespace
+  max_value: 3
+  seconds: 60
+  conditions:
+    - "descriptors[0]['keyA'] == 'valueA'"
+  variables:
+    - descriptors[0]['varA']

--- a/limitador-server/src/config.rs
+++ b/limitador-server/src/config.rs
@@ -17,6 +17,7 @@ use crate::envoy_rls::server::RateLimitHeaders;
 use limitador::limit::Expression;
 use limitador::storage;
 use std::fmt;
+use std::time::Duration;
 use tracing::level_filters::LevelFilter;
 use url::Url;
 
@@ -54,6 +55,9 @@ pub struct Configuration {
     pub structured_logs: bool,
     pub rate_limit_headers: RateLimitHeaders,
     pub grpc_reflection_service: bool,
+    pub disable_reservations: bool,
+    pub max_reservation_fraction: f64,
+    pub max_reservation_ttl: Duration,
 }
 
 pub mod env {
@@ -133,6 +137,9 @@ impl Configuration {
             structured_logs: false,
             rate_limit_headers,
             grpc_reflection_service,
+            disable_reservations: false,
+            max_reservation_fraction: 0.5,
+            max_reservation_ttl: Duration::from_secs(60),
         }
     }
 
@@ -165,6 +172,9 @@ impl Default for Configuration {
             structured_logs: false,
             rate_limit_headers: RateLimitHeaders::None,
             grpc_reflection_service: false,
+            disable_reservations: false,
+            max_reservation_fraction: 0.5,
+            max_reservation_ttl: Duration::from_secs(60),
         }
     }
 }

--- a/limitador-server/src/envoy_rls/kuadrant_service.rs
+++ b/limitador-server/src/envoy_rls/kuadrant_service.rs
@@ -10,26 +10,42 @@ use super::server::custom::service::ratelimit::v1::{
 };
 use super::server::envoy::service::ratelimit::v3::rate_limit_response::Code;
 use super::server::envoy::service::ratelimit::v3::{RateLimitRequest, RateLimitResponse};
+use super::server::ReservationConfig;
 use crate::prometheus_metrics::PrometheusMetrics;
 use crate::Limiter;
 use limitador::limit::Context;
 use limitador::reservation::ReservationId;
 
-// RFC 0021 defaults. Not yet wired to the `--max-reservation-ttl`/`--max-reservation-fraction`
-// server flags (separate, not-yet-implemented follow-up) - a caller-requested ttl is clamped
-// to this ceiling, and it's also used when the caller doesn't set `ttl` at all. There is no
-// equivalent clamp yet for `amount` (the fraction-of-limit clamp needs each matching counter's
-// own max_value, which isn't known until inside `RateLimiter::reserve`).
-const MAX_RESERVATION_TTL: Duration = Duration::from_secs(60);
+// Used only when the caller doesn't set `ttl` at all. Deliberately not "the real default" -
+// the library's own `RateLimiterBuilder::reservation_limits` ceiling (set once, at
+// construction time) always clamps this down to whatever's actually configured, so this only
+// needs to be "large enough to never be the binding constraint," not accurate.
+const UNSET_RESERVATION_TTL: Duration = Duration::from_secs(u32::MAX as u64);
 
 pub struct KuadrantService {
     limiter: Arc<Limiter>,
     metrics: Arc<PrometheusMetrics>,
+    reservation_config: ReservationConfig,
 }
 
 impl KuadrantService {
+    // Only used by tests: production code (`server.rs`) always goes through
+    // `new_with_reservation_config` so it can pass along the real, CLI-configured settings.
+    #[cfg(test)]
     pub fn new(limiter: Arc<Limiter>, metrics: Arc<PrometheusMetrics>) -> Self {
-        Self { limiter, metrics }
+        Self::new_with_reservation_config(limiter, metrics, ReservationConfig::default())
+    }
+
+    pub fn new_with_reservation_config(
+        limiter: Arc<Limiter>,
+        metrics: Arc<PrometheusMetrics>,
+        reservation_config: ReservationConfig,
+    ) -> Self {
+        Self {
+            limiter,
+            metrics,
+            reservation_config,
+        }
     }
 }
 
@@ -203,6 +219,10 @@ impl RateLimitService for KuadrantService {
     ) -> Result<Response<ReserveResponse>, Status> {
         debug!("Reserve request received: {:?}", request);
 
+        if self.reservation_config.disable_reservations {
+            return Err(Status::unimplemented("reservations are disabled"));
+        }
+
         let mut values: Vec<HashMap<String, String>> = Vec::default();
         let (_metadata, _ext, req) = request.into_parts();
         let namespace = req.domain;
@@ -227,11 +247,16 @@ impl RateLimitService for KuadrantService {
         let mut ctx = Context::default();
         ctx.list_binding("descriptors".to_string(), values);
 
+        // Both the fraction-of-limit clamp on `amount` and the ceiling on `ttl` happen inside
+        // `RateLimiter::reserve` itself (`RateLimiterBuilder::reservation_limits`, set once
+        // when the limiter is constructed) - the fraction clamp needs each matching counter's
+        // own max_value, already resolved there, so there's no point re-resolving limits here
+        // just to clamp again; `ttl` is simply passed through unclamped (or, if unset, as a
+        // large sentinel the library's own ceiling will cut down to size).
         let ttl = req
             .ttl
             .and_then(|d| Duration::try_from(d).ok())
-            .unwrap_or(MAX_RESERVATION_TTL)
-            .min(MAX_RESERVATION_TTL);
+            .unwrap_or(UNSET_RESERVATION_TTL);
 
         let reserve_resp = match &*self.limiter {
             Limiter::Blocking(limiter) => limiter.reserve(&namespace, &ctx, req.amount, ttl, false),
@@ -276,6 +301,10 @@ impl RateLimitService for KuadrantService {
         request: Request<CommitRequest>,
     ) -> Result<Response<CommitResponse>, Status> {
         debug!("Commit request received: {:?}", request);
+
+        if self.reservation_config.disable_reservations {
+            return Err(Status::unimplemented("reservations are disabled"));
+        }
 
         let mut values: Vec<HashMap<String, String>> = Vec::default();
         let (_metadata, _ext, req) = request.into_parts();

--- a/limitador-server/src/envoy_rls/kuadrant_service.rs
+++ b/limitador-server/src/envoy_rls/kuadrant_service.rs
@@ -225,6 +225,7 @@ impl RateLimitService for KuadrantService {
             return Ok(Response::new(ReserveResponse {
                 code: Code::Unknown.into(),
                 reservation_id: String::new(),
+                reserved_amount: 0,
             }));
         }
 
@@ -277,6 +278,7 @@ impl RateLimitService for KuadrantService {
         Ok(Response::new(ReserveResponse {
             code: code.into(),
             reservation_id,
+            reserved_amount: reserve_resp.amount,
         }))
     }
 
@@ -952,6 +954,7 @@ mod tests {
                 .into_inner();
             assert_eq!(response.code, i32::from(Code::Ok));
             assert!(!response.reservation_id.is_empty());
+            assert_eq!(response.reserved_amount, 6);
 
             // Still held: 0 + outstanding(6) + 6 = 12 > 10
             let blocked = service
@@ -961,6 +964,7 @@ mod tests {
                 .into_inner();
             assert_eq!(blocked.code, i32::from(Code::OverLimit));
             assert!(blocked.reservation_id.is_empty());
+            assert_eq!(blocked.reserved_amount, 0);
 
             let commit_req = CommitRequest {
                 domain: namespace.to_string(),

--- a/limitador-server/src/envoy_rls/kuadrant_service.rs
+++ b/limitador-server/src/envoy_rls/kuadrant_service.rs
@@ -1,14 +1,26 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use tonic::{Request, Response, Status};
 
 use super::server::custom::service::ratelimit::v1::rate_limit_service_server::RateLimitService;
+use super::server::custom::service::ratelimit::v1::{
+    CommitRequest, CommitResponse, ReserveRequest, ReserveResponse,
+};
 use super::server::envoy::service::ratelimit::v3::rate_limit_response::Code;
 use super::server::envoy::service::ratelimit::v3::{RateLimitRequest, RateLimitResponse};
 use crate::prometheus_metrics::PrometheusMetrics;
 use crate::Limiter;
 use limitador::limit::Context;
+use limitador::reservation::ReservationId;
+
+// RFC 0021 defaults. Not yet wired to the `--max-reservation-ttl`/`--max-reservation-fraction`
+// server flags (separate, not-yet-implemented follow-up) - a caller-requested ttl is clamped
+// to this ceiling, and it's also used when the caller doesn't set `ttl` at all. There is no
+// equivalent clamp yet for `amount` (the fraction-of-limit clamp needs each matching counter's
+// own max_value, which isn't known until inside `RateLimiter::reserve`).
+const MAX_RESERVATION_TTL: Duration = Duration::from_secs(60);
 
 pub struct KuadrantService {
     limiter: Arc<Limiter>,
@@ -182,6 +194,138 @@ impl RateLimitService for KuadrantService {
         };
 
         Ok(Response::new(reply))
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn reserve(
+        &self,
+        request: Request<ReserveRequest>,
+    ) -> Result<Response<ReserveResponse>, Status> {
+        debug!("Reserve request received: {:?}", request);
+
+        let mut values: Vec<HashMap<String, String>> = Vec::default();
+        let (_metadata, _ext, req) = request.into_parts();
+        let namespace = req.domain;
+
+        if namespace.is_empty() {
+            return Ok(Response::new(ReserveResponse {
+                code: Code::Unknown.into(),
+                reservation_id: String::new(),
+            }));
+        }
+
+        let namespace = namespace.into();
+
+        for descriptor in &req.descriptors {
+            let mut map = HashMap::default();
+            for entry in &descriptor.entries {
+                map.insert(entry.key.clone(), entry.value.clone());
+            }
+            values.push(map);
+        }
+
+        let mut ctx = Context::default();
+        ctx.list_binding("descriptors".to_string(), values);
+
+        let ttl = req
+            .ttl
+            .and_then(|d| Duration::try_from(d).ok())
+            .unwrap_or(MAX_RESERVATION_TTL)
+            .min(MAX_RESERVATION_TTL);
+
+        let reserve_resp = match &*self.limiter {
+            Limiter::Blocking(limiter) => limiter.reserve(&namespace, &ctx, req.amount, ttl, false),
+            Limiter::Async(limiter) => {
+                limiter
+                    .reserve(&namespace, &ctx, req.amount, ttl, false)
+                    .await
+            }
+        };
+
+        if let Err(e) = reserve_resp {
+            // See the comment on the same pattern in `check_rate_limit` above: an
+            // "unavailable" error lets `failure_mode_deny` decide the outcome, rather than
+            // silently letting the request through.
+            error!("Error: {:?}", e);
+            return Err(Status::unavailable("Service unavailable"));
+        }
+
+        let reserve_resp = reserve_resp.unwrap();
+        let (code, reservation_id) = if reserve_resp.limited {
+            self.metrics
+                .incr_limited_calls(&namespace, reserve_resp.limit_name.as_deref(), &ctx);
+            (Code::OverLimit, String::new())
+        } else {
+            self.metrics.incr_authorized_calls(&namespace, &ctx);
+            let reservation_id = reserve_resp
+                .reservation_id
+                .map(|id| id.to_string())
+                .unwrap_or_default();
+            (Code::Ok, reservation_id)
+        };
+
+        Ok(Response::new(ReserveResponse {
+            code: code.into(),
+            reservation_id,
+        }))
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn commit(
+        &self,
+        request: Request<CommitRequest>,
+    ) -> Result<Response<CommitResponse>, Status> {
+        debug!("Commit request received: {:?}", request);
+
+        let mut values: Vec<HashMap<String, String>> = Vec::default();
+        let (_metadata, _ext, req) = request.into_parts();
+        let namespace = req.domain;
+
+        if namespace.is_empty() {
+            return Ok(Response::new(CommitResponse {
+                reservation_released: false,
+            }));
+        }
+
+        let namespace = namespace.into();
+
+        for descriptor in &req.descriptors {
+            let mut map = HashMap::default();
+            for entry in &descriptor.entries {
+                map.insert(entry.key.clone(), entry.value.clone());
+            }
+            values.push(map);
+        }
+
+        let mut ctx = Context::default();
+        ctx.list_binding("descriptors".to_string(), values);
+
+        let reservation_id = ReservationId::from(req.reservation_id);
+
+        let commit_resp = match &*self.limiter {
+            Limiter::Blocking(limiter) => {
+                limiter.commit_reservation(&namespace, &ctx, &reservation_id, req.actual_amount)
+            }
+            Limiter::Async(limiter) => {
+                limiter
+                    .commit_reservation(&namespace, &ctx, &reservation_id, req.actual_amount)
+                    .await
+            }
+        };
+
+        if let Err(e) = commit_resp {
+            error!("Error: {:?}", e);
+            return Err(Status::unavailable("Service unavailable"));
+        }
+
+        let commit_resp = commit_resp.unwrap();
+        self.metrics.incr_report_calls(&namespace, &ctx);
+        self.metrics
+            .incr_authorized_hits(&namespace, &ctx, req.actual_amount);
+
+        Ok(Response::new(CommitResponse {
+            reservation_released: commit_resp.reservation_released,
+        }))
     }
 }
 
@@ -721,6 +865,170 @@ mod tests {
 
             let response = rate_limiter.report(req).await.unwrap().into_inner();
             assert_eq!(response.overall_code, i32::from(Code::Unknown));
+        }
+    }
+
+    mod reserve_and_commit {
+        use tonic::IntoRequest;
+
+        use limitador::limit::Limit;
+        use limitador::RateLimiter;
+
+        use crate::envoy_rls::server::envoy::extensions::common::ratelimit::v3::rate_limit_descriptor::Entry;
+        use crate::envoy_rls::server::envoy::extensions::common::ratelimit::v3::RateLimitDescriptor;
+        use crate::envoy_rls::server::tests::TEST_PROMETHEUS_HANDLE;
+
+        use super::super::*;
+
+        fn descriptor(app_id: &str) -> RateLimitDescriptor {
+            RateLimitDescriptor {
+                entries: vec![
+                    Entry {
+                        key: "req.method".to_string(),
+                        value: "GET".to_string(),
+                    },
+                    Entry {
+                        key: "app.id".to_string(),
+                        value: app_id.to_string(),
+                    },
+                ],
+                limit: None,
+            }
+        }
+
+        fn service_with_limit(namespace: &str, max_value: u64) -> KuadrantService {
+            let limit = Limit::new(
+                namespace,
+                max_value,
+                60,
+                vec!["descriptors[0]['req.method'] == 'GET'"
+                    .try_into()
+                    .expect("failed parsing!")],
+                vec!["descriptors[0]['app.id']"
+                    .try_into()
+                    .expect("failed parsing!")],
+            );
+            let limiter = RateLimiter::new(10_000);
+            limiter.add_limit(limit);
+            KuadrantService::new(
+                Arc::new(Limiter::Blocking(limiter)),
+                Arc::new(PrometheusMetrics::new_with_handle(
+                    false,
+                    TEST_PROMETHEUS_HANDLE.clone(),
+                )),
+            )
+        }
+
+        #[tokio::test]
+        async fn reserve_admits_and_commit_releases() {
+            let namespace = "test_namespace";
+            let service = service_with_limit(namespace, 10);
+
+            let req = ReserveRequest {
+                domain: namespace.to_string(),
+                descriptors: vec![descriptor("1")],
+                amount: 6,
+                ttl: None,
+            };
+
+            let response = service
+                .reserve(req.clone().into_request())
+                .await
+                .unwrap()
+                .into_inner();
+            assert_eq!(response.code, i32::from(Code::Ok));
+            assert!(!response.reservation_id.is_empty());
+
+            // Still held: 0 + outstanding(6) + 6 = 12 > 10
+            let blocked = service
+                .reserve(req.clone().into_request())
+                .await
+                .unwrap()
+                .into_inner();
+            assert_eq!(blocked.code, i32::from(Code::OverLimit));
+            assert!(blocked.reservation_id.is_empty());
+
+            let commit_req = CommitRequest {
+                domain: namespace.to_string(),
+                descriptors: vec![descriptor("1")],
+                reservation_id: response.reservation_id,
+                actual_amount: 2,
+            };
+            let commit_response = service
+                .commit(commit_req.into_request())
+                .await
+                .unwrap()
+                .into_inner();
+            assert!(commit_response.reservation_released);
+
+            // Counter now at 2, no outstanding reservations: 2 + 6 = 8 <= 10
+            let after = service
+                .reserve(req.into_request())
+                .await
+                .unwrap()
+                .into_inner();
+            assert_eq!(after.code, i32::from(Code::Ok));
+        }
+
+        #[tokio::test]
+        async fn reserve_returns_unknown_when_domain_is_empty() {
+            let service = service_with_limit("test_namespace", 10);
+
+            let req = ReserveRequest {
+                domain: "".to_string(),
+                descriptors: vec![descriptor("1")],
+                amount: 1,
+                ttl: None,
+            }
+            .into_request();
+
+            let response = service.reserve(req).await.unwrap().into_inner();
+            assert_eq!(response.code, i32::from(Code::Unknown));
+            assert!(response.reservation_id.is_empty());
+        }
+
+        #[tokio::test]
+        async fn commit_returns_not_released_when_domain_is_empty() {
+            let service = service_with_limit("test_namespace", 10);
+
+            let req = CommitRequest {
+                domain: "".to_string(),
+                descriptors: vec![descriptor("1")],
+                reservation_id: "some-id".to_string(),
+                actual_amount: 1,
+            }
+            .into_request();
+
+            let response = service.commit(req).await.unwrap().into_inner();
+            assert!(!response.reservation_released);
+        }
+
+        #[tokio::test]
+        async fn commit_degrades_gracefully_for_unknown_reservation() {
+            let namespace = "test_namespace";
+            let service = service_with_limit(namespace, 10);
+
+            let commit_req = CommitRequest {
+                domain: namespace.to_string(),
+                descriptors: vec![descriptor("1")],
+                reservation_id: "never-reserved".to_string(),
+                actual_amount: 3,
+            }
+            .into_request();
+
+            let response = service.commit(commit_req).await.unwrap().into_inner();
+            assert!(!response.reservation_released);
+
+            // actual_amount is still applied unconditionally: 3 + 8 = 11 > 10
+            let req = ReserveRequest {
+                domain: namespace.to_string(),
+                descriptors: vec![descriptor("1")],
+                amount: 8,
+                ttl: None,
+            }
+            .into_request();
+            let response = service.reserve(req).await.unwrap().into_inner();
+            assert_eq!(response.code, i32::from(Code::OverLimit));
         }
     }
 }

--- a/limitador-server/src/envoy_rls/kuadrant_service.rs
+++ b/limitador-server/src/envoy_rls/kuadrant_service.rs
@@ -224,7 +224,7 @@ impl RateLimitService for KuadrantService {
         if namespace.is_empty() {
             return Ok(Response::new(ReserveResponse {
                 code: Code::Unknown.into(),
-                reservation_id: String::new(),
+                reservation_id: None,
                 reserved_amount: 0,
             }));
         }
@@ -265,13 +265,10 @@ impl RateLimitService for KuadrantService {
         let (code, reservation_id) = if reserve_resp.limited {
             self.metrics
                 .incr_limited_calls(&namespace, reserve_resp.limit_name.as_deref(), &ctx);
-            (Code::OverLimit, String::new())
+            (Code::OverLimit, None)
         } else {
             self.metrics.incr_authorized_calls(&namespace, &ctx);
-            let reservation_id = reserve_resp
-                .reservation_id
-                .map(|id| id.to_string())
-                .unwrap_or_default();
+            let reservation_id = reserve_resp.reservation_id.map(|id| id.to_string());
             (Code::Ok, reservation_id)
         };
 
@@ -316,15 +313,23 @@ impl RateLimitService for KuadrantService {
         let mut ctx = Context::default();
         ctx.list_binding("descriptors".to_string(), values);
 
-        let reservation_id = ReservationId::from(req.reservation_id);
+        let reservation_id = req.reservation_id.map(ReservationId::from);
 
         let commit_resp = match &*self.limiter {
-            Limiter::Blocking(limiter) => {
-                limiter.commit_reservation(&namespace, &ctx, &reservation_id, req.actual_amount)
-            }
+            Limiter::Blocking(limiter) => limiter.commit_reservation(
+                &namespace,
+                &ctx,
+                reservation_id.as_ref(),
+                req.actual_amount,
+            ),
             Limiter::Async(limiter) => {
                 limiter
-                    .commit_reservation(&namespace, &ctx, &reservation_id, req.actual_amount)
+                    .commit_reservation(
+                        &namespace,
+                        &ctx,
+                        reservation_id.as_ref(),
+                        req.actual_amount,
+                    )
                     .await
             }
         };
@@ -953,7 +958,7 @@ mod tests {
                 .unwrap()
                 .into_inner();
             assert_eq!(response.code, i32::from(Code::Ok));
-            assert!(!response.reservation_id.is_empty());
+            assert!(response.reservation_id.is_some());
             assert_eq!(response.reserved_amount, 6);
 
             // Still held: 0 + outstanding(6) + 6 = 12 > 10
@@ -963,7 +968,7 @@ mod tests {
                 .unwrap()
                 .into_inner();
             assert_eq!(blocked.code, i32::from(Code::OverLimit));
-            assert!(blocked.reservation_id.is_empty());
+            assert!(blocked.reservation_id.is_none());
             assert_eq!(blocked.reserved_amount, 0);
 
             let commit_req = CommitRequest {
@@ -1002,7 +1007,7 @@ mod tests {
 
             let response = service.reserve(req).await.unwrap().into_inner();
             assert_eq!(response.code, i32::from(Code::Unknown));
-            assert!(response.reservation_id.is_empty());
+            assert!(response.reservation_id.is_none());
         }
 
         #[tokio::test]
@@ -1012,7 +1017,7 @@ mod tests {
             let req = CommitRequest {
                 domain: "".to_string(),
                 descriptors: vec![descriptor("1")],
-                reservation_id: "some-id".to_string(),
+                reservation_id: Some("some-id".to_string()),
                 actual_amount: 1,
             }
             .into_request();
@@ -1029,7 +1034,7 @@ mod tests {
             let commit_req = CommitRequest {
                 domain: namespace.to_string(),
                 descriptors: vec![descriptor("1")],
-                reservation_id: "never-reserved".to_string(),
+                reservation_id: Some("never-reserved".to_string()),
                 actual_amount: 3,
             }
             .into_request();

--- a/limitador-server/src/envoy_rls/kuadrant_service.rs
+++ b/limitador-server/src/envoy_rls/kuadrant_service.rs
@@ -16,12 +16,6 @@ use crate::Limiter;
 use limitador::limit::Context;
 use limitador::reservation::ReservationId;
 
-// Used only when the caller doesn't set `ttl` at all. Deliberately not "the real default" -
-// the library's own `RateLimiterBuilder::reservation_limits` ceiling (set once, at
-// construction time) always clamps this down to whatever's actually configured, so this only
-// needs to be "large enough to never be the binding constraint," not accurate.
-const UNSET_RESERVATION_TTL: Duration = Duration::from_secs(u32::MAX as u64);
-
 pub struct KuadrantService {
     limiter: Arc<Limiter>,
     metrics: Arc<PrometheusMetrics>,
@@ -247,16 +241,7 @@ impl RateLimitService for KuadrantService {
         let mut ctx = Context::default();
         ctx.list_binding("descriptors".to_string(), values);
 
-        // Both the fraction-of-limit clamp on `amount` and the ceiling on `ttl` happen inside
-        // `RateLimiter::reserve` itself (`RateLimiterBuilder::reservation_limits`, set once
-        // when the limiter is constructed) - the fraction clamp needs each matching counter's
-        // own max_value, already resolved there, so there's no point re-resolving limits here
-        // just to clamp again; `ttl` is simply passed through unclamped (or, if unset, as a
-        // large sentinel the library's own ceiling will cut down to size).
-        let ttl = req
-            .ttl
-            .and_then(|d| Duration::try_from(d).ok())
-            .unwrap_or(UNSET_RESERVATION_TTL);
+        let ttl = req.ttl.and_then(|d| Duration::try_from(d).ok());
 
         let reserve_resp = match &*self.limiter {
             Limiter::Blocking(limiter) => limiter.reserve(&namespace, &ctx, req.amount, ttl, false),

--- a/limitador-server/src/envoy_rls/server.rs
+++ b/limitador-server/src/envoy_rls/server.rs
@@ -56,6 +56,20 @@ impl RateLimitHeaders {
     }
 }
 
+/// Server-side knobs for the `Reserve`/`Commit` RPCs (RFC 0021).
+///
+/// `--max-reservation-fraction`/`--max-reservation-ttl` are *not* here: both are
+/// `RateLimiter`/`AsyncRateLimiter`-level settings (`RateLimiterBuilder::reservation_limits`),
+/// applied once when the limiter is constructed. The fraction clamp needs each matching
+/// counter's own `max_value` - already resolved internally by `reserve()` - rather than a
+/// second, redundant lookup here; the ttl ceiling lives alongside it for the same reason
+/// (a single place embedders configure both "how big" and "how long" a reservation may be).
+#[derive(Debug, Clone, Default)]
+pub struct ReservationConfig {
+    /// When set, `Reserve`/`Commit` return `UNIMPLEMENTED` instead of doing anything.
+    pub disable_reservations: bool,
+}
+
 pub struct MyRateLimiter {
     limiter: Arc<Limiter>,
     rate_limit_headers: RateLimitHeaders,
@@ -241,11 +255,13 @@ pub async fn run_envoy_rls_server(
     rate_limit_headers: RateLimitHeaders,
     metrics: Arc<PrometheusMetrics>,
     grpc_reflection_service: bool,
+    reservation_config: ReservationConfig,
 ) -> Result<(), transport::Error> {
     let rate_limiter = MyRateLimiter::new(limiter.clone(), rate_limit_headers, metrics.clone());
     let envoy_server = RateLimitServiceServer::new(rate_limiter);
 
-    let kuadrant_svc = KuadrantService::new(limiter, metrics);
+    let kuadrant_svc =
+        KuadrantService::new_with_reservation_config(limiter, metrics, reservation_config);
     let kuadrant_server =
         custom::service::ratelimit::v1::rate_limit_service_server::RateLimitServiceServer::new(
             kuadrant_svc,

--- a/limitador-server/src/main.rs
+++ b/limitador-server/src/main.rs
@@ -12,7 +12,7 @@ use crate::config::{
     redacted_url, Configuration, DiskStorageConfiguration, InMemoryStorageConfiguration,
     RedisStorageCacheConfiguration, RedisStorageConfiguration, StorageConfiguration,
 };
-use crate::envoy_rls::server::{run_envoy_rls_server, RateLimitHeaders};
+use crate::envoy_rls::server::{run_envoy_rls_server, RateLimitHeaders, ReservationConfig};
 use crate::http_api::server::run_http_server;
 use crate::metrics::MetricsLayer;
 use chrono::{NaiveDateTime, Utc};
@@ -24,6 +24,7 @@ use const_format::formatcp;
 use limitador::counter::Counter;
 use limitador::errors::LimitadorError;
 use limitador::limit::{Expression, Limit};
+use limitador::reservation::ReservationLimits;
 use limitador::storage::disk::DiskStorage;
 use limitador::storage::redis::{
     AsyncRedisStorage, CachedRedisStorage, CachedRedisStorageBuilder, DEFAULT_BATCH_SIZE,
@@ -92,20 +93,30 @@ impl From<LimitadorError> for LimitadorServerError {
 
 impl Limiter {
     pub async fn new(config: Configuration) -> Result<Self, LimitadorServerError> {
+        let reservation_limits = ReservationLimits {
+            max_fraction: config.max_reservation_fraction,
+            max_ttl: config.max_reservation_ttl,
+        };
         let rate_limiter = match config.storage {
-            StorageConfiguration::Redis(cfg) => Self::redis_limiter(cfg).await,
-            StorageConfiguration::InMemory(cfg) => Self::in_memory_limiter(cfg),
+            StorageConfiguration::Redis(cfg) => Self::redis_limiter(cfg, reservation_limits).await,
+            StorageConfiguration::InMemory(cfg) => Self::in_memory_limiter(cfg, reservation_limits),
             #[cfg(feature = "distributed_storage")]
-            StorageConfiguration::Distributed(cfg) => Self::distributed_limiter(cfg),
-            StorageConfiguration::Disk(cfg) => Self::disk_limiter(cfg),
+            StorageConfiguration::Distributed(cfg) => {
+                Self::distributed_limiter(cfg, reservation_limits)
+            }
+            StorageConfiguration::Disk(cfg) => Self::disk_limiter(cfg, reservation_limits),
         };
 
         Ok(rate_limiter)
     }
 
-    async fn redis_limiter(cfg: RedisStorageConfiguration) -> Self {
+    async fn redis_limiter(
+        cfg: RedisStorageConfiguration,
+        reservation_limits: ReservationLimits,
+    ) -> Self {
         let storage = Self::storage_using_redis(cfg).await;
-        let rate_limiter_builder = AsyncRateLimiterBuilder::new(storage);
+        let rate_limiter_builder =
+            AsyncRateLimiterBuilder::new(storage).reservation_limits(reservation_limits);
 
         Self::Async(rate_limiter_builder.build())
     }
@@ -149,7 +160,7 @@ impl Limiter {
         })
     }
 
-    fn disk_limiter(cfg: DiskStorageConfiguration) -> Self {
+    fn disk_limiter(cfg: DiskStorageConfiguration, reservation_limits: ReservationLimits) -> Self {
         let storage = match DiskStorage::open(cfg.path.as_str(), cfg.optimization) {
             Ok(storage) => storage,
             Err(err) => {
@@ -158,20 +169,28 @@ impl Limiter {
             }
         };
         let rate_limiter_builder =
-            RateLimiterBuilder::with_storage(Storage::with_counter_storage(Box::new(storage)));
+            RateLimiterBuilder::with_storage(Storage::with_counter_storage(Box::new(storage)))
+                .reservation_limits(reservation_limits);
 
         Self::Blocking(rate_limiter_builder.build())
     }
 
-    fn in_memory_limiter(cfg: InMemoryStorageConfiguration) -> Self {
+    fn in_memory_limiter(
+        cfg: InMemoryStorageConfiguration,
+        reservation_limits: ReservationLimits,
+    ) -> Self {
         let rate_limiter_builder =
-            RateLimiterBuilder::new(cfg.cache_size.or_else(guess_cache_size).unwrap());
+            RateLimiterBuilder::new(cfg.cache_size.or_else(guess_cache_size).unwrap())
+                .reservation_limits(reservation_limits);
 
         Self::Blocking(rate_limiter_builder.build())
     }
 
     #[cfg(feature = "distributed_storage")]
-    fn distributed_limiter(cfg: DistributedStorageConfiguration) -> Self {
+    fn distributed_limiter(
+        cfg: DistributedStorageConfiguration,
+        reservation_limits: ReservationLimits,
+    ) -> Self {
         let storage = DistributedInMemoryStorage::new(
             cfg.name,
             cfg.cache_size.or_else(guess_cache_size).unwrap(),
@@ -179,7 +198,8 @@ impl Limiter {
             cfg.peer_urls,
         );
         let rate_limiter_builder =
-            RateLimiterBuilder::with_storage(Storage::with_counter_storage(Box::new(storage)));
+            RateLimiterBuilder::with_storage(Storage::with_counter_storage(Box::new(storage)))
+                .reservation_limits(reservation_limits);
 
         Self::Blocking(rate_limiter_builder.build())
     }
@@ -269,6 +289,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let http_api_address = config.http_address();
     let rate_limit_headers = config.rate_limit_headers.clone();
     let grpc_reflection_service = config.grpc_reflection_service;
+    let reservation_config = ReservationConfig {
+        disable_reservations: config.disable_reservations,
+    };
 
     let rate_limiter: Arc<Limiter> = match Limiter::new(config).await {
         Ok(limiter) => Arc::new(limiter),
@@ -413,6 +436,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         rate_limit_headers,
         prometheus_metrics.clone(),
         grpc_reflection_service,
+        reservation_config,
     ));
 
     info!("HTTP server starting on {}", http_api_address);
@@ -604,6 +628,31 @@ fn create_config() -> (Configuration, &'static str) {
                 .action(ArgAction::SetTrue)
                 .display_order(100)
                 .help("Enables gRPC server reflection service"),
+        )
+        .arg(
+            Arg::new("disable_reservations")
+                .long("disable-reservations")
+                .action(ArgAction::SetTrue)
+                .display_order(110)
+                .help("Disables the Reserve/Commit gRPC RPCs (token rate limit reservations)"),
+        )
+        .arg(
+            Arg::new("max_reservation_fraction")
+                .long("max-reservation-fraction")
+                .action(ArgAction::Set)
+                .value_parser(value_parser!(f64))
+                .default_value("0.5")
+                .display_order(111)
+                .help("Maximum fraction of a limit's max_value a single Reserve call may hold"),
+        )
+        .arg(
+            Arg::new("max_reservation_ttl")
+                .long("max-reservation-ttl")
+                .action(ArgAction::Set)
+                .value_parser(value_parser!(u64))
+                .default_value("60")
+                .display_order(112)
+                .help("Maximum ttl, in seconds, a Reserve call may request"),
         )
         .subcommand(
             Command::new("memory")
@@ -846,6 +895,10 @@ fn create_config() -> (Configuration, &'static str) {
         _ => unreachable!("Verbosity should at most be 4!"),
     };
     config.structured_logs = matches.get_flag("S");
+    config.disable_reservations = matches.get_flag("disable_reservations");
+    config.max_reservation_fraction = *matches.get_one::<f64>("max_reservation_fraction").unwrap();
+    config.max_reservation_ttl =
+        Duration::from_secs(*matches.get_one::<u64>("max_reservation_ttl").unwrap());
 
     (config, full_version)
 }

--- a/limitador/Cargo.toml
+++ b/limitador/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 [features]
 default = ["disk_storage", "redis_storage"]
 disk_storage = ["rocksdb"]
-distributed_storage = ["tokio", "tokio-stream", "h2", "base64", "uuid", "tonic", "tonic-reflection", "prost", "prost-types"]
+distributed_storage = ["tokio", "tokio-stream", "h2", "base64", "tonic", "tonic-reflection", "prost", "prost-types"]
 redis_storage = ["redis", "r2d2", "tokio"]
 
 [dependencies]
@@ -48,7 +48,7 @@ tokio = { version = "1", optional = true, features = [
 base64 = { version = "0.22", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 h2 = { version = "0.4", optional = true }
-uuid = { version = "1.8.0", features = ["v4", "fast-rng"], optional = true }
+uuid = { version = "1.8.0", features = ["v4", "fast-rng"] }
 tonic = { version = "0.12.3", optional = true }
 tonic-reflection = { version = "0.12.3", optional = true }
 prost = { version = "0.13.3", optional = true }

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -560,7 +560,10 @@ impl RateLimiter {
         Ok(match auth {
             Authorization::Ok => ReserveResult {
                 limited: false,
-                reservation_id: Some(reservation_id),
+                // `hold_amount == 0` means nothing was actually stored (see the
+                // `hold_amount == 0` guards in storage) - don't hand back a `reservation_id`
+                // that could never be found again by `commit_reservation`.
+                reservation_id: (hold_amount > 0).then_some(reservation_id),
                 amount: hold_amount,
                 counters,
                 limit_name: None,
@@ -871,7 +874,10 @@ impl AsyncRateLimiter {
         Ok(match auth {
             Authorization::Ok => ReserveResult {
                 limited: false,
-                reservation_id: Some(reservation_id),
+                // `hold_amount == 0` means nothing was actually stored (see the
+                // `hold_amount == 0` guards in storage) - don't hand back a `reservation_id`
+                // that could never be found again by `commit_reservation`.
+                reservation_id: (hold_amount > 0).then_some(reservation_id),
                 amount: hold_amount,
                 counters,
                 limit_name: None,
@@ -1301,7 +1307,7 @@ mod test {
             .reserve(&ns, &ctx, 1, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(!result.limited);
-        assert!(result.reservation_id.is_some());
+        assert!(result.reservation_id.is_none());
         assert_eq!(result.amount, 0);
 
         // Repeating it stays consistent - no lingering zero-amount entries accumulate to
@@ -1310,7 +1316,7 @@ mod test {
             .reserve(&ns, &ctx, 1, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(!again.limited);
-        assert!(again.reservation_id.is_some());
+        assert!(again.reservation_id.is_none());
     }
 
     #[test]

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -494,9 +494,9 @@ impl RateLimiter {
         }
 
         let reservation_id = ReservationId::new();
-        let auth = self
-            .storage
-            .reserve(&mut counters, &reservation_id, amount, ttl, load_counters)?;
+        let auth =
+            self.storage
+                .reserve(&mut counters, &reservation_id, amount, ttl, load_counters)?;
 
         let counters = if load_counters {
             counters
@@ -541,7 +541,8 @@ impl RateLimiter {
         let reservation_released = if counters.is_empty() {
             false
         } else {
-            self.storage.release_reservation(&counters, reservation_id)?
+            self.storage
+                .release_reservation(&counters, reservation_id)?
         };
 
         Ok(CommitResult {

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -585,6 +585,10 @@ impl RateLimiter {
         reservation_id: &ReservationId,
         actual_amount: u64,
     ) -> LimitadorResult<CommitResult> {
+        // If the counters resolved here differ from those reserve originally held
+        // (e.g. limits changed between the two calls),
+        // any reservation left on a counter no longer resolved isn't released by this call.
+        // It just sits until its own ttl expires naturally.
         let counters = self.counters_that_apply(namespace, ctx)?;
 
         counters

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -494,16 +494,18 @@ impl RateLimiter {
             .map_err(|err| err.into())
     }
 
-    /// Holds `amount` of estimated capacity against every counter matching `namespace`/`ctx`,
-    /// for at most `ttl`. Admission accounts for any capacity already held by other live
-    /// reservations, in addition to the counters' current values. All matching counters are
-    /// admitted, or none are.
+    /// Admits, or not, based on `amount`: every counter matching `namespace`/`ctx` must stay
+    /// within its limit if `amount` were held, once outstanding reservations are accounted
+    /// for - all matching counters are admitted, or none are. If admitted, the amount
+    /// actually held (`ReserveResult::amount`) may be less than `amount`, clamped by
+    /// `ReservationLimits::max_fraction` as a self-defense limit so one reservation can't
+    /// claim an entire counter.
     ///
     /// On success, `reservation_id` in the result must later be passed to
     /// `commit_reservation` to release the hold once actual usage is known.
     ///
-    /// `ttl` of `None` uses `ReservationLimits::max_ttl` outright; `Some` is still clamped to
-    /// it.
+    /// The hold lasts for at most `ttl`; `None` uses `ReservationLimits::max_ttl` outright,
+    /// `Some` is still clamped to it.
     pub fn reserve(
         &self,
         namespace: &Namespace,
@@ -524,34 +526,30 @@ impl RateLimiter {
             });
         }
 
-        let amount = counters
+        // Admission checks the raw, requested `amount` - all-or-nothing, consistent with
+        // `check_and_update`/`is_rate_limited` never silently applying a smaller delta than
+        // requested. `max_fraction` only clamps how much is actually held once admitted, as
+        // a self-defense limit so one reservation can't claim the entire counter.
+        let hold_amount = counters
             .iter()
             .map(|c| (c.max_value() as f64 * self.reservation_limits.max_fraction) as u64)
             .min()
             .map_or(amount, |max| amount.min(max));
-
-        // `max_fraction` can clamp a positive request down to 0 (e.g. a small max_value with
-        // a tight fraction). Reserving 0 can never be denied, so - as with no counters
-        // applying above - skip storage entirely rather than let it create a pointless
-        // zero-amount `ReservationEntry` that holds no real capacity.
-        if amount == 0 {
-            return Ok(ReserveResult {
-                limited: false,
-                reservation_id: None,
-                amount: 0,
-                counters: Vec::default(),
-                limit_name: None,
-            });
-        }
+        debug_assert!(hold_amount <= amount);
 
         let ttl = ttl.map_or(self.reservation_limits.max_ttl, |ttl| {
             ttl.min(self.reservation_limits.max_ttl)
         });
 
         let reservation_id = ReservationId::new();
-        let auth =
-            self.storage
-                .reserve(&mut counters, &reservation_id, amount, ttl, load_counters)?;
+        let auth = self.storage.reserve(
+            &mut counters,
+            &reservation_id,
+            amount,
+            hold_amount,
+            ttl,
+            load_counters,
+        )?;
 
         let counters = if load_counters {
             counters
@@ -563,7 +561,7 @@ impl RateLimiter {
             Authorization::Ok => ReserveResult {
                 limited: false,
                 reservation_id: Some(reservation_id),
-                amount,
+                amount: hold_amount,
                 counters,
                 limit_name: None,
             },
@@ -838,24 +836,14 @@ impl AsyncRateLimiter {
             });
         }
 
-        let amount = counters
+        // See the comment in `RateLimiter::reserve`: admission checks the raw `amount`;
+        // `max_fraction` only clamps how much is actually held once admitted.
+        let hold_amount = counters
             .iter()
             .map(|c| (c.max_value() as f64 * self.reservation_limits.max_fraction) as u64)
             .min()
             .map_or(amount, |max| amount.min(max));
-
-        // See the comment in `RateLimiter::reserve`: skip storage entirely rather than let a
-        // fraction-clamped-to-zero positive request create a pointless zero-amount
-        // `ReservationEntry`.
-        if amount == 0 {
-            return Ok(ReserveResult {
-                limited: false,
-                reservation_id: None,
-                amount: 0,
-                counters: Vec::default(),
-                limit_name: None,
-            });
-        }
+        debug_assert!(hold_amount <= amount);
 
         let ttl = ttl.map_or(self.reservation_limits.max_ttl, |ttl| {
             ttl.min(self.reservation_limits.max_ttl)
@@ -864,7 +852,14 @@ impl AsyncRateLimiter {
         let reservation_id = ReservationId::new();
         let auth = self
             .storage
-            .reserve(&mut counters, &reservation_id, amount, ttl, load_counters)
+            .reserve(
+                &mut counters,
+                &reservation_id,
+                amount,
+                hold_amount,
+                ttl,
+                load_counters,
+            )
             .await?;
 
         let counters = if load_counters {
@@ -877,7 +872,7 @@ impl AsyncRateLimiter {
             Authorization::Ok => ReserveResult {
                 limited: false,
                 reservation_id: Some(reservation_id),
-                amount,
+                amount: hold_amount,
                 counters,
                 limit_name: None,
             },
@@ -1260,18 +1255,16 @@ mod test {
     }
 
     #[test]
-    fn reserve_handles_amount_clamped_to_zero() {
-        // max_value=1 with a 0.5 fraction clamps every positive request down to
-        // floor(1 * 0.5) = 0. Reserving 0 can never be denied, and shouldn't create a
-        // reservation to later release, so this behaves like the "no counters apply" case:
-        // admitted, with no `reservation_id`.
+    fn reserve_denies_when_requested_amount_exceeds_max_value() {
+        // Admission checks the raw requested amount - a request that could never fit in
+        // the counter at all is denied outright, regardless of `max_fraction`.
         let rl = RateLimiterBuilder::new(100)
             .reservation_limits(ReservationLimits {
                 max_fraction: 0.5,
                 ..Default::default()
             })
             .build();
-        let namespace = "fraction_clamped_to_zero";
+        let namespace = "over_max_value";
         let limit = Limit::new(namespace, 1, 60, vec![], Vec::<Expression>::default());
         rl.add_limit(limit);
 
@@ -1281,17 +1274,64 @@ mod test {
         let result = rl
             .reserve(&ns, &ctx, 5, Some(Duration::from_secs(30)), false)
             .unwrap();
-        assert!(!result.limited);
+        assert!(result.limited);
         assert!(result.reservation_id.is_none());
+        assert_eq!(result.amount, 0);
+    }
+
+    #[test]
+    fn reserve_handles_hold_amount_clamped_to_zero() {
+        // max_value=1 with a 0.5 fraction clamps the actually-held amount down to
+        // floor(1 * 0.5) = 0, but a request within max_value is still admitted - it just
+        // doesn't create a reservation to later release, since there's nothing to hold.
+        let rl = RateLimiterBuilder::new(100)
+            .reservation_limits(ReservationLimits {
+                max_fraction: 0.5,
+                ..Default::default()
+            })
+            .build();
+        let namespace = "hold_clamped_to_zero";
+        let limit = Limit::new(namespace, 1, 60, vec![], Vec::<Expression>::default());
+        rl.add_limit(limit);
+
+        let ns = namespace.into();
+        let ctx = Context::default();
+
+        let result = rl
+            .reserve(&ns, &ctx, 1, Some(Duration::from_secs(30)), false)
+            .unwrap();
+        assert!(!result.limited);
+        assert!(result.reservation_id.is_some());
         assert_eq!(result.amount, 0);
 
         // Repeating it stays consistent - no lingering zero-amount entries accumulate to
         // eventually (incorrectly) block admission.
         let again = rl
-            .reserve(&ns, &ctx, 5, Some(Duration::from_secs(30)), false)
+            .reserve(&ns, &ctx, 1, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(!again.limited);
-        assert!(again.reservation_id.is_none());
+        assert!(again.reservation_id.is_some());
+    }
+
+    #[test]
+    fn reserve_denies_a_reservation_that_could_never_fit_even_with_default_fraction() {
+        // With the default `max_fraction` (1.0, no extra clamp beyond `max_value`), a
+        // request far larger than the counter itself is denied outright - it's never
+        // silently admitted holding only `max_value`.
+        let rl = RateLimiter::new(10);
+        let namespace = "over_max_value_default_fraction";
+        let limit = Limit::new(namespace, 10, 60, vec![], Vec::<Expression>::default());
+        rl.add_limit(limit);
+
+        let ns = namespace.into();
+        let ctx = Context::default();
+
+        let result = rl
+            .reserve(&ns, &ctx, 1000, Some(Duration::from_secs(30)), false)
+            .unwrap();
+        assert!(result.limited);
+        assert!(result.reservation_id.is_none());
+        assert_eq!(result.amount, 0);
     }
 
     #[test]

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -501,12 +501,15 @@ impl RateLimiter {
     ///
     /// On success, `reservation_id` in the result must later be passed to
     /// `commit_reservation` to release the hold once actual usage is known.
+    ///
+    /// `ttl` of `None` uses `ReservationLimits::max_ttl` outright; `Some` is still clamped to
+    /// it.
     pub fn reserve(
         &self,
         namespace: &Namespace,
         ctx: &Context,
         amount: u64,
-        ttl: Duration,
+        ttl: Option<Duration>,
         load_counters: bool,
     ) -> LimitadorResult<ReserveResult> {
         let mut counters = self.counters_that_apply(namespace, ctx)?;
@@ -539,7 +542,9 @@ impl RateLimiter {
             });
         }
 
-        let ttl = ttl.min(self.reservation_limits.max_ttl);
+        let ttl = ttl.map_or(self.reservation_limits.max_ttl, |ttl| {
+            ttl.min(self.reservation_limits.max_ttl)
+        });
 
         let reservation_id = ReservationId::new();
         let auth =
@@ -810,7 +815,7 @@ impl AsyncRateLimiter {
         namespace: &Namespace,
         ctx: &Context<'_>,
         amount: u64,
-        ttl: Duration,
+        ttl: Option<Duration>,
         load_counters: bool,
     ) -> LimitadorResult<ReserveResult> {
         let mut counters = self.counters_that_apply(namespace, ctx).await?;
@@ -842,7 +847,9 @@ impl AsyncRateLimiter {
             });
         }
 
-        let ttl = ttl.min(self.reservation_limits.max_ttl);
+        let ttl = ttl.map_or(self.reservation_limits.max_ttl, |ttl| {
+            ttl.min(self.reservation_limits.max_ttl)
+        });
 
         let reservation_id = ReservationId::new();
         let auth = self
@@ -1021,7 +1028,7 @@ mod test {
                     s.spawn(move || {
                         let ctx = Context::default();
                         let res = rl
-                            .reserve(&ns, &ctx, AMOUNT, Duration::from_secs(30), false)
+                            .reserve(&ns, &ctx, AMOUNT, Some(Duration::from_secs(30)), false)
                             .unwrap();
                         if !res.limited {
                             admitted_count.fetch_add(1, Ordering::SeqCst);
@@ -1108,21 +1115,21 @@ mod test {
         let ctx = Context::default();
 
         let first = rl
-            .reserve(&ns, &ctx, 6, Duration::from_secs(30), false)
+            .reserve(&ns, &ctx, 6, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(!first.limited);
         assert!(first.reservation_id.is_some());
 
         // value(0) + outstanding(6) + 6 = 12 > 10: rejected
         let second = rl
-            .reserve(&ns, &ctx, 6, Duration::from_secs(30), false)
+            .reserve(&ns, &ctx, 6, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(second.limited);
         assert!(second.reservation_id.is_none());
 
         // value(0) + outstanding(6) + 4 = 10 <= 10: admitted
         let third = rl
-            .reserve(&ns, &ctx, 4, Duration::from_secs(30), false)
+            .reserve(&ns, &ctx, 4, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(!third.limited);
     }
@@ -1138,13 +1145,13 @@ mod test {
         let ctx = Context::default();
 
         let reserved = rl
-            .reserve(&ns, &ctx, 6, Duration::from_secs(30), false)
+            .reserve(&ns, &ctx, 6, Some(Duration::from_secs(30)), false)
             .unwrap();
         let reservation_id = reserved.reservation_id.expect("should be admitted");
 
         // Still held: 0 + outstanding(6) + 6 = 12 > 10
         let blocked = rl
-            .reserve(&ns, &ctx, 6, Duration::from_secs(30), false)
+            .reserve(&ns, &ctx, 6, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(blocked.limited);
 
@@ -1162,7 +1169,7 @@ mod test {
 
         // Counter is now at 4 (2 + 2) with no outstanding reservations: 4 + 6 = 10 <= 10
         let after = rl
-            .reserve(&ns, &ctx, 6, Duration::from_secs(30), false)
+            .reserve(&ns, &ctx, 6, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(!after.limited);
     }
@@ -1173,7 +1180,13 @@ mod test {
         let ns = "empty".into();
 
         let result = rl
-            .reserve(&ns, &Context::default(), 5, Duration::from_secs(10), false)
+            .reserve(
+                &ns,
+                &Context::default(),
+                5,
+                Some(Duration::from_secs(10)),
+                false,
+            )
             .unwrap();
         assert!(!result.limited);
         assert!(result.reservation_id.is_none());
@@ -1196,20 +1209,20 @@ mod test {
 
         // Requested 8, but clamped to floor(10 * 0.5) = 5.
         let first = rl
-            .reserve(&ns, &ctx, 8, Duration::from_secs(30), false)
+            .reserve(&ns, &ctx, 8, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(!first.limited);
 
         // A second reservation for 5 more would need 5 + 5 = 10 <= 10, so it's admitted -
         // proving the first only actually held 5, not the requested 8.
         let second = rl
-            .reserve(&ns, &ctx, 5, Duration::from_secs(30), false)
+            .reserve(&ns, &ctx, 5, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(!second.limited);
 
         // A third for even 1 more would be 10 + 1 = 11 > 10: rejected.
         let third = rl
-            .reserve(&ns, &ctx, 1, Duration::from_secs(30), false)
+            .reserve(&ns, &ctx, 1, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(third.limited);
     }
@@ -1227,7 +1240,7 @@ mod test {
         // Without an explicit `max_reservation_fraction`, the full 10 can be reserved in one
         // go - it's only ever clamped down to the counter's own `max_value`, never tighter.
         let result = rl
-            .reserve(&ns, &ctx, 10, Duration::from_secs(30), false)
+            .reserve(&ns, &ctx, 10, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(!result.limited);
     }
@@ -1252,7 +1265,7 @@ mod test {
         let ctx = Context::default();
 
         let result = rl
-            .reserve(&ns, &ctx, 5, Duration::from_secs(30), false)
+            .reserve(&ns, &ctx, 5, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(!result.limited);
         assert!(result.reservation_id.is_none());
@@ -1260,7 +1273,7 @@ mod test {
         // Repeating it stays consistent - no lingering zero-amount entries accumulate to
         // eventually (incorrectly) block admission.
         let again = rl
-            .reserve(&ns, &ctx, 5, Duration::from_secs(30), false)
+            .reserve(&ns, &ctx, 5, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(!again.limited);
         assert!(again.reservation_id.is_none());
@@ -1278,12 +1291,14 @@ mod test {
 
         // A zero ttl means this reservation is already expired by the time we look at it
         // again, without needing to sleep: `expires_at == now_1 <= now_2`.
-        let first = rl.reserve(&ns, &ctx, 8, Duration::ZERO, false).unwrap();
+        let first = rl
+            .reserve(&ns, &ctx, 8, Some(Duration::ZERO), false)
+            .unwrap();
         assert!(!first.limited);
 
         // The first reservation is already expired, so another 8 fits again: 0 + 0 + 8 <= 10
         let second = rl
-            .reserve(&ns, &ctx, 8, Duration::from_secs(30), false)
+            .reserve(&ns, &ctx, 8, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(!second.limited);
     }
@@ -1299,13 +1314,13 @@ mod test {
         let ctx = Context::default();
 
         let first = rl
-            .reserve(&ns, &ctx, 8, Duration::from_millis(20), false)
+            .reserve(&ns, &ctx, 8, Some(Duration::from_millis(20)), false)
             .unwrap();
         assert!(!first.limited);
 
         // Still outstanding: 0 + outstanding(8) + 8 = 16 > 10
         let blocked = rl
-            .reserve(&ns, &ctx, 8, Duration::from_secs(30), false)
+            .reserve(&ns, &ctx, 8, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(blocked.limited);
 
@@ -1313,7 +1328,7 @@ mod test {
 
         // The first reservation has now genuinely expired: 0 + 0 + 8 <= 10
         let admitted = rl
-            .reserve(&ns, &ctx, 8, Duration::from_secs(30), false)
+            .reserve(&ns, &ctx, 8, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(!admitted.limited);
     }

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -525,6 +525,20 @@ impl RateLimiter {
             .map(|c| (c.max_value() as f64 * self.reservation_limits.max_fraction) as u64)
             .min()
             .map_or(amount, |max| amount.min(max));
+
+        // `max_fraction` can clamp a positive request down to 0 (e.g. a small max_value with
+        // a tight fraction). Reserving 0 can never be denied, so - as with no counters
+        // applying above - skip storage entirely rather than let it create a pointless
+        // zero-amount `ReservationEntry` that holds no real capacity.
+        if amount == 0 {
+            return Ok(ReserveResult {
+                limited: false,
+                reservation_id: None,
+                counters: Vec::default(),
+                limit_name: None,
+            });
+        }
+
         let ttl = ttl.min(self.reservation_limits.max_ttl);
 
         let reservation_id = ReservationId::new();
@@ -815,6 +829,19 @@ impl AsyncRateLimiter {
             .map(|c| (c.max_value() as f64 * self.reservation_limits.max_fraction) as u64)
             .min()
             .map_or(amount, |max| amount.min(max));
+
+        // See the comment in `RateLimiter::reserve`: skip storage entirely rather than let a
+        // fraction-clamped-to-zero positive request create a pointless zero-amount
+        // `ReservationEntry`.
+        if amount == 0 {
+            return Ok(ReserveResult {
+                limited: false,
+                reservation_id: None,
+                counters: Vec::default(),
+                limit_name: None,
+            });
+        }
+
         let ttl = ttl.min(self.reservation_limits.max_ttl);
 
         let reservation_id = ReservationId::new();
@@ -1203,6 +1230,40 @@ mod test {
             .reserve(&ns, &ctx, 10, Duration::from_secs(30), false)
             .unwrap();
         assert!(!result.limited);
+    }
+
+    #[test]
+    fn reserve_handles_amount_clamped_to_zero() {
+        // max_value=1 with a 0.5 fraction clamps every positive request down to
+        // floor(1 * 0.5) = 0. Reserving 0 can never be denied, and shouldn't create a
+        // reservation to later release, so this behaves like the "no counters apply" case:
+        // admitted, with no `reservation_id`.
+        let rl = RateLimiterBuilder::new(100)
+            .reservation_limits(ReservationLimits {
+                max_fraction: 0.5,
+                ..Default::default()
+            })
+            .build();
+        let namespace = "fraction_clamped_to_zero";
+        let limit = Limit::new(namespace, 1, 60, vec![], Vec::<Expression>::default());
+        rl.add_limit(limit);
+
+        let ns = namespace.into();
+        let ctx = Context::default();
+
+        let result = rl
+            .reserve(&ns, &ctx, 5, Duration::from_secs(30), false)
+            .unwrap();
+        assert!(!result.limited);
+        assert!(result.reservation_id.is_none());
+
+        // Repeating it stays consistent - no lingering zero-amount entries accumulate to
+        // eventually (incorrectly) block admission.
+        let again = rl
+            .reserve(&ns, &ctx, 5, Duration::from_secs(30), false)
+            .unwrap();
+        assert!(!again.limited);
+        assert!(again.reservation_id.is_none());
     }
 
     #[test]

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -957,6 +957,60 @@ mod test {
     use std::collections::HashMap;
     use std::time::Duration;
 
+    // RFC 0021's motivating scenario: N concurrent in-flight requests against one limit,
+    // racing to reserve capacity before any of them has reported real usage. Uses real OS
+    // threads (`std::thread::scope`), not async tasks, since `reserve()`'s local (in-memory)
+    // path has no internal `.await` - only genuine thread-level parallelism can exercise a
+    // races there (see the `LocalReservationRegistry::admission_lock` docs for the bug this
+    // guards against).
+    #[test]
+    fn concurrent_reserve_calls_never_exceed_the_limit() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        const MAX_VALUE: u64 = 50;
+        const AMOUNT: u64 = 5;
+        const CONCURRENT_REQUESTS: usize = 20;
+
+        for _ in 0..20 {
+            let rl = Arc::new(RateLimiter::new(10_000));
+            let namespace = "race";
+            let limit = Limit::new(
+                namespace,
+                MAX_VALUE,
+                60,
+                vec![],
+                Vec::<Expression>::default(),
+            );
+            rl.add_limit(limit);
+            let ns: crate::limit::Namespace = namespace.into();
+
+            let admitted_count = Arc::new(AtomicUsize::new(0));
+            std::thread::scope(|s| {
+                for _ in 0..CONCURRENT_REQUESTS {
+                    let rl = rl.clone();
+                    let ns = ns.clone();
+                    let admitted_count = admitted_count.clone();
+                    s.spawn(move || {
+                        let ctx = Context::default();
+                        let res = rl
+                            .reserve(&ns, &ctx, AMOUNT, Duration::from_secs(30), false)
+                            .unwrap();
+                        if !res.limited {
+                            admitted_count.fetch_add(1, Ordering::SeqCst);
+                        }
+                    });
+                }
+            });
+
+            // Exactly floor(MAX_VALUE / AMOUNT) requests should have been admitted - never
+            // more (that would mean the race let outstanding reservations jointly exceed the
+            // limit), and never fewer (that would mean available capacity went unused).
+            let expected = (MAX_VALUE / AMOUNT) as usize;
+            assert_eq!(admitted_count.load(Ordering::SeqCst), expected);
+        }
+    }
+
     #[test]
     fn properly_updates_existing_limits() {
         let rl = RateLimiter::new(100);

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -518,6 +518,7 @@ impl RateLimiter {
             return Ok(ReserveResult {
                 limited: false,
                 reservation_id: None,
+                amount: 0,
                 counters,
                 limit_name: None,
             });
@@ -537,6 +538,7 @@ impl RateLimiter {
             return Ok(ReserveResult {
                 limited: false,
                 reservation_id: None,
+                amount: 0,
                 counters: Vec::default(),
                 limit_name: None,
             });
@@ -561,12 +563,14 @@ impl RateLimiter {
             Authorization::Ok => ReserveResult {
                 limited: false,
                 reservation_id: Some(reservation_id),
+                amount,
                 counters,
                 limit_name: None,
             },
             Authorization::Limited(name) => ReserveResult {
                 limited: true,
                 reservation_id: None,
+                amount: 0,
                 counters,
                 limit_name: name,
             },
@@ -828,6 +832,7 @@ impl AsyncRateLimiter {
             return Ok(ReserveResult {
                 limited: false,
                 reservation_id: None,
+                amount: 0,
                 counters,
                 limit_name: None,
             });
@@ -846,6 +851,7 @@ impl AsyncRateLimiter {
             return Ok(ReserveResult {
                 limited: false,
                 reservation_id: None,
+                amount: 0,
                 counters: Vec::default(),
                 limit_name: None,
             });
@@ -871,12 +877,14 @@ impl AsyncRateLimiter {
             Authorization::Ok => ReserveResult {
                 limited: false,
                 reservation_id: Some(reservation_id),
+                amount,
                 counters,
                 limit_name: None,
             },
             Authorization::Limited(name) => ReserveResult {
                 limited: true,
                 reservation_id: None,
+                amount: 0,
                 counters,
                 limit_name: name,
             },
@@ -1216,6 +1224,7 @@ mod test {
             .reserve(&ns, &ctx, 8, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(!first.limited);
+        assert_eq!(first.amount, 5);
 
         // A second reservation for 5 more would need 5 + 5 = 10 <= 10, so it's admitted -
         // proving the first only actually held 5, not the requested 8.
@@ -1247,6 +1256,7 @@ mod test {
             .reserve(&ns, &ctx, 10, Some(Duration::from_secs(30)), false)
             .unwrap();
         assert!(!result.limited);
+        assert_eq!(result.amount, 10);
     }
 
     #[test]
@@ -1273,6 +1283,7 @@ mod test {
             .unwrap();
         assert!(!result.limited);
         assert!(result.reservation_id.is_none());
+        assert_eq!(result.amount, 0);
 
         // Repeating it stays consistent - no lingering zero-amount entries accumulate to
         // eventually (incorrectly) block admission.

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -580,14 +580,16 @@ impl RateLimiter {
 
     /// Resolves a reservation with the caller's real usage: re-resolves counters from
     /// `namespace`/`ctx` exactly as `update_counters` does, and unconditionally applies
-    /// `actual_amount` to them, regardless of whether `reservation_id` is still live. This
-    /// means a late or already-expired reservation degrades gracefully to plain usage
-    /// reporting rather than failing.
+    /// `actual_amount` to them, regardless of whether `reservation_id` is still live.
+    /// `reservation_id` of `None` (e.g. `reserve()` admitted the call but held nothing, so
+    /// there was never a reservation to begin with) skips releasing anything and just
+    /// applies `actual_amount` - the same graceful degradation as `Some` with an
+    /// unrecognized or already-expired id.
     pub fn commit_reservation(
         &self,
         namespace: &Namespace,
         ctx: &Context,
-        reservation_id: &ReservationId,
+        reservation_id: Option<&ReservationId>,
         actual_amount: u64,
     ) -> LimitadorResult<CommitResult> {
         // If the counters resolved here differ from those reserve originally held
@@ -600,11 +602,11 @@ impl RateLimiter {
             .iter()
             .try_for_each(|counter| self.storage.update_counter(counter, actual_amount))?;
 
-        let reservation_released = if counters.is_empty() {
-            false
-        } else {
-            self.storage
-                .release_reservation(&counters, reservation_id)?
+        let reservation_released = match reservation_id {
+            Some(reservation_id) if !counters.is_empty() => self
+                .storage
+                .release_reservation(&counters, reservation_id)?,
+            _ => false,
         };
 
         Ok(CommitResult {
@@ -897,7 +899,7 @@ impl AsyncRateLimiter {
         &self,
         namespace: &Namespace,
         ctx: &Context<'_>,
-        reservation_id: &ReservationId,
+        reservation_id: Option<&ReservationId>,
         actual_amount: u64,
     ) -> LimitadorResult<CommitResult> {
         let counters = self.counters_that_apply(namespace, ctx).await?;
@@ -906,12 +908,13 @@ impl AsyncRateLimiter {
             self.storage.update_counter(counter, actual_amount).await?
         }
 
-        let reservation_released = if counters.is_empty() {
-            false
-        } else {
-            self.storage
-                .release_reservation(&counters, reservation_id)
-                .await?
+        let reservation_released = match reservation_id {
+            Some(reservation_id) if !counters.is_empty() => {
+                self.storage
+                    .release_reservation(&counters, reservation_id)
+                    .await?
+            }
+            _ => false,
         };
 
         Ok(CommitResult {
@@ -1170,13 +1173,13 @@ mod test {
 
         // Real usage turned out lower than the estimate
         let commit = rl
-            .commit_reservation(&ns, &ctx, &reservation_id, 2)
+            .commit_reservation(&ns, &ctx, Some(&reservation_id), 2)
             .unwrap();
         assert!(commit.reservation_released);
 
         // Committing again is a no-op release, but still applies actual_amount unconditionally
         let second_commit = rl
-            .commit_reservation(&ns, &ctx, &reservation_id, 2)
+            .commit_reservation(&ns, &ctx, Some(&reservation_id), 2)
             .unwrap();
         assert!(!second_commit.reservation_released);
 

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -196,12 +196,14 @@
 use crate::counter::Counter;
 use crate::errors::LimitadorError;
 use crate::limit::{Context, Limit, Namespace};
+use crate::reservation::{CommitResult, ReservationId, ReserveResult};
 use crate::storage::in_memory::InMemoryStorage;
 use crate::storage::{
     AsyncCounterStorage, AsyncStorage, Authorization, CounterStorage, Storage, StorageErr,
 };
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Duration;
 
 #[macro_use]
 extern crate core;
@@ -209,6 +211,7 @@ extern crate core;
 pub mod counter;
 pub mod errors;
 pub mod limit;
+pub mod reservation;
 pub mod storage;
 
 pub struct RateLimiter {
@@ -464,6 +467,88 @@ impl RateLimiter {
             .map_err(|err| err.into())
     }
 
+    /// Holds `amount` of estimated capacity against every counter matching `namespace`/`ctx`,
+    /// for at most `ttl`. Admission accounts for any capacity already held by other live
+    /// reservations, in addition to the counters' current values. All matching counters are
+    /// admitted, or none are.
+    ///
+    /// On success, `reservation_id` in the result must later be passed to
+    /// `commit_reservation` to release the hold once actual usage is known.
+    pub fn reserve(
+        &self,
+        namespace: &Namespace,
+        ctx: &Context,
+        amount: u64,
+        ttl: Duration,
+        load_counters: bool,
+    ) -> LimitadorResult<ReserveResult> {
+        let mut counters = self.counters_that_apply(namespace, ctx)?;
+
+        if counters.is_empty() {
+            return Ok(ReserveResult {
+                limited: false,
+                reservation_id: None,
+                counters,
+                limit_name: None,
+            });
+        }
+
+        let reservation_id = ReservationId::new();
+        let auth = self
+            .storage
+            .reserve(&mut counters, &reservation_id, amount, ttl, load_counters)?;
+
+        let counters = if load_counters {
+            counters
+        } else {
+            Vec::default()
+        };
+
+        Ok(match auth {
+            Authorization::Ok => ReserveResult {
+                limited: false,
+                reservation_id: Some(reservation_id),
+                counters,
+                limit_name: None,
+            },
+            Authorization::Limited(name) => ReserveResult {
+                limited: true,
+                reservation_id: None,
+                counters,
+                limit_name: name,
+            },
+        })
+    }
+
+    /// Resolves a reservation with the caller's real usage: re-resolves counters from
+    /// `namespace`/`ctx` exactly as `update_counters` does, and unconditionally applies
+    /// `actual_amount` to them, regardless of whether `reservation_id` is still live. This
+    /// means a late or already-expired reservation degrades gracefully to plain usage
+    /// reporting rather than failing.
+    pub fn commit_reservation(
+        &self,
+        namespace: &Namespace,
+        ctx: &Context,
+        reservation_id: &ReservationId,
+        actual_amount: u64,
+    ) -> LimitadorResult<CommitResult> {
+        let counters = self.counters_that_apply(namespace, ctx)?;
+
+        counters
+            .iter()
+            .try_for_each(|counter| self.storage.update_counter(counter, actual_amount))?;
+
+        let reservation_released = if counters.is_empty() {
+            false
+        } else {
+            self.storage.release_reservation(&counters, reservation_id)?
+        };
+
+        Ok(CommitResult {
+            reservation_released,
+        })
+    }
+
     // Deletes all the limits stored except the ones received in the params. For
     // every limit received, if it does not exist, it is created. If it already
     // exists, its associated counters are not reset.
@@ -669,6 +754,81 @@ impl AsyncRateLimiter {
             .map_err(|err| err.into())
     }
 
+    /// See [`RateLimiter::reserve`].
+    pub async fn reserve(
+        &self,
+        namespace: &Namespace,
+        ctx: &Context<'_>,
+        amount: u64,
+        ttl: Duration,
+        load_counters: bool,
+    ) -> LimitadorResult<ReserveResult> {
+        let mut counters = self.counters_that_apply(namespace, ctx).await?;
+
+        if counters.is_empty() {
+            return Ok(ReserveResult {
+                limited: false,
+                reservation_id: None,
+                counters,
+                limit_name: None,
+            });
+        }
+
+        let reservation_id = ReservationId::new();
+        let auth = self
+            .storage
+            .reserve(&mut counters, &reservation_id, amount, ttl, load_counters)
+            .await?;
+
+        let counters = if load_counters {
+            counters
+        } else {
+            Vec::default()
+        };
+
+        Ok(match auth {
+            Authorization::Ok => ReserveResult {
+                limited: false,
+                reservation_id: Some(reservation_id),
+                counters,
+                limit_name: None,
+            },
+            Authorization::Limited(name) => ReserveResult {
+                limited: true,
+                reservation_id: None,
+                counters,
+                limit_name: name,
+            },
+        })
+    }
+
+    /// See [`RateLimiter::commit_reservation`].
+    pub async fn commit_reservation(
+        &self,
+        namespace: &Namespace,
+        ctx: &Context<'_>,
+        reservation_id: &ReservationId,
+        actual_amount: u64,
+    ) -> LimitadorResult<CommitResult> {
+        let counters = self.counters_that_apply(namespace, ctx).await?;
+
+        for counter in &counters {
+            self.storage.update_counter(counter, actual_amount).await?
+        }
+
+        let reservation_released = if counters.is_empty() {
+            false
+        } else {
+            self.storage
+                .release_reservation(&counters, reservation_id)
+                .await?
+        };
+
+        Ok(CommitResult {
+            reservation_released,
+        })
+    }
+
     // Deletes all the limits stored except the ones received in the params. For
     // every limit received, if it does not exist, it is created. If it already
     // exists, its associated counters are not reset.
@@ -751,6 +911,7 @@ mod test {
     use crate::limit::{Context, Expression, Limit};
     use crate::RateLimiter;
     use std::collections::HashMap;
+    use std::time::Duration;
 
     #[test]
     fn properly_updates_existing_limits() {
@@ -809,5 +970,139 @@ mod test {
             .check_rate_limited_and_update(&namespace.into(), &ctx, 1, true)
             .unwrap();
         assert_eq!(r.counters.first().unwrap().remaining(), Some(41));
+    }
+
+    #[test]
+    fn reserve_accounts_for_outstanding_reservations() {
+        let rl = RateLimiter::new(100);
+        let namespace = "reservations";
+        let limit = Limit::new(namespace, 10, 60, vec![], Vec::<Expression>::default());
+        rl.add_limit(limit);
+
+        let ns = namespace.into();
+        let ctx = Context::default();
+
+        let first = rl
+            .reserve(&ns, &ctx, 6, Duration::from_secs(30), false)
+            .unwrap();
+        assert!(!first.limited);
+        assert!(first.reservation_id.is_some());
+
+        // value(0) + outstanding(6) + 6 = 12 > 10: rejected
+        let second = rl
+            .reserve(&ns, &ctx, 6, Duration::from_secs(30), false)
+            .unwrap();
+        assert!(second.limited);
+        assert!(second.reservation_id.is_none());
+
+        // value(0) + outstanding(6) + 4 = 10 <= 10: admitted
+        let third = rl
+            .reserve(&ns, &ctx, 4, Duration::from_secs(30), false)
+            .unwrap();
+        assert!(!third.limited);
+    }
+
+    #[test]
+    fn commit_reservation_applies_actual_amount_and_releases_hold() {
+        let rl = RateLimiter::new(100);
+        let namespace = "commit";
+        let limit = Limit::new(namespace, 10, 60, vec![], Vec::<Expression>::default());
+        rl.add_limit(limit);
+
+        let ns = namespace.into();
+        let ctx = Context::default();
+
+        let reserved = rl
+            .reserve(&ns, &ctx, 6, Duration::from_secs(30), false)
+            .unwrap();
+        let reservation_id = reserved.reservation_id.expect("should be admitted");
+
+        // Still held: 0 + outstanding(6) + 6 = 12 > 10
+        let blocked = rl
+            .reserve(&ns, &ctx, 6, Duration::from_secs(30), false)
+            .unwrap();
+        assert!(blocked.limited);
+
+        // Real usage turned out lower than the estimate
+        let commit = rl
+            .commit_reservation(&ns, &ctx, &reservation_id, 2)
+            .unwrap();
+        assert!(commit.reservation_released);
+
+        // Committing again is a no-op release, but still applies actual_amount unconditionally
+        let second_commit = rl
+            .commit_reservation(&ns, &ctx, &reservation_id, 2)
+            .unwrap();
+        assert!(!second_commit.reservation_released);
+
+        // Counter is now at 4 (2 + 2) with no outstanding reservations: 4 + 6 = 10 <= 10
+        let after = rl
+            .reserve(&ns, &ctx, 6, Duration::from_secs(30), false)
+            .unwrap();
+        assert!(!after.limited);
+    }
+
+    #[test]
+    fn reserve_without_matching_limits_is_a_noop() {
+        let rl = RateLimiter::new(100);
+        let ns = "empty".into();
+
+        let result = rl
+            .reserve(&ns, &Context::default(), 5, Duration::from_secs(10), false)
+            .unwrap();
+        assert!(!result.limited);
+        assert!(result.reservation_id.is_none());
+    }
+
+    #[test]
+    fn expired_reservations_do_not_count_as_outstanding() {
+        let rl = RateLimiter::new(100);
+        let namespace = "expiry";
+        let limit = Limit::new(namespace, 10, 60, vec![], Vec::<Expression>::default());
+        rl.add_limit(limit);
+
+        let ns = namespace.into();
+        let ctx = Context::default();
+
+        // A zero ttl means this reservation is already expired by the time we look at it
+        // again, without needing to sleep: `expires_at == now_1 <= now_2`.
+        let first = rl.reserve(&ns, &ctx, 8, Duration::ZERO, false).unwrap();
+        assert!(!first.limited);
+
+        // The first reservation is already expired, so another 8 fits again: 0 + 0 + 8 <= 10
+        let second = rl
+            .reserve(&ns, &ctx, 8, Duration::from_secs(30), false)
+            .unwrap();
+        assert!(!second.limited);
+    }
+
+    #[test]
+    fn reservation_expires_after_its_ttl_elapses() {
+        let rl = RateLimiter::new(100);
+        let namespace = "expiry-sleep";
+        let limit = Limit::new(namespace, 10, 60, vec![], Vec::<Expression>::default());
+        rl.add_limit(limit);
+
+        let ns = namespace.into();
+        let ctx = Context::default();
+
+        let first = rl
+            .reserve(&ns, &ctx, 8, Duration::from_millis(20), false)
+            .unwrap();
+        assert!(!first.limited);
+
+        // Still outstanding: 0 + outstanding(8) + 8 = 16 > 10
+        let blocked = rl
+            .reserve(&ns, &ctx, 8, Duration::from_secs(30), false)
+            .unwrap();
+        assert!(blocked.limited);
+
+        std::thread::sleep(Duration::from_millis(50));
+
+        // The first reservation has now genuinely expired: 0 + 0 + 8 <= 10
+        let admitted = rl
+            .reserve(&ns, &ctx, 8, Duration::from_secs(30), false)
+            .unwrap();
+        assert!(!admitted.limited);
     }
 }

--- a/limitador/src/lib.rs
+++ b/limitador/src/lib.rs
@@ -196,7 +196,7 @@
 use crate::counter::Counter;
 use crate::errors::LimitadorError;
 use crate::limit::{Context, Limit, Namespace};
-use crate::reservation::{CommitResult, ReservationId, ReserveResult};
+use crate::reservation::{CommitResult, ReservationId, ReservationLimits, ReserveResult};
 use crate::storage::in_memory::InMemoryStorage;
 use crate::storage::{
     AsyncCounterStorage, AsyncStorage, Authorization, CounterStorage, Storage, StorageErr,
@@ -216,14 +216,17 @@ pub mod storage;
 
 pub struct RateLimiter {
     storage: Storage,
+    reservation_limits: ReservationLimits,
 }
 
 pub struct AsyncRateLimiter {
     storage: AsyncStorage,
+    reservation_limits: ReservationLimits,
 }
 
 pub struct RateLimiterBuilder {
     storage: Storage,
+    reservation_limits: ReservationLimits,
 }
 
 type LimitadorResult<T> = Result<T, LimitadorError>;
@@ -286,12 +289,16 @@ impl From<CheckResult> for bool {
 
 impl RateLimiterBuilder {
     pub fn with_storage(storage: Storage) -> Self {
-        Self { storage }
+        Self {
+            storage,
+            reservation_limits: ReservationLimits::default(),
+        }
     }
 
     pub fn new(cache_size: u64) -> Self {
         Self {
             storage: Storage::new(cache_size),
+            reservation_limits: ReservationLimits::default(),
         }
     }
 
@@ -300,25 +307,43 @@ impl RateLimiterBuilder {
         self
     }
 
+    /// See [`ReservationLimits`].
+    pub fn reservation_limits(mut self, reservation_limits: ReservationLimits) -> Self {
+        self.reservation_limits = reservation_limits;
+        self
+    }
+
     pub fn build(self) -> RateLimiter {
         RateLimiter {
             storage: self.storage,
+            reservation_limits: self.reservation_limits,
         }
     }
 }
 
 pub struct AsyncRateLimiterBuilder {
     storage: AsyncStorage,
+    reservation_limits: ReservationLimits,
 }
 
 impl AsyncRateLimiterBuilder {
     pub fn new(storage: AsyncStorage) -> Self {
-        Self { storage }
+        Self {
+            storage,
+            reservation_limits: ReservationLimits::default(),
+        }
+    }
+
+    /// See [`ReservationLimits`].
+    pub fn reservation_limits(mut self, reservation_limits: ReservationLimits) -> Self {
+        self.reservation_limits = reservation_limits;
+        self
     }
 
     pub fn build(self) -> AsyncRateLimiter {
         AsyncRateLimiter {
             storage: self.storage,
+            reservation_limits: self.reservation_limits,
         }
     }
 }
@@ -327,12 +352,14 @@ impl RateLimiter {
     pub fn new(cache_size: u64) -> Self {
         Self {
             storage: Storage::new(cache_size),
+            reservation_limits: ReservationLimits::default(),
         }
     }
 
     pub fn new_with_storage(counters: Box<dyn CounterStorage>) -> Self {
         Self {
             storage: Storage::with_counter_storage(counters),
+            reservation_limits: ReservationLimits::default(),
         }
     }
 
@@ -493,6 +520,13 @@ impl RateLimiter {
             });
         }
 
+        let amount = counters
+            .iter()
+            .map(|c| (c.max_value() as f64 * self.reservation_limits.max_fraction) as u64)
+            .min()
+            .map_or(amount, |max| amount.min(max));
+        let ttl = ttl.min(self.reservation_limits.max_ttl);
+
         let reservation_id = ReservationId::new();
         let auth =
             self.storage
@@ -612,6 +646,7 @@ impl AsyncRateLimiter {
     pub fn new_with_storage(storage: Box<dyn AsyncCounterStorage>) -> Self {
         Self {
             storage: AsyncStorage::with_counter_storage(storage),
+            reservation_limits: ReservationLimits::default(),
         }
     }
 
@@ -775,6 +810,13 @@ impl AsyncRateLimiter {
             });
         }
 
+        let amount = counters
+            .iter()
+            .map(|c| (c.max_value() as f64 * self.reservation_limits.max_fraction) as u64)
+            .min()
+            .map_or(amount, |max| amount.min(max));
+        let ttl = ttl.min(self.reservation_limits.max_ttl);
+
         let reservation_id = ReservationId::new();
         let auth = self
             .storage
@@ -910,7 +952,8 @@ fn classify_limits_by_namespace(
 #[cfg(test)]
 mod test {
     use crate::limit::{Context, Expression, Limit};
-    use crate::RateLimiter;
+    use crate::reservation::ReservationLimits;
+    use crate::{RateLimiter, RateLimiterBuilder};
     use std::collections::HashMap;
     use std::time::Duration;
 
@@ -1053,6 +1096,59 @@ mod test {
             .unwrap();
         assert!(!result.limited);
         assert!(result.reservation_id.is_none());
+    }
+
+    #[test]
+    fn reserve_clamps_amount_to_max_reservation_fraction() {
+        let rl = RateLimiterBuilder::new(100)
+            .reservation_limits(ReservationLimits {
+                max_fraction: 0.5,
+                ..Default::default()
+            })
+            .build();
+        let namespace = "fraction";
+        let limit = Limit::new(namespace, 10, 60, vec![], Vec::<Expression>::default());
+        rl.add_limit(limit);
+
+        let ns = namespace.into();
+        let ctx = Context::default();
+
+        // Requested 8, but clamped to floor(10 * 0.5) = 5.
+        let first = rl
+            .reserve(&ns, &ctx, 8, Duration::from_secs(30), false)
+            .unwrap();
+        assert!(!first.limited);
+
+        // A second reservation for 5 more would need 5 + 5 = 10 <= 10, so it's admitted -
+        // proving the first only actually held 5, not the requested 8.
+        let second = rl
+            .reserve(&ns, &ctx, 5, Duration::from_secs(30), false)
+            .unwrap();
+        assert!(!second.limited);
+
+        // A third for even 1 more would be 10 + 1 = 11 > 10: rejected.
+        let third = rl
+            .reserve(&ns, &ctx, 1, Duration::from_secs(30), false)
+            .unwrap();
+        assert!(third.limited);
+    }
+
+    #[test]
+    fn default_max_reservation_fraction_does_not_clamp() {
+        let rl = RateLimiter::new(100);
+        let namespace = "no_fraction_clamp";
+        let limit = Limit::new(namespace, 10, 60, vec![], Vec::<Expression>::default());
+        rl.add_limit(limit);
+
+        let ns = namespace.into();
+        let ctx = Context::default();
+
+        // Without an explicit `max_reservation_fraction`, the full 10 can be reserved in one
+        // go - it's only ever clamped down to the counter's own `max_value`, never tighter.
+        let result = rl
+            .reserve(&ns, &ctx, 10, Duration::from_secs(30), false)
+            .unwrap();
+        assert!(!result.limited);
     }
 
     #[test]

--- a/limitador/src/reservation.rs
+++ b/limitador/src/reservation.rs
@@ -1,0 +1,103 @@
+use crate::counter::Counter;
+use std::fmt::{Display, Formatter};
+use std::time::SystemTime;
+use uuid::Uuid;
+
+/// Opaque handle identifying a single reservation created by `RateLimiter::reserve`
+/// (or its async twin) and later resolved by `RateLimiter::commit_reservation`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ReservationId(String);
+
+impl ReservationId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4().to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for ReservationId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Display for ReservationId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for ReservationId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl AsRef<str> for ReservationId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A single outstanding hold of estimated capacity against one counter.
+///
+/// The same `reservation_id` and `amount` are stored under every counter a
+/// `RateLimiter::reserve` call touched; `expires_at` is computed independently
+/// per counter, since it is clamped to that counter's own window boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReservationEntry {
+    reservation_id: ReservationId,
+    amount: u64,
+    expires_at: SystemTime,
+}
+
+impl ReservationEntry {
+    pub fn new(reservation_id: ReservationId, amount: u64, expires_at: SystemTime) -> Self {
+        Self {
+            reservation_id,
+            amount,
+            expires_at,
+        }
+    }
+
+    pub fn reservation_id(&self) -> &ReservationId {
+        &self.reservation_id
+    }
+
+    pub fn amount(&self) -> u64 {
+        self.amount
+    }
+
+    pub fn expires_at(&self) -> SystemTime {
+        self.expires_at
+    }
+
+    pub fn is_live_at(&self, when: SystemTime) -> bool {
+        self.expires_at > when
+    }
+}
+
+/// Result of `RateLimiter::reserve`/`AsyncRateLimiter::reserve`.
+///
+/// `reservation_id` is `Some` only when `limited` is `false`: admission was granted
+/// and the estimated `amount` is now held against every matching counter until it
+/// expires or is resolved by `RateLimiter::commit_reservation`.
+pub struct ReserveResult {
+    pub limited: bool,
+    pub reservation_id: Option<ReservationId>,
+    pub counters: Vec<Counter>,
+    pub limit_name: Option<String>,
+}
+
+/// Result of `RateLimiter::commit_reservation`/`AsyncRateLimiter::commit_reservation`.
+///
+/// `reservation_released` reflects whether a live reservation matching the given id
+/// was found and removed; `actual_amount` is applied to the counters unconditionally
+/// either way, so a missing/expired reservation degrades gracefully to `Report`-like
+/// behavior.
+pub struct CommitResult {
+    pub reservation_released: bool,
+}

--- a/limitador/src/reservation.rs
+++ b/limitador/src/reservation.rs
@@ -83,11 +83,18 @@ impl ReservationEntry {
 /// Result of `RateLimiter::reserve`/`AsyncRateLimiter::reserve`.
 ///
 /// `reservation_id` is `Some` only when `limited` is `false`: admission was granted
-/// and the estimated `amount` is now held against every matching counter until it
-/// expires or is resolved by `RateLimiter::commit_reservation`.
+/// and `amount` is now held against every matching counter until it expires or is
+/// resolved by `RateLimiter::commit_reservation`.
+///
+/// `amount` is the amount actually held, uniformly across every matching counter - it
+/// can be less than what was requested if `ReservationLimits::max_fraction` clamped it
+/// down, and it's `0` when `limited` is `true`. It's purely informational:
+/// `commit_reservation`'s `actual_amount` is independent of it and always applied as
+/// given.
 pub struct ReserveResult {
     pub limited: bool,
     pub reservation_id: Option<ReservationId>,
+    pub amount: u64,
     pub counters: Vec<Counter>,
     pub limit_name: Option<String>,
 }

--- a/limitador/src/reservation.rs
+++ b/limitador/src/reservation.rs
@@ -1,6 +1,6 @@
 use crate::counter::Counter;
 use std::fmt::{Display, Formatter};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 use uuid::Uuid;
 
 /// Opaque handle identifying a single reservation created by `RateLimiter::reserve`
@@ -100,4 +100,33 @@ pub struct ReserveResult {
 /// behavior.
 pub struct CommitResult {
     pub reservation_released: bool,
+}
+
+/// Policy limits applied by `RateLimiter::reserve`/`AsyncRateLimiter::reserve`, set once via
+/// `RateLimiterBuilder::reservation_limits`/`AsyncRateLimiterBuilder::reservation_limits`
+/// rather than per call - the fraction clamp needs each matching counter's own `max_value`,
+/// which `reserve()` already resolves internally, so there's no reason for callers to supply
+/// it (or re-resolve counters themselves) on every call.
+#[derive(Debug, Clone, Copy)]
+pub struct ReservationLimits {
+    /// Clamps a `reserve()` call's requested amount to `counter.max_value() * max_fraction`
+    /// for every matching counter; the most restrictive one wins. Defaults to `1.0`, i.e. no
+    /// clamp beyond each counter's own `max_value` - RFC 0021 recommends `0.5` as a safety
+    /// default, but that's a policy choice for embedders to opt into, not a silent default
+    /// that would change what already-configured callers' `reserve()` calls admit.
+    pub max_fraction: f64,
+    /// Hard ceiling on a `reserve()` call's requested ttl. Defaults to 60s (RFC 0021's
+    /// recommendation) - unlike `max_fraction`, there's no safe "no-op" `Duration` to default
+    /// to instead, since an extreme sentinel risks overflowing `SystemTime::now() + ttl`
+    /// inside storage.
+    pub max_ttl: Duration,
+}
+
+impl Default for ReservationLimits {
+    fn default() -> Self {
+        Self {
+            max_fraction: 1.0,
+            max_ttl: Duration::from_secs(60),
+        }
+    }
 }

--- a/limitador/src/reservation.rs
+++ b/limitador/src/reservation.rs
@@ -117,14 +117,21 @@ pub struct CommitResult {
 #[derive(Debug, Clone, Copy)]
 pub struct ReservationLimits {
     /// Caps the amount actually held by an admitted `reserve()` call to
-    /// `counter.max_value() * max_fraction`, for every matching counter - the most
+    /// `counter.max_value() * max_fraction`, for every matching counter, the most
     /// restrictive one wins. This never affects admission itself (that's always decided on
     /// the raw requested amount); it only limits how much of a counter a single reservation
     /// can claim, so it can't starve concurrent reservations. Defaults to `1.0`, i.e. no
-    /// clamp beyond each counter's own `max_value` - RFC 0021 recommends `0.5` as a safety
-    /// default, but that's a policy choice for embedders to opt into, not a silent default
-    /// that would change what already-configured callers' `reserve()` calls admit.
+    /// clamp beyond each counter's own `max_value`.
+    ///
+    /// This is a trade-off knob, not a free safety win: a lower `max_fraction` admits more
+    /// *concurrent* reservations (better for fairness), but each holds a smaller, less
+    /// accurate share of the real amount it may end up committing - so the more of them are
+    /// in flight at once, the more the counter's real value can overshoot `max_value` once
+    /// they all commit. A higher `max_fraction` accepts more monopolization risk (one
+    /// reservation can claim more of the counter, or all of it at `1.0`) in exchange for a
+    /// tighter bound on aggregate overshoot.
     pub max_fraction: f64,
+
     /// Hard ceiling on a `reserve()` call's requested ttl. Defaults to 60s (RFC 0021's
     /// recommendation) - unlike `max_fraction`, there's no safe "no-op" `Duration` to default
     /// to instead, since an extreme sentinel risks overflowing `SystemTime::now() + ttl`

--- a/limitador/src/reservation.rs
+++ b/limitador/src/reservation.rs
@@ -116,8 +116,11 @@ pub struct CommitResult {
 /// it (or re-resolve counters themselves) on every call.
 #[derive(Debug, Clone, Copy)]
 pub struct ReservationLimits {
-    /// Clamps a `reserve()` call's requested amount to `counter.max_value() * max_fraction`
-    /// for every matching counter; the most restrictive one wins. Defaults to `1.0`, i.e. no
+    /// Caps the amount actually held by an admitted `reserve()` call to
+    /// `counter.max_value() * max_fraction`, for every matching counter - the most
+    /// restrictive one wins. This never affects admission itself (that's always decided on
+    /// the raw requested amount); it only limits how much of a counter a single reservation
+    /// can claim, so it can't starve concurrent reservations. Defaults to `1.0`, i.e. no
     /// clamp beyond each counter's own `max_value` - RFC 0021 recommends `0.5` as a safety
     /// default, but that's a policy choice for embedders to opt into, not a silent default
     /// that would change what already-configured callers' `reserve()` calls admit.

--- a/limitador/src/storage/disk/rocksdb_storage.rs
+++ b/limitador/src/storage/disk/rocksdb_storage.rs
@@ -1,10 +1,12 @@
 use crate::counter::Counter;
 use crate::limit::Limit;
+use crate::reservation::ReservationId;
 use crate::storage::disk::expiring_value::ExpiringValue;
 use crate::storage::disk::OptimizeFor;
 use crate::storage::keys::bin::{
     key_for_counter, partial_counter_from_counter_key, prefix_for_namespace,
 };
+use crate::storage::local_reservations::{LocalReservationRegistry, ReservationRequest};
 use crate::storage::{Authorization, CounterStorage, StorageErr};
 use rocksdb::{
     CompactionDecision, DBCompressionType, DBWithThreadMode, IteratorMode, MultiThreaded, Options,
@@ -18,6 +20,8 @@ use tracing::debug_span;
 
 pub struct RocksDbStorage {
     db: DBWithThreadMode<MultiThreaded>,
+    // Local-memory only, not shared across processes - see `LocalReservationRegistry`'s docs.
+    reservations: LocalReservationRegistry,
 }
 
 impl CounterStorage for RocksDbStorage {
@@ -151,6 +155,50 @@ impl CounterStorage for RocksDbStorage {
         }
         Ok(())
     }
+
+    // Local-memory only (see `LocalReservationRegistry`'s docs): not shared across processes,
+    // which is consistent with `RocksDbStorage`'s existing single-instance scope for counters
+    // themselves.
+    #[tracing::instrument(skip_all)]
+    fn reserve(
+        &self,
+        counters: &mut Vec<Counter>,
+        reservation_id: &ReservationId,
+        amount: u64,
+        ttl: Duration,
+        load_counters: bool,
+    ) -> Result<Authorization, StorageErr> {
+        let now = SystemTime::now();
+        let mut values_and_window_ttls = Vec::with_capacity(counters.len());
+        for counter in counters.iter() {
+            let key = key_for_counter(counter);
+            // Zero-delta "touch": establishes a fresh window if absent/expired, without
+            // affecting the counter's real value - mirrors `InMemoryStorage`'s `touch`.
+            let value = self.insert_or_update(&key, counter, 0)?;
+            values_and_window_ttls.push((value.value(), value.ttl()));
+        }
+
+        Ok(self.reservations.reserve(
+            counters,
+            &values_and_window_ttls,
+            ReservationRequest {
+                reservation_id,
+                amount,
+                ttl,
+                load_counters,
+                now,
+            },
+        ))
+    }
+
+    #[tracing::instrument(skip_all)]
+    fn release_reservation(
+        &self,
+        counters: &[Counter],
+        reservation_id: &ReservationId,
+    ) -> Result<bool, StorageErr> {
+        Ok(self.reservations.release(counters, reservation_id))
+    }
 }
 
 impl RocksDbStorage {
@@ -187,7 +235,10 @@ impl RocksDbStorage {
         });
         opts.create_if_missing(true);
         let db = DB::open(&opts, path).unwrap();
-        Ok(Self { db })
+        Ok(Self {
+            db,
+            reservations: LocalReservationRegistry::new(),
+        })
     }
 
     fn insert_or_update(

--- a/limitador/src/storage/disk/rocksdb_storage.rs
+++ b/limitador/src/storage/disk/rocksdb_storage.rs
@@ -166,7 +166,8 @@ impl CounterStorage for RocksDbStorage {
         &self,
         counters: &mut Vec<Counter>,
         reservation_id: &ReservationId,
-        amount: u64,
+        check_amount: u64,
+        hold_amount: u64,
         ttl: Duration,
         load_counters: bool,
     ) -> Result<Authorization, StorageErr> {
@@ -185,7 +186,8 @@ impl CounterStorage for RocksDbStorage {
             &values_and_window_ttls,
             ReservationRequest {
                 reservation_id,
-                amount,
+                check_amount,
+                hold_amount,
                 ttl,
                 load_counters,
                 now,
@@ -279,13 +281,27 @@ impl RocksDbStorage {
 mod tests {
     use super::RocksDbStorage;
     use crate::counter::Counter;
-    use crate::limit::Limit;
+    use crate::limit::{Context, Limit};
+    use crate::reservation::ReservationId;
     use crate::storage::disk::OptimizeFor;
-    use crate::storage::CounterStorage;
+    use crate::storage::{Authorization, CounterStorage};
     use std::collections::HashMap;
     use std::fs;
     use std::time::Duration;
     use tempfile::TempDir;
+
+    fn counter(max_value: u64) -> Counter {
+        let limit = Limit::new(
+            "reserve_test",
+            max_value,
+            60,
+            vec![],
+            Vec::<crate::limit::Expression>::default(),
+        );
+        Counter::new(limit, &Context::default())
+            .unwrap()
+            .expect("must have a counter")
+    }
 
     #[test]
     fn opens_db_on_disk() {
@@ -337,5 +353,31 @@ mod tests {
                 "Should be above threshold still!"
             );
         }
+    }
+
+    #[test]
+    fn reserve_with_hold_amount_zero_creates_no_entry() {
+        let tmp = TempDir::new().expect("We should have a dir!");
+        let storage =
+            RocksDbStorage::open(tmp.path(), OptimizeFor::Space).expect("We should have storage");
+        let mut counters = vec![counter(10)];
+        let reservation_id = ReservationId::new();
+
+        let auth = storage
+            .reserve(
+                &mut counters,
+                &reservation_id,
+                10,
+                0,
+                Duration::from_secs(60),
+                false,
+            )
+            .unwrap();
+        assert!(matches!(auth, Authorization::Ok));
+
+        let released = storage
+            .release_reservation(&counters, &reservation_id)
+            .unwrap();
+        assert!(!released, "nothing should have been held to release");
     }
 }

--- a/limitador/src/storage/disk/rocksdb_storage.rs
+++ b/limitador/src/storage/disk/rocksdb_storage.rs
@@ -6,7 +6,9 @@ use crate::storage::disk::OptimizeFor;
 use crate::storage::keys::bin::{
     key_for_counter, partial_counter_from_counter_key, prefix_for_namespace,
 };
-use crate::storage::local_reservations::{LocalReservationRegistry, ReservationRequest};
+use crate::storage::local_reservations::{
+    LocalReservationRegistry, ReservationRequest, DEFAULT_LOCAL_RESERVATIONS_CACHE_SIZE,
+};
 use crate::storage::{Authorization, CounterStorage, StorageErr};
 use rocksdb::{
     CompactionDecision, DBCompressionType, DBWithThreadMode, IteratorMode, MultiThreaded, Options,
@@ -237,7 +239,7 @@ impl RocksDbStorage {
         let db = DB::open(&opts, path).unwrap();
         Ok(Self {
             db,
-            reservations: LocalReservationRegistry::new(),
+            reservations: LocalReservationRegistry::new(DEFAULT_LOCAL_RESERVATIONS_CACHE_SIZE),
         })
     }
 

--- a/limitador/src/storage/in_memory.rs
+++ b/limitador/src/storage/in_memory.rs
@@ -1,5 +1,6 @@
 use crate::counter::Counter;
 use crate::limit::{Context, Limit, Namespace};
+use crate::reservation::{ReservationEntry, ReservationId};
 use crate::storage::atomic_expiring_value::AtomicExpiringValue;
 use crate::storage::{Authorization, CounterStorage, StorageErr};
 use moka::sync::{Cache, CacheBuilder};
@@ -13,6 +14,7 @@ use std::time::{Duration, SystemTime};
 pub struct InMemoryStorage {
     simple_limits: RwLock<BTreeMap<Limit, AtomicExpiringValue>>,
     qualified_counters: Cache<Counter, Arc<AtomicExpiringValue>>,
+    reservations: RwLock<HashMap<Counter, Vec<ReservationEntry>>>,
 }
 
 impl CounterStorage for InMemoryStorage {
@@ -199,6 +201,73 @@ impl CounterStorage for InMemoryStorage {
         self.simple_limits.write().unwrap().clear();
         Ok(())
     }
+
+    #[tracing::instrument(skip_all)]
+    fn reserve(
+        &self,
+        counters: &mut Vec<Counter>,
+        reservation_id: &ReservationId,
+        amount: u64,
+        ttl: Duration,
+        load_counters: bool,
+    ) -> Result<Authorization, StorageErr> {
+        let now = SystemTime::now();
+        let mut first_limited = None;
+        let mut expires_at_by_counter = Vec::with_capacity(counters.len());
+
+        for counter in counters.iter_mut() {
+            let (value, window_ttl) = self.touch(counter, now);
+            let outstanding = self.outstanding(counter, now);
+            let expires_at = std::cmp::min(now + ttl, now + window_ttl);
+            expires_at_by_counter.push(expires_at);
+
+            let total = value + outstanding + amount;
+            if load_counters {
+                let remaining = counter.max_value().checked_sub(total);
+                counter.set_remaining(remaining.unwrap_or_default());
+                counter.set_expires_in(window_ttl);
+            }
+            if first_limited.is_none() && total > counter.max_value() {
+                first_limited = Some(Authorization::Limited(
+                    counter.limit().name().map(|n| n.to_owned()),
+                ));
+            }
+        }
+
+        if let Some(limited) = first_limited {
+            return Ok(limited);
+        }
+
+        let mut registry = self.reservations.write().unwrap();
+        for (counter, expires_at) in counters.iter().zip(expires_at_by_counter) {
+            let entries = registry.entry(counter.clone()).or_default();
+            entries.retain(|e| e.is_live_at(now));
+            entries.push(ReservationEntry::new(reservation_id.clone(), amount, expires_at));
+        }
+
+        Ok(Authorization::Ok)
+    }
+
+    #[tracing::instrument(skip_all)]
+    fn release_reservation(
+        &self,
+        counters: &[Counter],
+        reservation_id: &ReservationId,
+    ) -> Result<bool, StorageErr> {
+        let mut released = false;
+        let mut registry = self.reservations.write().unwrap();
+        for counter in counters {
+            if let Some(entries) = registry.get_mut(counter) {
+                let before = entries.len();
+                entries.retain(|e| e.reservation_id() != reservation_id);
+                released |= entries.len() != before;
+                if entries.is_empty() {
+                    registry.remove(counter);
+                }
+            }
+        }
+        Ok(released)
+    }
 }
 
 impl InMemoryStorage {
@@ -208,6 +277,7 @@ impl InMemoryStorage {
             qualified_counters: CacheBuilder::new(cache_size)
                 .support_invalidation_closures()
                 .build(),
+            reservations: RwLock::new(HashMap::new()),
         }
     }
 
@@ -261,6 +331,45 @@ impl InMemoryStorage {
             Some(current_val) => current_val + delta <= counter.max_value(),
             None => counter.max_value() >= delta,
         }
+    }
+
+    // Reads the counter's current value, lazily starting (or restarting, if expired) its
+    // window with a zero-delta update. Returns the (unaffected) value and the ttl of the
+    // window it now belongs to, so callers can compute a per-counter reservation expiry
+    // without ever touching the counter's real value.
+    fn touch(&self, counter: &Counter, now: SystemTime) -> (u64, Duration) {
+        if counter.is_qualified() {
+            let value = match self.qualified_counters.get(counter) {
+                None => self.qualified_counters.get_with(counter.clone(), || {
+                    Arc::new(AtomicExpiringValue::new(0, now + counter.window()))
+                }),
+                Some(value) => value,
+            };
+            let current = value.update(0, counter.window(), now);
+            (current, value.ttl())
+        } else {
+            let mut counters = self.simple_limits.write().unwrap();
+            let value = counters
+                .entry(counter.limit().clone())
+                .or_insert_with(|| AtomicExpiringValue::new(0, now + counter.window()));
+            let current = value.update(0, counter.window(), now);
+            (current, value.ttl())
+        }
+    }
+
+    fn outstanding(&self, counter: &Counter, now: SystemTime) -> u64 {
+        self.reservations
+            .read()
+            .unwrap()
+            .get(counter)
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter(|e| e.is_live_at(now))
+                    .map(|e| e.amount())
+                    .sum()
+            })
+            .unwrap_or_default()
     }
 }
 

--- a/limitador/src/storage/in_memory.rs
+++ b/limitador/src/storage/in_memory.rs
@@ -208,7 +208,8 @@ impl CounterStorage for InMemoryStorage {
         &self,
         counters: &mut Vec<Counter>,
         reservation_id: &ReservationId,
-        amount: u64,
+        check_amount: u64,
+        hold_amount: u64,
         ttl: Duration,
         load_counters: bool,
     ) -> Result<Authorization, StorageErr> {
@@ -223,7 +224,8 @@ impl CounterStorage for InMemoryStorage {
             &values_and_window_ttls,
             ReservationRequest {
                 reservation_id,
-                amount,
+                check_amount,
+                hold_amount,
                 ttl,
                 load_counters,
                 now,
@@ -372,5 +374,42 @@ mod tests {
             storage.counters_in_namespace(counter_1.namespace()).len(),
             2
         );
+    }
+
+    fn counter(max_value: u64) -> Counter {
+        let limit = Limit::new(
+            "reserve_test",
+            max_value,
+            60,
+            vec![],
+            Vec::<crate::limit::Expression>::default(),
+        );
+        Counter::new(limit, &Context::default())
+            .unwrap()
+            .expect("must have a counter")
+    }
+
+    #[test]
+    fn reserve_with_hold_amount_zero_creates_no_entry() {
+        let storage = InMemoryStorage::default();
+        let mut counters = vec![counter(10)];
+        let reservation_id = ReservationId::new();
+
+        let auth = storage
+            .reserve(
+                &mut counters,
+                &reservation_id,
+                10,
+                0,
+                Duration::from_secs(60),
+                false,
+            )
+            .unwrap();
+        assert!(matches!(auth, Authorization::Ok));
+
+        let released = storage
+            .release_reservation(&counters, &reservation_id)
+            .unwrap();
+        assert!(!released, "nothing should have been held to release");
     }
 }

--- a/limitador/src/storage/in_memory.rs
+++ b/limitador/src/storage/in_memory.rs
@@ -1,7 +1,8 @@
 use crate::counter::Counter;
 use crate::limit::{Context, Limit, Namespace};
-use crate::reservation::{ReservationEntry, ReservationId};
+use crate::reservation::ReservationId;
 use crate::storage::atomic_expiring_value::AtomicExpiringValue;
+use crate::storage::local_reservations::{LocalReservationRegistry, ReservationRequest};
 use crate::storage::{Authorization, CounterStorage, StorageErr};
 use moka::sync::{Cache, CacheBuilder};
 use moka::PredicateError;
@@ -14,7 +15,7 @@ use std::time::{Duration, SystemTime};
 pub struct InMemoryStorage {
     simple_limits: RwLock<BTreeMap<Limit, AtomicExpiringValue>>,
     qualified_counters: Cache<Counter, Arc<AtomicExpiringValue>>,
-    reservations: RwLock<HashMap<Counter, Vec<ReservationEntry>>>,
+    reservations: LocalReservationRegistry,
 }
 
 impl CounterStorage for InMemoryStorage {
@@ -212,40 +213,22 @@ impl CounterStorage for InMemoryStorage {
         load_counters: bool,
     ) -> Result<Authorization, StorageErr> {
         let now = SystemTime::now();
-        let mut first_limited = None;
-        let mut expires_at_by_counter = Vec::with_capacity(counters.len());
+        let values_and_window_ttls: Vec<(u64, Duration)> = counters
+            .iter()
+            .map(|counter| self.touch(counter, now))
+            .collect();
 
-        for counter in counters.iter_mut() {
-            let (value, window_ttl) = self.touch(counter, now);
-            let outstanding = self.outstanding(counter, now);
-            let expires_at = std::cmp::min(now + ttl, now + window_ttl);
-            expires_at_by_counter.push(expires_at);
-
-            let total = value + outstanding + amount;
-            if load_counters {
-                let remaining = counter.max_value().checked_sub(total);
-                counter.set_remaining(remaining.unwrap_or_default());
-                counter.set_expires_in(window_ttl);
-            }
-            if first_limited.is_none() && total > counter.max_value() {
-                first_limited = Some(Authorization::Limited(
-                    counter.limit().name().map(|n| n.to_owned()),
-                ));
-            }
-        }
-
-        if let Some(limited) = first_limited {
-            return Ok(limited);
-        }
-
-        let mut registry = self.reservations.write().unwrap();
-        for (counter, expires_at) in counters.iter().zip(expires_at_by_counter) {
-            let entries = registry.entry(counter.clone()).or_default();
-            entries.retain(|e| e.is_live_at(now));
-            entries.push(ReservationEntry::new(reservation_id.clone(), amount, expires_at));
-        }
-
-        Ok(Authorization::Ok)
+        Ok(self.reservations.reserve(
+            counters,
+            &values_and_window_ttls,
+            ReservationRequest {
+                reservation_id,
+                amount,
+                ttl,
+                load_counters,
+                now,
+            },
+        ))
     }
 
     #[tracing::instrument(skip_all)]
@@ -254,19 +237,7 @@ impl CounterStorage for InMemoryStorage {
         counters: &[Counter],
         reservation_id: &ReservationId,
     ) -> Result<bool, StorageErr> {
-        let mut released = false;
-        let mut registry = self.reservations.write().unwrap();
-        for counter in counters {
-            if let Some(entries) = registry.get_mut(counter) {
-                let before = entries.len();
-                entries.retain(|e| e.reservation_id() != reservation_id);
-                released |= entries.len() != before;
-                if entries.is_empty() {
-                    registry.remove(counter);
-                }
-            }
-        }
-        Ok(released)
+        Ok(self.reservations.release(counters, reservation_id))
     }
 }
 
@@ -277,7 +248,7 @@ impl InMemoryStorage {
             qualified_counters: CacheBuilder::new(cache_size)
                 .support_invalidation_closures()
                 .build(),
-            reservations: RwLock::new(HashMap::new()),
+            reservations: LocalReservationRegistry::new(),
         }
     }
 
@@ -355,21 +326,6 @@ impl InMemoryStorage {
             let current = value.update(0, counter.window(), now);
             (current, value.ttl())
         }
-    }
-
-    fn outstanding(&self, counter: &Counter, now: SystemTime) -> u64 {
-        self.reservations
-            .read()
-            .unwrap()
-            .get(counter)
-            .map(|entries| {
-                entries
-                    .iter()
-                    .filter(|e| e.is_live_at(now))
-                    .map(|e| e.amount())
-                    .sum()
-            })
-            .unwrap_or_default()
     }
 }
 

--- a/limitador/src/storage/in_memory.rs
+++ b/limitador/src/storage/in_memory.rs
@@ -248,7 +248,7 @@ impl InMemoryStorage {
             qualified_counters: CacheBuilder::new(cache_size)
                 .support_invalidation_closures()
                 .build(),
-            reservations: LocalReservationRegistry::new(),
+            reservations: LocalReservationRegistry::new(cache_size),
         }
     }
 

--- a/limitador/src/storage/keys.rs
+++ b/limitador/src/storage/keys.rs
@@ -39,6 +39,18 @@ pub fn key_for_counter(counter: &Counter) -> Vec<u8> {
     }
 }
 
+// Reservations are held in a Redis hash (one field per `reservation_id`), so they can't
+// share a key with the counter's own value (a plain string incremented via `INCRBY`) —
+// Redis only allows one data type per key. Deriving this key by suffixing
+// `key_for_counter`'s bytes, rather than serializing the counter's identity again from
+// scratch, avoids a second encode and trivially inherits the `{namespace}` hash tag the
+// counter key already carries, keeping both keys on the same Redis Cluster shard.
+pub fn key_for_reservations(counter: &Counter) -> Vec<u8> {
+    let mut key = key_for_counter(counter);
+    key.extend_from_slice(b",reservations");
+    key
+}
+
 pub fn key_for_counters_of_limit(limit: &Limit) -> Vec<u8> {
     if let Some(id) = limit.id() {
         #[derive(PartialEq, Debug, Serialize, Deserialize)]

--- a/limitador/src/storage/local_reservations.rs
+++ b/limitador/src/storage/local_reservations.rs
@@ -175,7 +175,15 @@ impl LocalReservationRegistry {
         Authorization::Ok
     }
 
+    // Held for the whole read-then-write sequence below, same as `reserve()` - see
+    // `admission_lock`'s docs. Without this, a concurrent `reserve()` could replace this
+    // counter's cache entry with a fresh `Arc` (e.g. if the one we're about to read had
+    // already expired/been evicted) between our `get` and our later `invalidate`; blindly
+    // writing back our now-stale captured `Arc` would silently discard whatever
+    // concurrently-admitted, still-live reservation that fresh `Arc` holds.
     pub(crate) fn release(&self, counters: &[Counter], reservation_id: &ReservationId) -> bool {
+        let _admission_guard = self.admission_lock.lock().unwrap();
+
         let mut released = false;
         for counter in counters {
             if let Some(entry) = self.entries.get(counter) {
@@ -190,9 +198,14 @@ impl LocalReservationRegistry {
                 };
                 if now_empty {
                     self.entries.invalidate(counter);
-                } else {
-                    self.entries.insert(counter.clone(), entry);
                 }
+                // Otherwise: nothing left to do. The mutation above already happened through
+                // the same `Arc`/`RwLock` the cache still maps `counter` to (guaranteed by
+                // holding `admission_lock` for the whole call), so it's already visible to
+                // later reads - reinserting would only risk clobbering a fresher entry with
+                // our own stale reference, and would incorrectly push the entry's
+                // Moka-tracked expiry out from now, past the counter's actual window
+                // boundary, since `release` never touches `window_ttl`.
             }
         }
         released

--- a/limitador/src/storage/local_reservations.rs
+++ b/limitador/src/storage/local_reservations.rs
@@ -57,7 +57,11 @@ pub(crate) struct LocalReservationRegistry {
 
 pub(crate) struct ReservationRequest<'a> {
     pub(crate) reservation_id: &'a ReservationId,
-    pub(crate) amount: u64,
+    /// Amount checked against each counter's remaining capacity to decide admission.
+    pub(crate) check_amount: u64,
+    /// Amount actually held once admitted - may be less than `check_amount` (e.g. clamped
+    /// by policy); `0` counts as "denied" for admission purposes.
+    pub(crate) hold_amount: u64,
     pub(crate) ttl: Duration,
     pub(crate) load_counters: bool,
     pub(crate) now: SystemTime,
@@ -123,6 +127,8 @@ impl LocalReservationRegistry {
         values_and_window_ttls: &[(u64, Duration)],
         request: ReservationRequest,
     ) -> Authorization {
+        debug_assert!(request.hold_amount <= request.check_amount);
+
         // Held for the whole check-then-write sequence below - see `admission_lock`'s docs.
         let _admission_guard = self.admission_lock.lock().unwrap();
 
@@ -135,7 +141,7 @@ impl LocalReservationRegistry {
             let expires_at = std::cmp::min(now + request.ttl, now + *window_ttl);
             expires_at_by_counter.push(expires_at);
 
-            let total = value + outstanding + request.amount;
+            let total = value + outstanding + request.check_amount;
             if request.load_counters {
                 let remaining = counter.max_value().checked_sub(total);
                 counter.set_remaining(remaining.unwrap_or_default());
@@ -150,6 +156,12 @@ impl LocalReservationRegistry {
 
         if let Some(limited) = first_limited {
             return limited;
+        }
+
+        // Admitted, but nothing to actually hold (e.g. `hold_amount` clamped to 0 by
+        // policy) - skip creating a pointless zero-amount entry.
+        if request.hold_amount == 0 {
+            return Authorization::Ok;
         }
 
         for ((counter, expires_at), (_, window_ttl)) in counters
@@ -169,7 +181,7 @@ impl LocalReservationRegistry {
                 guard.entries.retain(|e| e.is_live_at(now));
                 guard.entries.push(ReservationEntry::new(
                     request.reservation_id.clone(),
-                    request.amount,
+                    request.hold_amount,
                     expires_at,
                 ));
             }

--- a/limitador/src/storage/local_reservations.rs
+++ b/limitador/src/storage/local_reservations.rs
@@ -1,0 +1,112 @@
+use crate::counter::Counter;
+use crate::reservation::{ReservationEntry, ReservationId};
+use crate::storage::Authorization;
+use std::collections::HashMap;
+use std::sync::RwLock;
+use std::time::{Duration, SystemTime};
+
+/// A local (single-process, in-memory only) reservation registry.
+///
+/// Used as a pragmatic starting point by backends that don't yet share reservations across
+/// replicas/processes (`RocksDbStorage`, `CachedRedisStorage`) - mirroring the RFC's accepted
+/// "local-memory-only" scope already granted to disk/distributed storage for counters
+/// themselves. Not a substitute for a properly shared implementation where multiple
+/// replicas need to see each other's outstanding reservations.
+pub(crate) struct LocalReservationRegistry {
+    entries: RwLock<HashMap<Counter, Vec<ReservationEntry>>>,
+}
+
+pub(crate) struct ReservationRequest<'a> {
+    pub(crate) reservation_id: &'a ReservationId,
+    pub(crate) amount: u64,
+    pub(crate) ttl: Duration,
+    pub(crate) load_counters: bool,
+    pub(crate) now: SystemTime,
+}
+
+impl LocalReservationRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: RwLock::new(HashMap::new()),
+        }
+    }
+
+    fn outstanding(&self, counter: &Counter, now: SystemTime) -> u64 {
+        self.entries
+            .read()
+            .unwrap()
+            .get(counter)
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter(|e| e.is_live_at(now))
+                    .map(|e| e.amount())
+                    .sum()
+            })
+            .unwrap_or_default()
+    }
+
+    /// `values_and_window_ttls[i]` must be the current value and remaining window ttl of
+    /// `counters[i]`, already read (and, if absent, lazily established) by the caller.
+    pub(crate) fn reserve(
+        &self,
+        counters: &mut [Counter],
+        values_and_window_ttls: &[(u64, Duration)],
+        request: ReservationRequest,
+    ) -> Authorization {
+        let now = request.now;
+        let mut first_limited = None;
+        let mut expires_at_by_counter = Vec::with_capacity(counters.len());
+
+        for (counter, (value, window_ttl)) in counters.iter_mut().zip(values_and_window_ttls) {
+            let outstanding = self.outstanding(counter, now);
+            let expires_at = std::cmp::min(now + request.ttl, now + *window_ttl);
+            expires_at_by_counter.push(expires_at);
+
+            let total = value + outstanding + request.amount;
+            if request.load_counters {
+                let remaining = counter.max_value().checked_sub(total);
+                counter.set_remaining(remaining.unwrap_or_default());
+                counter.set_expires_in(*window_ttl);
+            }
+            if first_limited.is_none() && total > counter.max_value() {
+                first_limited = Some(Authorization::Limited(
+                    counter.limit().name().map(|n| n.to_owned()),
+                ));
+            }
+        }
+
+        if let Some(limited) = first_limited {
+            return limited;
+        }
+
+        let mut registry = self.entries.write().unwrap();
+        for (counter, expires_at) in counters.iter().zip(expires_at_by_counter) {
+            let entries = registry.entry(counter.clone()).or_default();
+            entries.retain(|e| e.is_live_at(now));
+            entries.push(ReservationEntry::new(
+                request.reservation_id.clone(),
+                request.amount,
+                expires_at,
+            ));
+        }
+
+        Authorization::Ok
+    }
+
+    pub(crate) fn release(&self, counters: &[Counter], reservation_id: &ReservationId) -> bool {
+        let mut released = false;
+        let mut registry = self.entries.write().unwrap();
+        for counter in counters {
+            if let Some(entries) = registry.get_mut(counter) {
+                let before = entries.len();
+                entries.retain(|e| e.reservation_id() != reservation_id);
+                released |= entries.len() != before;
+                if entries.is_empty() {
+                    registry.remove(counter);
+                }
+            }
+        }
+        released
+    }
+}

--- a/limitador/src/storage/local_reservations.rs
+++ b/limitador/src/storage/local_reservations.rs
@@ -3,7 +3,7 @@ use crate::reservation::{ReservationEntry, ReservationId};
 use crate::storage::Authorization;
 use moka::sync::{Cache, CacheBuilder};
 use moka::Expiry;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant, SystemTime};
 
 /// Used by backends that don't have their own natural "expected number of distinct
@@ -38,6 +38,17 @@ type Entry = Arc<RwLock<CounterReservations>>;
 /// until the cache fills up.
 pub(crate) struct LocalReservationRegistry {
     entries: Cache<Counter, Entry>,
+    // Serializes the whole check-then-write admission decision in `reserve()` across every
+    // counter it touches. Without this, two truly concurrent `reserve()` calls (real
+    // OS-thread parallelism) can both read the same stale `outstanding` value, both decide
+    // to admit, and both write - jointly exceeding the limit. Reservations are a lower-volume
+    // path (only token/LLM-style rate limiting), so trading fine-grained per-counter
+    // concurrency for one simple, obviously-correct critical section is the right tradeoff -
+    // this is the in-process equivalent of the atomicity Redis gets for free from running the
+    // whole check-and-write as a single Lua script. `release()` doesn't need this lock: it
+    // only ever monotonically decreases outstanding, so racing it against a `reserve()`'s read
+    // can only make that read more conservative, never allow over-admission.
+    admission_lock: Mutex<()>,
 }
 
 pub(crate) struct ReservationRequest<'a> {
@@ -80,6 +91,7 @@ impl LocalReservationRegistry {
             entries: CacheBuilder::new(max_size)
                 .expire_after(ReservationExpiry)
                 .build(),
+            admission_lock: Mutex::new(()),
         }
     }
 
@@ -101,16 +113,15 @@ impl LocalReservationRegistry {
 
     /// `values_and_window_ttls[i]` must be the current value and remaining window ttl of
     /// `counters[i]`, already read (and, if absent, lazily established) by the caller.
-    // TODO: `outstanding` is read here, then written well below, with no lock held across
-    // the gap - two truly concurrent `reserve()` calls on the same counter (real OS-thread
-    // parallelism, not async interleaving) could both admit past the limit. Not reachable
-    // today (gRPC server is single threaded tokio runtime), but should be closed properly.
     pub(crate) fn reserve(
         &self,
         counters: &mut [Counter],
         values_and_window_ttls: &[(u64, Duration)],
         request: ReservationRequest,
     ) -> Authorization {
+        // Held for the whole check-then-write sequence below - see `admission_lock`'s docs.
+        let _admission_guard = self.admission_lock.lock().unwrap();
+
         let now = request.now;
         let mut first_limited = None;
         let mut expires_at_by_counter = Vec::with_capacity(counters.len());

--- a/limitador/src/storage/local_reservations.rs
+++ b/limitador/src/storage/local_reservations.rs
@@ -1,9 +1,28 @@
 use crate::counter::Counter;
 use crate::reservation::{ReservationEntry, ReservationId};
 use crate::storage::Authorization;
-use std::collections::HashMap;
-use std::sync::RwLock;
-use std::time::{Duration, SystemTime};
+use moka::sync::{Cache, CacheBuilder};
+use moka::Expiry;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant, SystemTime};
+
+/// Used by backends that don't have their own natural "expected number of distinct
+/// counters" knob to size their local reservation registry against (currently only
+/// `RocksDbStorage`; `InMemoryStorage` and `CachedRedisStorage` reuse their own counter
+/// cache size instead).
+#[cfg(feature = "disk_storage")]
+pub(crate) const DEFAULT_LOCAL_RESERVATIONS_CACHE_SIZE: u64 = 10_000;
+
+/// A counter's outstanding reservations, plus the remaining ttl of its current window as
+/// of the last `reserve()` call that touched it - a reservation can never outlive its
+/// counter's window (see `LocalReservationRegistry::reserve`'s `expires_at` clamp), so this
+/// is also always a safe upper bound for how long to keep the whole entry cached.
+struct CounterReservations {
+    window_ttl: Duration,
+    entries: Vec<ReservationEntry>,
+}
+
+type Entry = Arc<RwLock<CounterReservations>>;
 
 /// A local (single-process, in-memory only) reservation registry.
 ///
@@ -12,8 +31,13 @@ use std::time::{Duration, SystemTime};
 /// "local-memory-only" scope already granted to disk/distributed storage for counters
 /// themselves. Not a substitute for a properly shared implementation where multiple
 /// replicas need to see each other's outstanding reservations.
+///
+/// Backed by a size-bounded Moka cache with a per-entry `Expiry` policy tied to each
+/// counter's own window ttl, so a counter's reservations are actively reclaimed once its
+/// window closes - even if that counter is never touched again - rather than accumulating
+/// until the cache fills up.
 pub(crate) struct LocalReservationRegistry {
-    entries: RwLock<HashMap<Counter, Vec<ReservationEntry>>>,
+    entries: Cache<Counter, Entry>,
 }
 
 pub(crate) struct ReservationRequest<'a> {
@@ -24,20 +48,49 @@ pub(crate) struct ReservationRequest<'a> {
     pub(crate) now: SystemTime,
 }
 
+struct ReservationExpiry;
+
+impl Expiry<Counter, Entry> for ReservationExpiry {
+    fn expire_after_create(
+        &self,
+        _key: &Counter,
+        value: &Entry,
+        _created_at: Instant,
+    ) -> Option<Duration> {
+        Some(value.read().unwrap().window_ttl)
+    }
+
+    // Mutating through the `RwLock` alone doesn't notify the cache of anything; `reserve`
+    // re-inserts after updating `window_ttl` so this gets re-evaluated against the fresh
+    // value, the same way the Redis backend re-issues `PEXPIRE` on every `reserve()` call.
+    fn expire_after_update(
+        &self,
+        _key: &Counter,
+        value: &Entry,
+        _updated_at: Instant,
+        _duration_until_expiry: Option<Duration>,
+    ) -> Option<Duration> {
+        Some(value.read().unwrap().window_ttl)
+    }
+}
+
 impl LocalReservationRegistry {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(max_size: u64) -> Self {
         Self {
-            entries: RwLock::new(HashMap::new()),
+            entries: CacheBuilder::new(max_size)
+                .expire_after(ReservationExpiry)
+                .build(),
         }
     }
 
     fn outstanding(&self, counter: &Counter, now: SystemTime) -> u64 {
         self.entries
-            .read()
-            .unwrap()
             .get(counter)
-            .map(|entries| {
-                entries
+            .map(|entry| {
+                entry
+                    .read()
+                    .unwrap()
+                    .entries
                     .iter()
                     .filter(|e| e.is_live_at(now))
                     .map(|e| e.amount())
@@ -48,6 +101,10 @@ impl LocalReservationRegistry {
 
     /// `values_and_window_ttls[i]` must be the current value and remaining window ttl of
     /// `counters[i]`, already read (and, if absent, lazily established) by the caller.
+    // TODO: `outstanding` is read here, then written well below, with no lock held across
+    // the gap - two truly concurrent `reserve()` calls on the same counter (real OS-thread
+    // parallelism, not async interleaving) could both admit past the limit. Not reachable
+    // today (gRPC server is single threaded tokio runtime), but should be closed properly.
     pub(crate) fn reserve(
         &self,
         counters: &mut [Counter],
@@ -80,15 +137,28 @@ impl LocalReservationRegistry {
             return limited;
         }
 
-        let mut registry = self.entries.write().unwrap();
-        for (counter, expires_at) in counters.iter().zip(expires_at_by_counter) {
-            let entries = registry.entry(counter.clone()).or_default();
-            entries.retain(|e| e.is_live_at(now));
-            entries.push(ReservationEntry::new(
-                request.reservation_id.clone(),
-                request.amount,
-                expires_at,
-            ));
+        for ((counter, expires_at), (_, window_ttl)) in counters
+            .iter()
+            .zip(expires_at_by_counter)
+            .zip(values_and_window_ttls)
+        {
+            let entry = self.entries.get_with(counter.clone(), || {
+                Arc::new(RwLock::new(CounterReservations {
+                    window_ttl: *window_ttl,
+                    entries: Vec::new(),
+                }))
+            });
+            {
+                let mut guard = entry.write().unwrap();
+                guard.window_ttl = *window_ttl;
+                guard.entries.retain(|e| e.is_live_at(now));
+                guard.entries.push(ReservationEntry::new(
+                    request.reservation_id.clone(),
+                    request.amount,
+                    expires_at,
+                ));
+            }
+            self.entries.insert(counter.clone(), entry);
         }
 
         Authorization::Ok
@@ -96,14 +166,21 @@ impl LocalReservationRegistry {
 
     pub(crate) fn release(&self, counters: &[Counter], reservation_id: &ReservationId) -> bool {
         let mut released = false;
-        let mut registry = self.entries.write().unwrap();
         for counter in counters {
-            if let Some(entries) = registry.get_mut(counter) {
-                let before = entries.len();
-                entries.retain(|e| e.reservation_id() != reservation_id);
-                released |= entries.len() != before;
-                if entries.is_empty() {
-                    registry.remove(counter);
+            if let Some(entry) = self.entries.get(counter) {
+                let now_empty = {
+                    let mut guard = entry.write().unwrap();
+                    let before = guard.entries.len();
+                    guard
+                        .entries
+                        .retain(|e| e.reservation_id() != reservation_id);
+                    released |= guard.entries.len() != before;
+                    guard.entries.is_empty()
+                };
+                if now_empty {
+                    self.entries.invalidate(counter);
+                } else {
+                    self.entries.insert(counter.clone(), entry);
                 }
             }
         }

--- a/limitador/src/storage/local_reservations.rs
+++ b/limitador/src/storage/local_reservations.rs
@@ -38,16 +38,20 @@ type Entry = Arc<RwLock<CounterReservations>>;
 /// until the cache fills up.
 pub(crate) struct LocalReservationRegistry {
     entries: Cache<Counter, Entry>,
-    // Serializes the whole check-then-write admission decision in `reserve()` across every
-    // counter it touches. Without this, two truly concurrent `reserve()` calls (real
-    // OS-thread parallelism) can both read the same stale `outstanding` value, both decide
-    // to admit, and both write - jointly exceeding the limit. Reservations are a lower-volume
-    // path (only token/LLM-style rate limiting), so trading fine-grained per-counter
-    // concurrency for one simple, obviously-correct critical section is the right tradeoff -
-    // this is the in-process equivalent of the atomicity Redis gets for free from running the
-    // whole check-and-write as a single Lua script. `release()` doesn't need this lock: it
-    // only ever monotonically decreases outstanding, so racing it against a `reserve()`'s read
-    // can only make that read more conservative, never allow over-admission.
+    // Held by both `reserve()` and `release()` for their entire read-then-write sequence.
+    //
+    // - In `reserve()`: without it, two truly concurrent calls (real OS-thread parallelism)
+    //   could both read the same stale `outstanding` value, both decide to admit, and both
+    //   write - jointly exceeding the limit.
+    // - In `release()`: without it, a concurrent `reserve()` could replace a counter's cache
+    //   entry with a fresh `Arc` (e.g. if the one `release()` just read had already
+    //   expired/been evicted) before `release()` writes back; `release()` would then discard
+    //   whatever live reservation that fresh `Arc` holds.
+    //
+    // Reservations are a lower-volume path (only token/LLM-style rate limiting), so trading
+    // fine-grained per-counter concurrency for one simple, obviously-correct critical section
+    // is the right tradeoff - this is the in-process equivalent of the atomicity Redis gets
+    // for free from running the whole check-and-write as a single Lua script.
     admission_lock: Mutex<()>,
 }
 

--- a/limitador/src/storage/mod.rs
+++ b/limitador/src/storage/mod.rs
@@ -155,12 +155,19 @@ impl Storage {
         &self,
         counters: &mut Vec<Counter>,
         reservation_id: &ReservationId,
-        amount: u64,
+        check_amount: u64,
+        hold_amount: u64,
         ttl: Duration,
         load_counters: bool,
     ) -> Result<Authorization, StorageErr> {
-        self.counters
-            .reserve(counters, reservation_id, amount, ttl, load_counters)
+        self.counters.reserve(
+            counters,
+            reservation_id,
+            check_amount,
+            hold_amount,
+            ttl,
+            load_counters,
+        )
     }
 
     pub fn release_reservation(
@@ -298,12 +305,20 @@ impl AsyncStorage {
         &self,
         counters: &mut Vec<Counter>,
         reservation_id: &ReservationId,
-        amount: u64,
+        check_amount: u64,
+        hold_amount: u64,
         ttl: Duration,
         load_counters: bool,
     ) -> Result<Authorization, StorageErr> {
         self.counters
-            .reserve(counters, reservation_id, amount, ttl, load_counters)
+            .reserve(
+                counters,
+                reservation_id,
+                check_amount,
+                hold_amount,
+                ttl,
+                load_counters,
+            )
             .await
     }
 
@@ -337,9 +352,11 @@ pub trait CounterStorage: Sync + Send {
     fn delete_counters(&self, limits: &HashSet<Arc<Limit>>) -> Result<(), StorageErr>; // todo revise typing here?
     fn clear(&self) -> Result<(), StorageErr>;
 
-    /// Holds `amount` of estimated capacity against every counter in `counters`, provided
-    /// none of them would be pushed over their limit once outstanding reservations are
-    /// accounted for. All counters are admitted, or none are.
+    /// Admits, or not, based on `check_amount`: every counter in `counters` must stay
+    /// within its limit if `check_amount` were held, once outstanding reservations are
+    /// accounted for - all counters are admitted, or none are. If admitted, `hold_amount`
+    /// (which may be less than `check_amount`, e.g. clamped by policy) is what actually
+    /// gets held.
     ///
     /// Backends that don't yet support reservations can rely on this default, which
     /// always fails with a non-transient [`StorageErr`].
@@ -347,7 +364,8 @@ pub trait CounterStorage: Sync + Send {
         &self,
         _counters: &mut Vec<Counter>,
         _reservation_id: &ReservationId,
-        _amount: u64,
+        _check_amount: u64,
+        _hold_amount: u64,
         _ttl: Duration,
         _load_counters: bool,
     ) -> Result<Authorization, StorageErr> {
@@ -391,7 +409,8 @@ pub trait AsyncCounterStorage: Sync + Send {
         &self,
         _counters: &mut Vec<Counter>,
         _reservation_id: &ReservationId,
-        _amount: u64,
+        _check_amount: u64,
+        _hold_amount: u64,
         _ttl: Duration,
         _load_counters: bool,
     ) -> Result<Authorization, StorageErr> {

--- a/limitador/src/storage/mod.rs
+++ b/limitador/src/storage/mod.rs
@@ -24,6 +24,8 @@ pub mod redis;
 mod atomic_expiring_value;
 #[cfg(any(feature = "disk_storage", feature = "redis_storage"))]
 mod keys;
+// Used unconditionally by `in_memory` and, when enabled, by `disk`/`redis`.
+mod local_reservations;
 
 pub enum Authorization {
     Ok,

--- a/limitador/src/storage/mod.rs
+++ b/limitador/src/storage/mod.rs
@@ -1,11 +1,13 @@
 use crate::counter::Counter;
 use crate::limit::{Limit, Namespace};
+use crate::reservation::ReservationId;
 use crate::InMemoryStorage;
 use async_trait::async_trait;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
 #[cfg(feature = "disk_storage")]
 pub mod disk;
@@ -147,6 +149,26 @@ impl Storage {
         }
     }
 
+    pub fn reserve(
+        &self,
+        counters: &mut Vec<Counter>,
+        reservation_id: &ReservationId,
+        amount: u64,
+        ttl: Duration,
+        load_counters: bool,
+    ) -> Result<Authorization, StorageErr> {
+        self.counters
+            .reserve(counters, reservation_id, amount, ttl, load_counters)
+    }
+
+    pub fn release_reservation(
+        &self,
+        counters: &[Counter],
+        reservation_id: &ReservationId,
+    ) -> Result<bool, StorageErr> {
+        self.counters.release_reservation(counters, reservation_id)
+    }
+
     pub fn clear(&self) -> Result<(), StorageErr> {
         self.limits.write().unwrap().clear();
         self.counters.clear()
@@ -270,6 +292,29 @@ impl AsyncStorage {
         self.counters.get_counters(&limits).await
     }
 
+    pub async fn reserve(
+        &self,
+        counters: &mut Vec<Counter>,
+        reservation_id: &ReservationId,
+        amount: u64,
+        ttl: Duration,
+        load_counters: bool,
+    ) -> Result<Authorization, StorageErr> {
+        self.counters
+            .reserve(counters, reservation_id, amount, ttl, load_counters)
+            .await
+    }
+
+    pub async fn release_reservation(
+        &self,
+        counters: &[Counter],
+        reservation_id: &ReservationId,
+    ) -> Result<bool, StorageErr> {
+        self.counters
+            .release_reservation(counters, reservation_id)
+            .await
+    }
+
     pub async fn clear(&self) -> Result<(), StorageErr> {
         self.limits.write().unwrap().clear();
         self.counters.clear().await
@@ -289,6 +334,37 @@ pub trait CounterStorage: Sync + Send {
     fn get_counters(&self, limits: &HashSet<Arc<Limit>>) -> Result<HashSet<Counter>, StorageErr>; // todo revise typing here?
     fn delete_counters(&self, limits: &HashSet<Arc<Limit>>) -> Result<(), StorageErr>; // todo revise typing here?
     fn clear(&self) -> Result<(), StorageErr>;
+
+    /// Holds `amount` of estimated capacity against every counter in `counters`, provided
+    /// none of them would be pushed over their limit once outstanding reservations are
+    /// accounted for. All counters are admitted, or none are.
+    ///
+    /// Backends that don't yet support reservations can rely on this default, which
+    /// always fails with a non-transient [`StorageErr`].
+    fn reserve(
+        &self,
+        _counters: &mut Vec<Counter>,
+        _reservation_id: &ReservationId,
+        _amount: u64,
+        _ttl: Duration,
+        _load_counters: bool,
+    ) -> Result<Authorization, StorageErr> {
+        Err(StorageErr::unsupported(
+            "reservations are not supported by this storage backend",
+        ))
+    }
+
+    /// Releases the reservation identified by `reservation_id` from every counter in
+    /// `counters`, if a live entry is found. Returns whether anything was released.
+    fn release_reservation(
+        &self,
+        _counters: &[Counter],
+        _reservation_id: &ReservationId,
+    ) -> Result<bool, StorageErr> {
+        Err(StorageErr::unsupported(
+            "reservations are not supported by this storage backend",
+        ))
+    }
 }
 
 #[async_trait]
@@ -307,6 +383,31 @@ pub trait AsyncCounterStorage: Sync + Send {
     ) -> Result<HashSet<Counter>, StorageErr>;
     async fn delete_counters(&self, limits: &HashSet<Arc<Limit>>) -> Result<(), StorageErr>;
     async fn clear(&self) -> Result<(), StorageErr>;
+
+    /// See [`CounterStorage::reserve`].
+    async fn reserve(
+        &self,
+        _counters: &mut Vec<Counter>,
+        _reservation_id: &ReservationId,
+        _amount: u64,
+        _ttl: Duration,
+        _load_counters: bool,
+    ) -> Result<Authorization, StorageErr> {
+        Err(StorageErr::unsupported(
+            "reservations are not supported by this storage backend",
+        ))
+    }
+
+    /// See [`CounterStorage::release_reservation`].
+    async fn release_reservation(
+        &self,
+        _counters: &[Counter],
+        _reservation_id: &ReservationId,
+    ) -> Result<bool, StorageErr> {
+        Err(StorageErr::unsupported(
+            "reservations are not supported by this storage backend",
+        ))
+    }
 }
 
 #[derive(Debug)]
@@ -329,6 +430,14 @@ impl Error for StorageErr {
 }
 
 impl StorageErr {
+    pub(crate) fn unsupported(msg: impl Into<String>) -> Self {
+        Self {
+            msg: msg.into(),
+            source: None,
+            transient: false,
+        }
+    }
+
     pub fn msg(&self) -> &str {
         &self.msg
     }

--- a/limitador/src/storage/redis/redis_async.rs
+++ b/limitador/src/storage/redis/redis_async.rs
@@ -221,10 +221,13 @@ impl AsyncCounterStorage for AsyncRedisStorage {
         &self,
         counters: &mut Vec<Counter>,
         reservation_id: &ReservationId,
-        amount: u64,
+        check_amount: u64,
+        hold_amount: u64,
         ttl: Duration,
         load_counters: bool,
     ) -> Result<Authorization, StorageErr> {
+        debug_assert!(hold_amount <= check_amount);
+
         let mut con = self.conn_manager.clone();
 
         let now_ms = SystemTime::now()
@@ -244,7 +247,8 @@ impl AsyncCounterStorage for AsyncRedisStorage {
             invocation.arg(counter.max_value());
         }
         invocation
-            .arg(amount)
+            .arg(check_amount)
+            .arg(hold_amount)
             .arg(ttl.as_millis() as i64)
             .arg(reservation_id.as_str())
             .arg(now_ms);
@@ -260,7 +264,7 @@ impl AsyncCounterStorage for AsyncRedisStorage {
             let value = raw[i * 3].max(0) as u64;
             let outstanding = raw[i * 3 + 1].max(0) as u64;
             let window_ttl_ms = raw[i * 3 + 2].max(0) as u64;
-            let total = value + outstanding + amount;
+            let total = value + outstanding + check_amount;
 
             if load_counters {
                 let remaining = counter.max_value().checked_sub(total);
@@ -348,12 +352,69 @@ impl AsyncRedisStorage {
         script.prepare_invoke().load_async(&mut con).await?;
         Ok(())
     }
+
+    // Used by `CachedRedisStorage::reserve` to prime its local cache on a miss with the real
+    // value/ttl, the same way `check_and_update`'s own cache-miss path eventually reconciles
+    // via `apply_remote_delta` - without this, a counter only ever touched through
+    // Reserve/Commit would never get a cache entry at all, and `reserve` would always see it
+    // as empty regardless of what's actually been committed to Redis.
+    pub(super) async fn values_and_window_ttls(
+        &self,
+        counters: &[Counter],
+    ) -> Result<Vec<(u64, Duration)>, StorageErr> {
+        let mut con = self.conn_manager.clone();
+
+        let script = redis::Script::new(VALUES_AND_TTLS);
+        let mut invocation = script.prepare_invoke();
+        for counter in counters {
+            invocation.key(key_for_counter(counter));
+        }
+
+        let raw: Vec<Option<i64>> = invocation
+            .invoke_async(&mut con)
+            .instrument(info_span!("datastore"))
+            .await?;
+
+        Ok(counters
+            .iter()
+            .zip(raw.chunks(2))
+            .map(|(counter, pair)| {
+                let value = pair[0].unwrap_or(0).max(0) as u64;
+                let ttl = match pair[1] {
+                    Some(ms) if ms >= 0 => Duration::from_millis(ms as u64),
+                    _ => counter.window(),
+                };
+                (value, ttl)
+            })
+            .collect())
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::counter::Counter;
+    use crate::limit::{Context, Expression, Limit};
+    use crate::reservation::ReservationId;
+    use crate::storage::keys::key_for_reservations;
     use crate::storage::redis::AsyncRedisStorage;
+    use crate::storage::{AsyncCounterStorage, Authorization};
     use redis::ErrorKind;
+    use serial_test::serial;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    fn counter(namespace: &str, max_value: u64) -> Counter {
+        let limit = Arc::new(Limit::new(
+            namespace,
+            max_value,
+            60,
+            vec![],
+            Vec::<Expression>::default(),
+        ));
+        Counter::new(limit, &Context::default())
+            .unwrap()
+            .expect("must have a counter")
+    }
 
     #[tokio::test]
     async fn errs_on_bad_url() {
@@ -369,5 +430,83 @@ mod tests {
         let error = result.err().unwrap();
         assert_eq!(error.kind(), ErrorKind::IoError);
         assert!(error.is_connection_refusal())
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn reserve_with_hold_amount_zero_creates_no_entry() {
+        let storage = AsyncRedisStorage::new("redis://127.0.0.1:6379")
+            .await
+            .unwrap();
+        storage.clear().await.unwrap();
+        let mut counters = vec![counter("async_reserve_hold_zero_test", 10)];
+        let reservation_id = ReservationId::new();
+
+        let auth = storage
+            .reserve(
+                &mut counters,
+                &reservation_id,
+                10,
+                0,
+                Duration::from_secs(60),
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(auth, Authorization::Ok));
+
+        let mut con = storage.conn_manager.clone();
+        let reservations_key = key_for_reservations(&counters[0]);
+        let exists: bool = redis::cmd("EXISTS")
+            .arg(&reservations_key)
+            .query_async(&mut con)
+            .await
+            .unwrap();
+        assert!(!exists, "no reservation hash should have been written");
+
+        let released = storage
+            .release_reservation(&counters, &reservation_id)
+            .await
+            .unwrap();
+        assert!(!released, "nothing should have been held to release");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn reserve_with_check_amount_zero_creates_no_reservation_entry() {
+        let storage = AsyncRedisStorage::new("redis://127.0.0.1:6379")
+            .await
+            .unwrap();
+        storage.clear().await.unwrap();
+        let mut counters = vec![counter("async_reserve_check_zero_test", 10)];
+        let reservation_id = ReservationId::new();
+
+        let auth = storage
+            .reserve(
+                &mut counters,
+                &reservation_id,
+                0,
+                0,
+                Duration::from_secs(60),
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(auth, Authorization::Ok));
+
+        let mut con = storage.conn_manager.clone();
+        let reservations_key = key_for_reservations(&counters[0]);
+        let exists: bool = redis::cmd("EXISTS")
+            .arg(&reservations_key)
+            .query_async(&mut con)
+            .await
+            .unwrap();
+        assert!(!exists, "no reservation hash should have been written");
+
+        let released = storage
+            .release_reservation(&counters, &reservation_id)
+            .await
+            .unwrap();
+        assert!(!released, "nothing should have been held to release");
     }
 }

--- a/limitador/src/storage/redis/redis_async.rs
+++ b/limitador/src/storage/redis/redis_async.rs
@@ -237,6 +237,7 @@ impl AsyncCounterStorage for AsyncRedisStorage {
         for counter in counters.iter() {
             invocation.key(key_for_counter(counter));
             invocation.key(key_for_reservations(counter));
+            invocation.key(key_for_counters_of_limit(counter.limit()));
         }
         for counter in counters.iter() {
             invocation.arg(counter.window().as_secs());

--- a/limitador/src/storage/redis/redis_async.rs
+++ b/limitador/src/storage/redis/redis_async.rs
@@ -4,9 +4,10 @@ use self::redis::aio::ConnectionManager;
 use self::redis::ConnectionInfo;
 use crate::counter::Counter;
 use crate::limit::Limit;
+use crate::reservation::ReservationId;
 use crate::storage::keys::*;
 use crate::storage::redis::is_limited;
-use crate::storage::redis::scripts::{SCRIPT_UPDATE_COUNTER, VALUES_AND_TTLS};
+use crate::storage::redis::scripts::{SCRIPT_RESERVE, SCRIPT_UPDATE_COUNTER, VALUES_AND_TTLS};
 use crate::storage::{AsyncCounterStorage, Authorization, StorageErr};
 use async_trait::async_trait;
 use redis::{AsyncCommands, ErrorKind, RedisError};
@@ -14,7 +15,7 @@ use std::collections::HashSet;
 use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::{info_span, Instrument};
 
 // Note: this implementation does not guarantee exact limits. Ensuring that we
@@ -214,6 +215,87 @@ impl AsyncCounterStorage for AsyncRedisStorage {
             .await?;
         Ok(())
     }
+
+    #[tracing::instrument(skip_all)]
+    async fn reserve(
+        &self,
+        counters: &mut Vec<Counter>,
+        reservation_id: &ReservationId,
+        amount: u64,
+        ttl: Duration,
+        load_counters: bool,
+    ) -> Result<Authorization, StorageErr> {
+        let mut con = self.conn_manager.clone();
+
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+
+        let script = redis::Script::new(SCRIPT_RESERVE);
+        let mut invocation = script.prepare_invoke();
+        for counter in counters.iter() {
+            invocation.key(key_for_counter(counter));
+            invocation.key(key_for_reservations(counter));
+        }
+        for counter in counters.iter() {
+            invocation.arg(counter.window().as_secs());
+            invocation.arg(counter.max_value());
+        }
+        invocation
+            .arg(amount)
+            .arg(ttl.as_millis() as i64)
+            .arg(reservation_id.as_str())
+            .arg(now_ms);
+
+        let raw: Vec<i64> = invocation
+            .invoke_async(&mut con)
+            .instrument(info_span!("datastore"))
+            .await?;
+        let admitted = raw.last().copied().unwrap_or(0) == 1;
+
+        let mut first_limited = None;
+        for (i, counter) in counters.iter_mut().enumerate() {
+            let value = raw[i * 3].max(0) as u64;
+            let outstanding = raw[i * 3 + 1].max(0) as u64;
+            let window_ttl_ms = raw[i * 3 + 2].max(0) as u64;
+            let total = value + outstanding + amount;
+
+            if load_counters {
+                let remaining = counter.max_value().checked_sub(total);
+                counter.set_remaining(remaining.unwrap_or_default());
+                counter.set_expires_in(Duration::from_millis(window_ttl_ms));
+            }
+            if first_limited.is_none() && total > counter.max_value() {
+                first_limited = Some(counter.limit().name().map(|n| n.to_owned()));
+            }
+        }
+
+        if admitted {
+            Ok(Authorization::Ok)
+        } else {
+            Ok(Authorization::Limited(first_limited.unwrap_or(None)))
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn release_reservation(
+        &self,
+        counters: &[Counter],
+        reservation_id: &ReservationId,
+    ) -> Result<bool, StorageErr> {
+        let mut con = self.conn_manager.clone();
+
+        let mut released = false;
+        for counter in counters {
+            let removed: i64 = con
+                .hdel(key_for_reservations(counter), reservation_id.as_str())
+                .instrument(info_span!("datastore"))
+                .await?;
+            released |= removed > 0;
+        }
+        Ok(released)
+    }
 }
 
 impl AsyncRedisStorage {
@@ -235,6 +317,7 @@ impl AsyncRedisStorage {
         let store = Self { conn_manager };
         store.load_script(SCRIPT_UPDATE_COUNTER).await?;
         store.load_script(VALUES_AND_TTLS).await?;
+        store.load_script(SCRIPT_RESERVE).await?;
         Ok(store)
     }
 

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -520,7 +520,7 @@ mod tests {
 
         let mut mock_client = MockRedisConnection::new(vec![MockCmd::new(
             redis::cmd("EVALSHA")
-                .arg("95a717e821d8fbdd667b5e4c6fede4c9cad16006")
+                .arg("4ea27f5b6faf30153f9e26e4d685d40435f3cc1d")
                 .arg("2")
                 .arg(key_for_counter(&counter))
                 .arg(key_for_counters_of_limit(counter.limit()))
@@ -579,7 +579,7 @@ mod tests {
 
         let mock_client = MockRedisConnection::new(vec![MockCmd::new(
             redis::cmd("EVALSHA")
-                .arg("95a717e821d8fbdd667b5e4c6fede4c9cad16006")
+                .arg("4ea27f5b6faf30153f9e26e4d685d40435f3cc1d")
                 .arg("2")
                 .arg(key_for_counter(&counter))
                 .arg(key_for_counters_of_limit(counter.limit()))
@@ -633,7 +633,7 @@ mod tests {
         assert!(error.is_timeout());
         let mock_client = MockRedisConnection::new(vec![MockCmd::new::<&mut Cmd, Value>(
             redis::cmd("EVALSHA")
-                .arg("95a717e821d8fbdd667b5e4c6fede4c9cad16006")
+                .arg("4ea27f5b6faf30153f9e26e4d685d40435f3cc1d")
                 .arg("2")
                 .arg(key_for_counter(&counter))
                 .arg(key_for_counters_of_limit(counter.limit()))

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -1,6 +1,8 @@
 use crate::counter::Counter;
 use crate::limit::Limit;
+use crate::reservation::ReservationId;
 use crate::storage::keys::*;
+use crate::storage::local_reservations::{LocalReservationRegistry, ReservationRequest};
 use crate::storage::redis::counters_cache::{
     CachedCounterValue, CountersCache, CountersCacheBuilder,
 };
@@ -43,6 +45,10 @@ use tracing::{error, info, info_span, warn, Instrument};
 pub struct CachedRedisStorage {
     cached_counters: Arc<CountersCache>,
     async_redis_storage: AsyncRedisStorage,
+    // Local-memory only, not shared across processes - see `LocalReservationRegistry`'s docs.
+    // A starting point, matching the accuracy trade-offs this backend already makes for
+    // counters themselves; not meant for production multi-replica deployments yet.
+    reservations: LocalReservationRegistry,
 }
 
 #[async_trait]
@@ -144,6 +150,49 @@ impl AsyncCounterStorage for CachedRedisStorage {
     async fn clear(&self) -> Result<(), StorageErr> {
         self.async_redis_storage.clear().await
     }
+
+    // Local-memory only (see `LocalReservationRegistry`'s docs): admission is checked against
+    // this instance's own cached view of each counter, the same accuracy trade-off
+    // `check_and_update` already makes for this backend.
+    #[tracing::instrument(skip_all)]
+    async fn reserve(
+        &self,
+        counters: &mut Vec<Counter>,
+        reservation_id: &ReservationId,
+        amount: u64,
+        ttl: Duration,
+        load_counters: bool,
+    ) -> Result<Authorization, StorageErr> {
+        let now = SystemTime::now();
+        let values_and_window_ttls: Vec<(u64, Duration)> = counters
+            .iter()
+            .map(|counter| match self.cached_counters.get(counter) {
+                Some(cached) => (cached.hits(counter), cached.ttl()),
+                None => (0, counter.window()),
+            })
+            .collect();
+
+        Ok(self.reservations.reserve(
+            counters,
+            &values_and_window_ttls,
+            ReservationRequest {
+                reservation_id,
+                amount,
+                ttl,
+                load_counters,
+                now,
+            },
+        ))
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn release_reservation(
+        &self,
+        counters: &[Counter],
+        reservation_id: &ReservationId,
+    ) -> Result<bool, StorageErr> {
+        Ok(self.reservations.release(counters, reservation_id))
+    }
 }
 
 impl CachedRedisStorage {
@@ -209,6 +258,7 @@ impl CachedRedisStorage {
         Ok(Self {
             cached_counters: counters_cache,
             async_redis_storage,
+            reservations: LocalReservationRegistry::new(),
         })
     }
 }

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -258,7 +258,7 @@ impl CachedRedisStorage {
         Ok(Self {
             cached_counters: counters_cache,
             async_redis_storage,
-            reservations: LocalReservationRegistry::new(),
+            reservations: LocalReservationRegistry::new(max_cached_counters as u64),
         })
     }
 }

--- a/limitador/src/storage/redis/redis_cached.rs
+++ b/limitador/src/storage/redis/redis_cached.rs
@@ -152,24 +152,54 @@ impl AsyncCounterStorage for CachedRedisStorage {
     }
 
     // Local-memory only (see `LocalReservationRegistry`'s docs): admission is checked against
-    // this instance's own cached view of each counter, the same accuracy trade-off
-    // `check_and_update` already makes for this backend.
+    // this instance's own cached view of each counter. Unlike `check_and_update`, a cache
+    // miss here can't just default to 0 - a counter only ever touched through Reserve/Commit
+    // (`commit_reservation`'s `update_counter` never populates this cache) would then never
+    // get a real entry at all, so `reserve` would always see it as empty regardless of what's
+    // actually been committed. Misses are fetched live from Redis instead, in one batched
+    // round trip.
     #[tracing::instrument(skip_all)]
     async fn reserve(
         &self,
         counters: &mut Vec<Counter>,
         reservation_id: &ReservationId,
-        amount: u64,
+        check_amount: u64,
+        hold_amount: u64,
         ttl: Duration,
         load_counters: bool,
     ) -> Result<Authorization, StorageErr> {
         let now = SystemTime::now();
-        let values_and_window_ttls: Vec<(u64, Duration)> = counters
+
+        let mut values_and_window_ttls: Vec<Option<(u64, Duration)>> = counters
             .iter()
-            .map(|counter| match self.cached_counters.get(counter) {
-                Some(cached) => (cached.hits(counter), cached.ttl()),
-                None => (0, counter.window()),
+            .map(|counter| {
+                self.cached_counters
+                    .get(counter)
+                    .map(|cached| (cached.hits(counter), cached.ttl()))
             })
+            .collect();
+
+        let missing: Vec<usize> = values_and_window_ttls
+            .iter()
+            .enumerate()
+            .filter_map(|(i, v)| v.is_none().then_some(i))
+            .collect();
+
+        if !missing.is_empty() {
+            let missing_counters: Vec<Counter> =
+                missing.iter().map(|&i| counters[i].clone()).collect();
+            let fetched = self
+                .async_redis_storage
+                .values_and_window_ttls(&missing_counters)
+                .await?;
+            for (i, value_ttl) in missing.into_iter().zip(fetched) {
+                values_and_window_ttls[i] = Some(value_ttl);
+            }
+        }
+
+        let values_and_window_ttls: Vec<(u64, Duration)> = values_and_window_ttls
+            .into_iter()
+            .map(|v| v.expect("every entry was either cached or just fetched"))
             .collect();
 
         Ok(self.reservations.reserve(
@@ -177,7 +207,8 @@ impl AsyncCounterStorage for CachedRedisStorage {
             &values_and_window_ttls,
             ReservationRequest {
                 reservation_id,
-                amount,
+                check_amount,
+                hold_amount,
                 ttl,
                 load_counters,
                 now,
@@ -446,21 +477,37 @@ async fn flush_batcher_and_update_counters<C: ConnectionLike>(
 #[cfg(test)]
 mod tests {
     use crate::counter::Counter;
-    use crate::limit::Limit;
+    use crate::limit::{Context, Expression, Limit};
+    use crate::reservation::ReservationId;
     use crate::storage::keys::{key_for_counter, key_for_counters_of_limit};
     use crate::storage::redis::counters_cache::{
         CachedCounterValue, CountersCache, CountersCacheBuilder,
     };
     use crate::storage::redis::redis_cached::{flush_batcher_and_update_counters, update_counters};
     use crate::storage::redis::CachedRedisStorage;
+    use crate::storage::{AsyncCounterStorage, Authorization};
     use redis::{Cmd, ErrorKind, RedisError, Value};
     use redis_test::{MockCmd, MockRedisConnection};
+    use serial_test::serial;
     use std::collections::HashMap;
     use std::io;
     use std::ops::Add;
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    fn counter(namespace: &str, max_value: u64) -> Counter {
+        let limit = Limit::new(
+            namespace,
+            max_value,
+            60,
+            vec![],
+            Vec::<Expression>::default(),
+        );
+        Counter::new(limit, &Context::default())
+            .unwrap()
+            .expect("must have a counter")
+    }
 
     #[tokio::test]
     async fn errs_on_bad_url() {
@@ -660,5 +707,34 @@ mod tests {
         let c = cached_counters.get(&counter).unwrap();
         assert_eq!(c.hits(&counter), 5);
         assert_eq!(c.pending_writes(), Ok(3));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn reserve_with_hold_amount_zero_creates_no_entry() {
+        let storage = CachedRedisStorage::new("redis://127.0.0.1:6379")
+            .await
+            .unwrap();
+        let mut counters = vec![counter("cached_reserve_hold_zero_test", 10)];
+        let reservation_id = ReservationId::new();
+
+        let auth = storage
+            .reserve(
+                &mut counters,
+                &reservation_id,
+                10,
+                0,
+                Duration::from_secs(60),
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(auth, Authorization::Ok));
+
+        let released = storage
+            .release_reservation(&counters, &reservation_id)
+            .await
+            .unwrap();
+        assert!(!released, "nothing should have been held to release");
     }
 }

--- a/limitador/src/storage/redis/redis_sync.rs
+++ b/limitador/src/storage/redis/redis_sync.rs
@@ -191,6 +191,7 @@ impl CounterStorage for RedisStorage {
         for counter in counters.iter() {
             invocation.key(key_for_counter(counter));
             invocation.key(key_for_reservations(counter));
+            invocation.key(key_for_counters_of_limit(counter.limit()));
         }
         for counter in counters.iter() {
             invocation.arg(counter.window().as_secs());

--- a/limitador/src/storage/redis/redis_sync.rs
+++ b/limitador/src/storage/redis/redis_sync.rs
@@ -175,10 +175,13 @@ impl CounterStorage for RedisStorage {
         &self,
         counters: &mut Vec<Counter>,
         reservation_id: &ReservationId,
-        amount: u64,
+        check_amount: u64,
+        hold_amount: u64,
         ttl: Duration,
         load_counters: bool,
     ) -> Result<Authorization, StorageErr> {
+        debug_assert!(hold_amount <= check_amount);
+
         let mut con = self.conn_pool.get()?;
 
         let now_ms = SystemTime::now()
@@ -198,7 +201,8 @@ impl CounterStorage for RedisStorage {
             invocation.arg(counter.max_value());
         }
         invocation
-            .arg(amount)
+            .arg(check_amount)
+            .arg(hold_amount)
             .arg(ttl.as_millis() as i64)
             .arg(reservation_id.as_str())
             .arg(now_ms);
@@ -211,7 +215,7 @@ impl CounterStorage for RedisStorage {
             let value = raw[i * 3].max(0) as u64;
             let outstanding = raw[i * 3 + 1].max(0) as u64;
             let window_ttl_ms = raw[i * 3 + 2].max(0) as u64;
-            let total = value + outstanding + amount;
+            let total = value + outstanding + check_amount;
 
             if load_counters {
                 let remaining = counter.max_value().checked_sub(total);
@@ -325,11 +329,25 @@ mod test {
     use crate::limit::{Context, Expression, Limit};
     use crate::reservation::ReservationId;
     use crate::storage::keys::key_for_counter;
+    use crate::storage::keys::key_for_reservations;
     use crate::storage::redis::RedisStorage;
     use crate::storage::{Authorization, CounterStorage};
     use serial_test::serial;
     use std::sync::Arc;
     use std::time::Duration;
+
+    fn counter(namespace: &str, max_value: u64) -> Counter {
+        let limit = Arc::new(Limit::new(
+            namespace,
+            max_value,
+            60,
+            vec![],
+            Vec::<Expression>::default(),
+        ));
+        Counter::new(limit, &Context::default())
+            .unwrap()
+            .expect("must have a counter")
+    }
 
     // Regression test for the bug fixed by adding `NX` to `SCRIPT_UPDATE_COUNTER`'s
     // `expire` call: `Reserve` pre-creates a counter's key at value 0 to start its window,
@@ -359,6 +377,7 @@ mod test {
                 &mut counters,
                 &reservation_id,
                 1,
+                1,
                 Duration::from_secs(60),
                 false,
             )
@@ -385,6 +404,74 @@ mod test {
             "the counter's real first update must not re-anchor the window Reserve already \
              started: ttl_after_reserve={ttl_after_reserve}ms, ttl_after_update={ttl_after_update}ms"
         );
+    }
+
+    #[test]
+    #[serial]
+    fn reserve_with_hold_amount_zero_creates_no_entry() {
+        let storage = RedisStorage::default();
+        storage.clear().unwrap();
+        let mut counters = vec![counter("reserve_hold_zero_test", 10)];
+        let reservation_id = ReservationId::new();
+
+        let auth = storage
+            .reserve(
+                &mut counters,
+                &reservation_id,
+                10,
+                0,
+                Duration::from_secs(60),
+                false,
+            )
+            .unwrap();
+        assert!(matches!(auth, Authorization::Ok));
+
+        let mut con = storage.conn_pool.get().unwrap();
+        let reservations_key = key_for_reservations(&counters[0]);
+        let exists: bool = redis::cmd("EXISTS")
+            .arg(&reservations_key)
+            .query(&mut *con)
+            .unwrap();
+        assert!(!exists, "no reservation hash should have been written");
+
+        let released = storage
+            .release_reservation(&counters, &reservation_id)
+            .unwrap();
+        assert!(!released, "nothing should have been held to release");
+    }
+
+    #[test]
+    #[serial]
+    fn reserve_with_check_amount_zero_creates_no_reservation_entry() {
+        let storage = RedisStorage::default();
+        storage.clear().unwrap();
+        let mut counters = vec![counter("reserve_check_zero_test", 10)];
+        let reservation_id = ReservationId::new();
+
+        let auth = storage
+            .reserve(
+                &mut counters,
+                &reservation_id,
+                0,
+                0,
+                Duration::from_secs(60),
+                false,
+            )
+            .unwrap();
+        assert!(matches!(auth, Authorization::Ok));
+
+        let mut con = storage.conn_pool.get().unwrap();
+        let reservations_key = key_for_reservations(&counters[0]);
+        let exists: bool = redis::cmd("EXISTS")
+            .arg(&reservations_key)
+            .query(&mut *con)
+            .unwrap();
+        assert!(!exists, "no reservation hash should have been written");
+
+        let released = storage
+            .release_reservation(&counters, &reservation_id)
+            .unwrap();
+        assert!(!released, "nothing should have been held to release");
     }
 
     #[test]

--- a/limitador/src/storage/redis/redis_sync.rs
+++ b/limitador/src/storage/redis/redis_sync.rs
@@ -3,15 +3,16 @@ extern crate redis;
 use self::redis::{Commands, ConnectionInfo, ConnectionLike, IntoConnectionInfo, RedisError};
 use crate::counter::Counter;
 use crate::limit::Limit;
+use crate::reservation::ReservationId;
 use crate::storage::keys::*;
 use crate::storage::redis::is_limited;
-use crate::storage::redis::scripts::{SCRIPT_UPDATE_COUNTER, VALUES_AND_TTLS};
+use crate::storage::redis::scripts::{SCRIPT_RESERVE, SCRIPT_UPDATE_COUNTER, VALUES_AND_TTLS};
 use crate::storage::{Authorization, CounterStorage, StorageErr};
 use r2d2::{ManageConnection, Pool};
 use std::collections::HashSet;
 use std::ops::Deref;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const DEFAULT_REDIS_URL: &str = "redis://127.0.0.1:6379";
 const MAX_REDIS_CONNS: u32 = 20; // TODO: make it configurable
@@ -167,6 +168,81 @@ impl CounterStorage for RedisStorage {
         let mut con = self.conn_pool.get()?;
         redis::cmd("FLUSHDB").exec(&mut *con)?;
         Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    fn reserve(
+        &self,
+        counters: &mut Vec<Counter>,
+        reservation_id: &ReservationId,
+        amount: u64,
+        ttl: Duration,
+        load_counters: bool,
+    ) -> Result<Authorization, StorageErr> {
+        let mut con = self.conn_pool.get()?;
+
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+
+        let script = redis::Script::new(SCRIPT_RESERVE);
+        let mut invocation = script.prepare_invoke();
+        for counter in counters.iter() {
+            invocation.key(key_for_counter(counter));
+            invocation.key(key_for_reservations(counter));
+        }
+        for counter in counters.iter() {
+            invocation.arg(counter.window().as_secs());
+            invocation.arg(counter.max_value());
+        }
+        invocation
+            .arg(amount)
+            .arg(ttl.as_millis() as i64)
+            .arg(reservation_id.as_str())
+            .arg(now_ms);
+
+        let raw: Vec<i64> = invocation.invoke(&mut *con)?;
+        let admitted = raw.last().copied().unwrap_or(0) == 1;
+
+        let mut first_limited = None;
+        for (i, counter) in counters.iter_mut().enumerate() {
+            let value = raw[i * 3].max(0) as u64;
+            let outstanding = raw[i * 3 + 1].max(0) as u64;
+            let window_ttl_ms = raw[i * 3 + 2].max(0) as u64;
+            let total = value + outstanding + amount;
+
+            if load_counters {
+                let remaining = counter.max_value().checked_sub(total);
+                counter.set_remaining(remaining.unwrap_or_default());
+                counter.set_expires_in(Duration::from_millis(window_ttl_ms));
+            }
+            if first_limited.is_none() && total > counter.max_value() {
+                first_limited = Some(counter.limit().name().map(|n| n.to_owned()));
+            }
+        }
+
+        if admitted {
+            Ok(Authorization::Ok)
+        } else {
+            Ok(Authorization::Limited(first_limited.unwrap_or(None)))
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    fn release_reservation(
+        &self,
+        counters: &[Counter],
+        reservation_id: &ReservationId,
+    ) -> Result<bool, StorageErr> {
+        let mut con = self.conn_pool.get()?;
+
+        let mut released = false;
+        for counter in counters {
+            let removed: i64 = con.hdel(key_for_reservations(counter), reservation_id.as_str())?;
+            released |= removed > 0;
+        }
+        Ok(released)
     }
 }
 

--- a/limitador/src/storage/redis/redis_sync.rs
+++ b/limitador/src/storage/redis/redis_sync.rs
@@ -321,7 +321,71 @@ impl From<::r2d2::Error> for StorageErr {
 
 #[cfg(test)]
 mod test {
+    use crate::counter::Counter;
+    use crate::limit::{Context, Expression, Limit};
+    use crate::reservation::ReservationId;
+    use crate::storage::keys::key_for_counter;
     use crate::storage::redis::RedisStorage;
+    use crate::storage::{Authorization, CounterStorage};
+    use serial_test::serial;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    // Regression test for the bug fixed by adding `NX` to `SCRIPT_UPDATE_COUNTER`'s
+    // `expire` call: `Reserve` pre-creates a counter's key at value 0 to start its window,
+    // so the first real `update_counter` after it (here, via `Commit`) must not treat that
+    // as "a fresh key" and re-anchor the TTL - the window `Reserve` already started must be
+    // preserved.
+    #[test]
+    #[serial]
+    fn reserve_then_update_counter_does_not_extend_the_ttl() {
+        let storage = RedisStorage::default();
+        storage.clear().unwrap();
+
+        let namespace = "reserve_then_update_ttl_test";
+        let limit = Arc::new(Limit::new(
+            namespace,
+            10,
+            60,
+            vec![],
+            Vec::<Expression>::default(),
+        ));
+        let ctx = Context::default();
+        let mut counters = vec![Counter::new(limit, &ctx).unwrap().unwrap()];
+
+        let reservation_id = ReservationId::new();
+        let auth = storage
+            .reserve(
+                &mut counters,
+                &reservation_id,
+                1,
+                Duration::from_secs(60),
+                false,
+            )
+            .unwrap();
+        assert!(matches!(auth, Authorization::Ok));
+
+        let key = key_for_counter(&counters[0]);
+        let mut con = storage.conn_pool.get().unwrap();
+        let ttl_after_reserve: i64 = redis::cmd("PTTL").arg(&key).query(&mut *con).unwrap();
+        assert!(
+            ttl_after_reserve > 0,
+            "expected Reserve to have already started the counter's window"
+        );
+
+        // A real, if brief, sleep so a "window reset" would show up as the TTL going back up
+        // towards the full 60s, not just measurement noise around an unchanged value.
+        std::thread::sleep(Duration::from_millis(50));
+
+        storage.update_counter(&counters[0], 1).unwrap();
+
+        let ttl_after_update: i64 = redis::cmd("PTTL").arg(&key).query(&mut *con).unwrap();
+        assert!(
+            ttl_after_update <= ttl_after_reserve,
+            "the counter's real first update must not re-anchor the window Reserve already \
+             started: ttl_after_reserve={ttl_after_reserve}ms, ttl_after_update={ttl_after_update}ms"
+        );
+    }
 
     #[test]
     fn errs_on_bad_url() {

--- a/limitador/src/storage/redis/scripts.rs
+++ b/limitador/src/storage/redis/scripts.rs
@@ -11,10 +11,14 @@
 // KEYS[2]: key that contains the counters that belong to the limit
 // ARGV[1]: counter TTL
 // ARGV[2]: delta
+//
+// `expire ... NX` (Redis >= 7.0) skips (re)setting the TTL if one is already running -
+// needed because `SCRIPT_RESERVE` can pre-create a counter key at 0 with a live TTL, and
+// `c == delta` alone can't tell that apart from a genuinely brand new key.
 pub const SCRIPT_UPDATE_COUNTER: &str = "
     local c = redis.call('incrby', KEYS[1], ARGV[2])
     if c == tonumber(ARGV[2]) then
-      redis.call('expire', KEYS[1], ARGV[1])
+      redis.call('expire', KEYS[1], ARGV[1], 'NX')
       redis.call('sadd', KEYS[2], KEYS[1])
     end
     return c";
@@ -25,6 +29,8 @@ pub const SCRIPT_UPDATE_COUNTER: &str = "
 // ARGV[i+1]: Deltas
 // This function returns a list with the values and TTLs for the updated counter_keys,
 // the first position the counter value and the second the TTL
+//
+// See `SCRIPT_UPDATE_COUNTER`'s comment on the `NX` flag.
 pub const BATCH_UPDATE_COUNTERS: &str = "
     local res = {}
     for i = 1, #KEYS, 2 do
@@ -36,7 +42,7 @@ pub const BATCH_UPDATE_COUNTERS: &str = "
         local c = redis.call('incrby', counter_key, delta)
         table.insert(res, c)
         if c == tonumber(delta) then
-            redis.call('expire', counter_key, ttl)
+            redis.call('expire', counter_key, ttl, 'NX')
             redis.call('sadd', limit_key, counter_key)
         end
         table.insert(res, redis.call('pexpiretime', counter_key))

--- a/limitador/src/storage/redis/scripts.rs
+++ b/limitador/src/storage/redis/scripts.rs
@@ -63,10 +63,11 @@ pub const VALUES_AND_TTLS: &str = "
     return res
 ";
 
-// Atomically checks and, if every counter admits it, holds `amount` of estimated
-// capacity against all of them. All counters are admitted, or none are: nothing is
-// written unless every counter would stay within its limit once outstanding, live
-// reservations are accounted for.
+// Atomically checks `check_amount` and, if every counter admits it, holds `hold_amount`
+// of estimated capacity against all of them (`hold_amount` may be less than
+// `check_amount`, e.g. clamped by policy). All counters are admitted, or none are:
+// nothing is written unless every counter would stay within its limit once outstanding,
+// live reservations and `check_amount` are accounted for.
 //
 // KEYS come in triplets: [counter_key, reservation_key, limit_key, ...]. `limit_key` is
 // the same per-limit set `SCRIPT_UPDATE_COUNTER` maintains (the one `get_counters`/the
@@ -74,23 +75,25 @@ pub const VALUES_AND_TTLS: &str = "
 // here too, so a counter touched only by Reserve is still visible, exactly as if it had
 // been touched by Report/CheckRateLimit.
 // ARGV holds one (window_seconds, max_value) pair per counter, in the same order as
-// KEYS, followed by four trailing scalars:
+// KEYS, followed by five trailing scalars:
 //   ARGV[2i-1] = window (seconds) for counter i, used to lazily start its window if
 //                the counter key doesn't exist yet
 //   ARGV[2i]   = max_value for counter i
-//   ARGV[2n+1] = amount requested
-//   ARGV[2n+2] = reservation ttl (ms), already clamped by the caller
-//   ARGV[2n+3] = reservation id
-//   ARGV[2n+4] = now (ms)
+//   ARGV[2n+1] = check_amount, tested against each counter's remaining capacity
+//   ARGV[2n+2] = hold_amount, written if admitted
+//   ARGV[2n+3] = reservation ttl (ms), already clamped by the caller
+//   ARGV[2n+4] = reservation id
+//   ARGV[2n+5] = now (ms)
 //
 // Returns a flat list, three values per counter - [value, outstanding, window_ttl_ms] -
 // followed by a trailing 1 (admitted) or 0 (limited).
 pub const SCRIPT_RESERVE: &str = "
     local n = #KEYS / 3
-    local amount = tonumber(ARGV[2 * n + 1])
-    local ttl_ms = tonumber(ARGV[2 * n + 2])
-    local reservation_id = ARGV[2 * n + 3]
-    local now_ms = tonumber(ARGV[2 * n + 4])
+    local check_amount = tonumber(ARGV[2 * n + 1])
+    local hold_amount = tonumber(ARGV[2 * n + 2])
+    local ttl_ms = tonumber(ARGV[2 * n + 3])
+    local reservation_id = ARGV[2 * n + 4]
+    local now_ms = tonumber(ARGV[2 * n + 5])
 
     local values = {}
     local outstanding = {}
@@ -133,19 +136,19 @@ pub const SCRIPT_RESERVE: &str = "
         outstanding[i] = held
         window_ttls[i] = window_ttl_ms
 
-        if value + held + amount > max_value then
+        if value + held + check_amount > max_value then
             admitted = false
         end
     end
 
-    if admitted then
+    if admitted and hold_amount > 0 then
         for i = 1, n do
             local reservation_key = KEYS[3 * i - 1]
             local expires_at_ms = now_ms + ttl_ms
             if expires_at_ms > now_ms + window_ttls[i] then
                 expires_at_ms = now_ms + window_ttls[i]
             end
-            redis.call('hset', reservation_key, reservation_id, amount .. ':' .. expires_at_ms)
+            redis.call('hset', reservation_key, reservation_id, hold_amount .. ':' .. expires_at_ms)
             redis.call('pexpire', reservation_key, window_ttls[i])
         end
     end

--- a/limitador/src/storage/redis/scripts.rs
+++ b/limitador/src/storage/redis/scripts.rs
@@ -62,25 +62,29 @@ pub const VALUES_AND_TTLS: &str = "
 // written unless every counter would stay within its limit once outstanding, live
 // reservations are accounted for.
 //
-// KEYS come in pairs: [counter_key, reservation_key, counter_key, reservation_key, ...]
+// KEYS come in triplets: [counter_key, reservation_key, limit_key, ...]. `limit_key` is
+// the same per-limit set `SCRIPT_UPDATE_COUNTER` maintains (the one `get_counters`/the
+// `/counters` endpoint enumerate) - a freshly-initialized counter is registered into it
+// here too, so a counter touched only by Reserve is still visible, exactly as if it had
+// been touched by Report/CheckRateLimit.
 // ARGV holds one (window_seconds, max_value) pair per counter, in the same order as
 // KEYS, followed by four trailing scalars:
 //   ARGV[2i-1] = window (seconds) for counter i, used to lazily start its window if
 //                the counter key doesn't exist yet
 //   ARGV[2i]   = max_value for counter i
-//   ARGV[#KEYS+1] = amount requested
-//   ARGV[#KEYS+2] = reservation ttl (ms), already clamped by the caller
-//   ARGV[#KEYS+3] = reservation id
-//   ARGV[#KEYS+4] = now (ms)
+//   ARGV[2n+1] = amount requested
+//   ARGV[2n+2] = reservation ttl (ms), already clamped by the caller
+//   ARGV[2n+3] = reservation id
+//   ARGV[2n+4] = now (ms)
 //
 // Returns a flat list, three values per counter - [value, outstanding, window_ttl_ms] -
 // followed by a trailing 1 (admitted) or 0 (limited).
 pub const SCRIPT_RESERVE: &str = "
-    local n = #KEYS / 2
-    local amount = tonumber(ARGV[#KEYS + 1])
-    local ttl_ms = tonumber(ARGV[#KEYS + 2])
-    local reservation_id = ARGV[#KEYS + 3]
-    local now_ms = tonumber(ARGV[#KEYS + 4])
+    local n = #KEYS / 3
+    local amount = tonumber(ARGV[2 * n + 1])
+    local ttl_ms = tonumber(ARGV[2 * n + 2])
+    local reservation_id = ARGV[2 * n + 3]
+    local now_ms = tonumber(ARGV[2 * n + 4])
 
     local values = {}
     local outstanding = {}
@@ -88,13 +92,15 @@ pub const SCRIPT_RESERVE: &str = "
     local admitted = true
 
     for i = 1, n do
-        local counter_key = KEYS[2 * i - 1]
-        local reservation_key = KEYS[2 * i]
+        local counter_key = KEYS[3 * i - 2]
+        local reservation_key = KEYS[3 * i - 1]
+        local limit_key = KEYS[3 * i]
         local window_secs = tonumber(ARGV[2 * i - 1])
         local max_value = tonumber(ARGV[2 * i])
 
         if redis.call('exists', counter_key) == 0 then
             redis.call('set', counter_key, 0, 'EX', window_secs)
+            redis.call('sadd', limit_key, counter_key)
         end
         local value = tonumber(redis.call('get', counter_key)) or 0
         local window_ttl_ms = redis.call('pttl', counter_key)
@@ -128,7 +134,7 @@ pub const SCRIPT_RESERVE: &str = "
 
     if admitted then
         for i = 1, n do
-            local reservation_key = KEYS[2 * i]
+            local reservation_key = KEYS[3 * i - 1]
             local expires_at_ms = now_ms + ttl_ms
             if expires_at_ms > now_ms + window_ttls[i] then
                 expires_at_ms = now_ms + window_ttls[i]

--- a/limitador/src/storage/redis/scripts.rs
+++ b/limitador/src/storage/redis/scripts.rs
@@ -56,3 +56,94 @@ pub const VALUES_AND_TTLS: &str = "
     end
     return res
 ";
+
+// Atomically checks and, if every counter admits it, holds `amount` of estimated
+// capacity against all of them. All counters are admitted, or none are: nothing is
+// written unless every counter would stay within its limit once outstanding, live
+// reservations are accounted for.
+//
+// KEYS come in pairs: [counter_key, reservation_key, counter_key, reservation_key, ...]
+// ARGV holds one (window_seconds, max_value) pair per counter, in the same order as
+// KEYS, followed by four trailing scalars:
+//   ARGV[2i-1] = window (seconds) for counter i, used to lazily start its window if
+//                the counter key doesn't exist yet
+//   ARGV[2i]   = max_value for counter i
+//   ARGV[#KEYS+1] = amount requested
+//   ARGV[#KEYS+2] = reservation ttl (ms), already clamped by the caller
+//   ARGV[#KEYS+3] = reservation id
+//   ARGV[#KEYS+4] = now (ms)
+//
+// Returns a flat list, three values per counter - [value, outstanding, window_ttl_ms] -
+// followed by a trailing 1 (admitted) or 0 (limited).
+pub const SCRIPT_RESERVE: &str = "
+    local n = #KEYS / 2
+    local amount = tonumber(ARGV[#KEYS + 1])
+    local ttl_ms = tonumber(ARGV[#KEYS + 2])
+    local reservation_id = ARGV[#KEYS + 3]
+    local now_ms = tonumber(ARGV[#KEYS + 4])
+
+    local values = {}
+    local outstanding = {}
+    local window_ttls = {}
+    local admitted = true
+
+    for i = 1, n do
+        local counter_key = KEYS[2 * i - 1]
+        local reservation_key = KEYS[2 * i]
+        local window_secs = tonumber(ARGV[2 * i - 1])
+        local max_value = tonumber(ARGV[2 * i])
+
+        if redis.call('exists', counter_key) == 0 then
+            redis.call('set', counter_key, 0, 'EX', window_secs)
+        end
+        local value = tonumber(redis.call('get', counter_key)) or 0
+        local window_ttl_ms = redis.call('pttl', counter_key)
+        if window_ttl_ms < 0 then
+            window_ttl_ms = window_secs * 1000
+        end
+
+        local held = 0
+        local fields = redis.call('hgetall', reservation_key)
+        for j = 1, #fields, 2 do
+            local field = fields[j]
+            local packed = fields[j + 1]
+            local sep = string.find(packed, ':')
+            local field_amount = tonumber(string.sub(packed, 1, sep - 1))
+            local field_expires_at = tonumber(string.sub(packed, sep + 1))
+            if field_expires_at > now_ms then
+                held = held + field_amount
+            else
+                redis.call('hdel', reservation_key, field)
+            end
+        end
+
+        values[i] = value
+        outstanding[i] = held
+        window_ttls[i] = window_ttl_ms
+
+        if value + held + amount > max_value then
+            admitted = false
+        end
+    end
+
+    if admitted then
+        for i = 1, n do
+            local reservation_key = KEYS[2 * i]
+            local expires_at_ms = now_ms + ttl_ms
+            if expires_at_ms > now_ms + window_ttls[i] then
+                expires_at_ms = now_ms + window_ttls[i]
+            end
+            redis.call('hset', reservation_key, reservation_id, amount .. ':' .. expires_at_ms)
+            redis.call('pexpire', reservation_key, window_ttls[i])
+        end
+    end
+
+    local res = {}
+    for i = 1, n do
+        table.insert(res, values[i])
+        table.insert(res, outstanding[i])
+        table.insert(res, window_ttls[i])
+    end
+    table.insert(res, admitted and 1 or 0)
+    return res
+";

--- a/limitador/tests/helpers/tests_limiter.rs
+++ b/limitador/tests/helpers/tests_limiter.rs
@@ -1,8 +1,10 @@
 use limitador::counter::Counter;
 use limitador::errors::LimitadorError;
 use limitador::limit::{Context, Limit, Namespace};
+use limitador::reservation::{CommitResult, ReservationId, ReserveResult};
 use limitador::{AsyncRateLimiter, CheckResult, RateLimiter};
 use std::collections::HashSet;
+use std::time::Duration;
 
 // This exposes a struct that wraps both implementations of the rate limiter,
 // the blocking and the async one. This allows us to avoid duplications in the
@@ -132,6 +134,45 @@ impl TestsLimiter {
         match &self.limiter_impl {
             LimiterImpl::Blocking(limiter) => limiter.configure_with(limits),
             LimiterImpl::Async(limiter) => limiter.configure_with(limits).await,
+        }
+    }
+
+    pub async fn reserve(
+        &self,
+        namespace: &str,
+        ctx: &Context<'_>,
+        amount: u64,
+        ttl: Duration,
+        load_counters: bool,
+    ) -> Result<ReserveResult, LimitadorError> {
+        match &self.limiter_impl {
+            LimiterImpl::Blocking(limiter) => {
+                limiter.reserve(&namespace.into(), ctx, amount, ttl, load_counters)
+            }
+            LimiterImpl::Async(limiter) => {
+                limiter
+                    .reserve(&namespace.into(), ctx, amount, ttl, load_counters)
+                    .await
+            }
+        }
+    }
+
+    pub async fn commit_reservation(
+        &self,
+        namespace: &str,
+        ctx: &Context<'_>,
+        reservation_id: &ReservationId,
+        actual_amount: u64,
+    ) -> Result<CommitResult, LimitadorError> {
+        match &self.limiter_impl {
+            LimiterImpl::Blocking(limiter) => {
+                limiter.commit_reservation(&namespace.into(), ctx, reservation_id, actual_amount)
+            }
+            LimiterImpl::Async(limiter) => {
+                limiter
+                    .commit_reservation(&namespace.into(), ctx, reservation_id, actual_amount)
+                    .await
+            }
         }
     }
 }

--- a/limitador/tests/helpers/tests_limiter.rs
+++ b/limitador/tests/helpers/tests_limiter.rs
@@ -142,7 +142,7 @@ impl TestsLimiter {
         namespace: &str,
         ctx: &Context<'_>,
         amount: u64,
-        ttl: Duration,
+        ttl: Option<Duration>,
         load_counters: bool,
     ) -> Result<ReserveResult, LimitadorError> {
         match &self.limiter_impl {

--- a/limitador/tests/helpers/tests_limiter.rs
+++ b/limitador/tests/helpers/tests_limiter.rs
@@ -161,7 +161,7 @@ impl TestsLimiter {
         &self,
         namespace: &str,
         ctx: &Context<'_>,
-        reservation_id: &ReservationId,
+        reservation_id: Option<&ReservationId>,
         actual_amount: u64,
     ) -> Result<CommitResult, LimitadorError> {
         match &self.limiter_impl {

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -295,7 +295,10 @@ mod test {
     // Not run against `disk_storage`, unlike the other reservation tests above:
     // `RocksDbStorage::insert_or_update` silently no-ops a delta that alone exceeds
     // `max_value`, so `update_counters`'s forced overshoot below never actually gets
-    // written - a separate, pre-existing bug tracked for its own fix.
+    // written - see https://github.com/Kuadrant/limitador/issues/516. Once that's fixed,
+    // replace this whole manual block with a single
+    // `test_with_reservation_capable_storage_impls!(reserve_denies_amount_zero_when_already_over_limit);`
+    // like the other reservation tests above.
     #[tokio::test]
     async fn reserve_denies_amount_zero_when_already_over_limit_in_memory_storage() {
         let rate_limiter = RateLimiter::new_with_storage(Box::<InMemoryStorage>::default());

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -1364,7 +1364,7 @@ mod test {
         let ctx = Context::default();
 
         let first = rate_limiter
-            .reserve(namespace, &ctx, 6, Duration::from_secs(30), false)
+            .reserve(namespace, &ctx, 6, Some(Duration::from_secs(30)), false)
             .await
             .unwrap();
         assert!(!first.limited);
@@ -1372,7 +1372,7 @@ mod test {
 
         // value(0) + outstanding(6) + 6 = 12 > 10: rejected
         let second = rate_limiter
-            .reserve(namespace, &ctx, 6, Duration::from_secs(30), false)
+            .reserve(namespace, &ctx, 6, Some(Duration::from_secs(30)), false)
             .await
             .unwrap();
         assert!(second.limited);
@@ -1380,7 +1380,7 @@ mod test {
 
         // value(0) + outstanding(6) + 4 = 10 <= 10: admitted
         let third = rate_limiter
-            .reserve(namespace, &ctx, 4, Duration::from_secs(30), false)
+            .reserve(namespace, &ctx, 4, Some(Duration::from_secs(30)), false)
             .await
             .unwrap();
         assert!(!third.limited);
@@ -1396,14 +1396,14 @@ mod test {
         let ctx = Context::default();
 
         let reserved = rate_limiter
-            .reserve(namespace, &ctx, 6, Duration::from_secs(30), false)
+            .reserve(namespace, &ctx, 6, Some(Duration::from_secs(30)), false)
             .await
             .unwrap();
         let reservation_id = reserved.reservation_id.expect("should be admitted");
 
         // Still held: 0 + outstanding(6) + 6 = 12 > 10
         let blocked = rate_limiter
-            .reserve(namespace, &ctx, 6, Duration::from_secs(30), false)
+            .reserve(namespace, &ctx, 6, Some(Duration::from_secs(30)), false)
             .await
             .unwrap();
         assert!(blocked.limited);
@@ -1424,7 +1424,7 @@ mod test {
 
         // Counter is now at 4 (2 + 2) with no outstanding reservations: 4 + 6 = 10 <= 10
         let after = rate_limiter
-            .reserve(namespace, &ctx, 6, Duration::from_secs(30), false)
+            .reserve(namespace, &ctx, 6, Some(Duration::from_secs(30)), false)
             .await
             .unwrap();
         assert!(!after.limited);
@@ -1436,7 +1436,7 @@ mod test {
                 "empty",
                 &Context::default(),
                 5,
-                Duration::from_secs(10),
+                Some(Duration::from_secs(10)),
                 false,
             )
             .await
@@ -1455,14 +1455,14 @@ mod test {
         // A zero ttl means this reservation is already expired by the time we look at it
         // again.
         let first = rate_limiter
-            .reserve(namespace, &ctx, 8, Duration::ZERO, false)
+            .reserve(namespace, &ctx, 8, Some(Duration::ZERO), false)
             .await
             .unwrap();
         assert!(!first.limited);
 
         // The first reservation is already expired, so another 8 fits again: 0 + 0 + 8 <= 10
         let second = rate_limiter
-            .reserve(namespace, &ctx, 8, Duration::from_secs(30), false)
+            .reserve(namespace, &ctx, 8, Some(Duration::from_secs(30)), false)
             .await
             .unwrap();
         assert!(!second.limited);
@@ -1508,7 +1508,7 @@ mod test {
                 s.spawn(move || {
                     let ctx = Context::default();
                     let res = rl
-                        .reserve(&ns, &ctx, AMOUNT, Duration::from_secs(30), false)
+                        .reserve(&ns, &ctx, AMOUNT, Some(Duration::from_secs(30)), false)
                         .unwrap();
                     if !res.limited {
                         admitted_count.fetch_add(1, Ordering::SeqCst);
@@ -1559,7 +1559,7 @@ mod test {
             handles.push(tokio::spawn(async move {
                 let ctx = Context::default();
                 let res = rl
-                    .reserve(&ns, &ctx, AMOUNT, Duration::from_secs(30), false)
+                    .reserve(&ns, &ctx, AMOUNT, Some(Duration::from_secs(30)), false)
                     .await
                     .unwrap();
                 if !res.limited {

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -282,6 +282,75 @@ mod test {
     );
     test_with_reservation_capable_storage_impls!(reserve_without_matching_limits_is_a_noop);
     test_with_reservation_capable_storage_impls!(expired_reservations_do_not_count_as_outstanding);
+    test_with_reservation_capable_storage_impls!(
+        reserve_denies_when_amount_alone_exceeds_max_value
+    );
+    test_with_reservation_capable_storage_impls!(reserve_admits_when_amount_fits);
+    test_with_reservation_capable_storage_impls!(
+        reserve_with_amount_zero_creates_no_reservation_entry
+    );
+    test_with_reservation_capable_storage_impls!(
+        reserve_then_commit_then_reserve_reflects_committed_usage
+    );
+    // Not run against `disk_storage`, unlike the other reservation tests above:
+    // `RocksDbStorage::insert_or_update` silently no-ops a delta that alone exceeds
+    // `max_value`, so `update_counters`'s forced overshoot below never actually gets
+    // written - a separate, pre-existing bug tracked for its own fix.
+    #[tokio::test]
+    async fn reserve_denies_amount_zero_when_already_over_limit_in_memory_storage() {
+        let rate_limiter = RateLimiter::new_with_storage(Box::<InMemoryStorage>::default());
+        reserve_denies_amount_zero_when_already_over_limit(
+            &mut TestsLimiter::new_from_blocking_impl(rate_limiter),
+        )
+        .await;
+    }
+
+    #[cfg(feature = "redis_storage")]
+    #[tokio::test]
+    #[serial]
+    async fn reserve_denies_amount_zero_when_already_over_limit_with_sync_redis() {
+        let storage = RedisStorage::default();
+        storage.clear().unwrap();
+        let rate_limiter = RateLimiter::new_with_storage(Box::new(storage));
+        reserve_denies_amount_zero_when_already_over_limit(
+            &mut TestsLimiter::new_from_blocking_impl(rate_limiter),
+        )
+        .await;
+    }
+
+    #[cfg(feature = "redis_storage")]
+    #[tokio::test]
+    #[serial]
+    async fn reserve_denies_amount_zero_when_already_over_limit_with_async_redis() {
+        let storage = AsyncRedisStorage::new("redis://127.0.0.1:6379")
+            .await
+            .expect("We need a Redis running locally");
+        storage.clear().await.unwrap();
+        let rate_limiter = AsyncRateLimiter::new_with_storage(Box::new(storage));
+        reserve_denies_amount_zero_when_already_over_limit(&mut TestsLimiter::new_from_async_impl(
+            rate_limiter,
+        ))
+        .await;
+    }
+
+    #[cfg(feature = "redis_storage")]
+    #[tokio::test]
+    #[serial]
+    async fn reserve_denies_amount_zero_when_already_over_limit_with_async_redis_and_local_cache() {
+        let storage_builder = CachedRedisStorageBuilder::new("redis://127.0.0.1:6379")
+            .flushing_period(Duration::from_millis(2))
+            .max_cached_counters(10000);
+        let storage = storage_builder
+            .build()
+            .await
+            .expect("We need a Redis running locally");
+        storage.clear().await.unwrap();
+        let rate_limiter = AsyncRateLimiter::new_with_storage(Box::new(storage));
+        reserve_denies_amount_zero_when_already_over_limit(&mut TestsLimiter::new_from_async_impl(
+            rate_limiter,
+        ))
+        .await;
+    }
 
     test_with_distributed_storage_impls!(distributed_rate_limited);
 
@@ -1430,6 +1499,41 @@ mod test {
         assert!(!after.limited);
     }
 
+    // The main Reserve/Commit workflow: real usage committed after a reservation must be
+    // visible to later reservations, not just to other reservations' outstanding accounting.
+    // A backend that reads a stale/empty view of the counter's committed value (rather than
+    // outstanding reservations) would incorrectly admit the final reserve below.
+    async fn reserve_then_commit_then_reserve_reflects_committed_usage(
+        rate_limiter: &mut TestsLimiter,
+    ) {
+        let namespace = "reserve_commit_reserve";
+        let limit = Limit::new(namespace, 10, 60, vec![], Vec::<Expression>::default());
+        rate_limiter.add_limit(&limit).await;
+
+        let ctx = Context::default();
+
+        // Reserve 4, but real usage turns out to be higher than the estimate.
+        let reserved = rate_limiter
+            .reserve(namespace, &ctx, 4, Some(Duration::from_secs(30)), false)
+            .await
+            .unwrap();
+        assert!(!reserved.limited);
+        let reservation_id = reserved.reservation_id.expect("should be admitted");
+
+        let commit = rate_limiter
+            .commit_reservation(namespace, &ctx, &reservation_id, 9)
+            .await
+            .unwrap();
+        assert!(commit.reservation_released);
+
+        // Counter is now at 9 with no outstanding reservations: 9 + 5 = 14 > 10, denied.
+        let after = rate_limiter
+            .reserve(namespace, &ctx, 5, Some(Duration::from_secs(30)), false)
+            .await
+            .unwrap();
+        assert!(after.limited);
+    }
+
     async fn reserve_without_matching_limits_is_a_noop(rate_limiter: &mut TestsLimiter) {
         let result = rate_limiter
             .reserve(
@@ -1466,6 +1570,85 @@ mod test {
             .await
             .unwrap();
         assert!(!second.limited);
+    }
+
+    async fn reserve_denies_when_amount_alone_exceeds_max_value(rate_limiter: &mut TestsLimiter) {
+        // Admission checks the raw requested amount - a request that could never fit in the
+        // counter at all is denied outright, regardless of `max_fraction` (default here).
+        let namespace = "over_max_value";
+        let limit = Limit::new(namespace, 10, 60, vec![], Vec::<Expression>::default());
+        rate_limiter.add_limit(&limit).await;
+
+        let ctx = Context::default();
+
+        let result = rate_limiter
+            .reserve(namespace, &ctx, 1000, Some(Duration::from_secs(30)), false)
+            .await
+            .unwrap();
+        assert!(result.limited);
+        assert!(result.reservation_id.is_none());
+    }
+
+    async fn reserve_admits_when_amount_fits(rate_limiter: &mut TestsLimiter) {
+        let namespace = "amount_fits";
+        let limit = Limit::new(namespace, 10, 60, vec![], Vec::<Expression>::default());
+        rate_limiter.add_limit(&limit).await;
+
+        let ctx = Context::default();
+
+        let result = rate_limiter
+            .reserve(namespace, &ctx, 10, Some(Duration::from_secs(30)), false)
+            .await
+            .unwrap();
+        assert!(!result.limited);
+        assert!(result.reservation_id.is_some());
+    }
+
+    async fn reserve_with_amount_zero_creates_no_reservation_entry(
+        rate_limiter: &mut TestsLimiter,
+    ) {
+        let namespace = "amount_zero";
+        let limit = Limit::new(namespace, 10, 60, vec![], Vec::<Expression>::default());
+        rate_limiter.add_limit(&limit).await;
+
+        let ctx = Context::default();
+
+        let result = rate_limiter
+            .reserve(namespace, &ctx, 0, Some(Duration::from_secs(30)), false)
+            .await
+            .unwrap();
+        assert!(!result.limited);
+        let reservation_id = result.reservation_id.expect("should be admitted");
+
+        // Nothing was actually held, so there's nothing to release.
+        let commit = rate_limiter
+            .commit_reservation(namespace, &ctx, &reservation_id, 0)
+            .await
+            .unwrap();
+        assert!(!commit.reservation_released);
+    }
+
+    async fn reserve_denies_amount_zero_when_already_over_limit(rate_limiter: &mut TestsLimiter) {
+        // Checking 0 must still reflect the counter's real state, matching how
+        // `is_within_limits`/`check_and_update` never special-case a zero delta: a counter
+        // already over its limit (e.g. from a commit that overshot it) stays "limited" even
+        // for a reservation that asks for nothing extra.
+        let namespace = "amount_zero_over_limit";
+        let limit = Limit::new(namespace, 10, 60, vec![], Vec::<Expression>::default());
+        rate_limiter.add_limit(&limit).await;
+
+        let ctx = Context::default();
+
+        rate_limiter
+            .update_counters(namespace, &ctx, 15)
+            .await
+            .unwrap();
+
+        let result = rate_limiter
+            .reserve(namespace, &ctx, 0, Some(Duration::from_secs(30)), false)
+            .await
+            .unwrap();
+        assert!(result.limited);
     }
 
     // RFC 0021's motivating scenario against the shared, Redis-backed path: N concurrent

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -73,6 +73,73 @@ macro_rules! test_with_all_storage_impls {
     };
 }
 
+// Backends that have implemented `CounterStorage`/`AsyncCounterStorage`'s
+// `reserve`/`release_reservation` so far - either shared (in-memory, both Redis storages) or,
+// for disk/cached-Redis, a local-memory-only starting point (see `LocalReservationRegistry`).
+// Distributed storage still relies on the traits' default (unsupported) impl and is
+// deliberately left out, rather than run and fail - it's also not compiled by default
+// (`distributed_storage` isn't in either crate's default features) and not production-ready.
+macro_rules! test_with_reservation_capable_storage_impls {
+    ($function:ident) => {
+        paste::item! {
+            #[tokio::test]
+            async fn [<$function _in_memory_storage>]() {
+                let rate_limiter =
+                    RateLimiter::new_with_storage(Box::<InMemoryStorage>::default());
+                $function(&mut TestsLimiter::new_from_blocking_impl(rate_limiter)).await;
+            }
+
+            #[cfg(feature = "disk_storage")]
+            #[tokio::test]
+            async fn [<$function _disk_storage>]() {
+                let dir = TempDir::new().expect("We should have a dir!");
+                let rate_limiter =
+                    RateLimiter::new_with_storage(Box::new(DiskStorage::open(dir.path(), OptimizeFor::Throughput).expect("Couldn't open temp dir")));
+                $function(&mut TestsLimiter::new_from_blocking_impl(rate_limiter)).await;
+            }
+
+            #[cfg(feature = "redis_storage")]
+            #[tokio::test]
+            #[serial]
+            async fn [<$function _with_sync_redis>]() {
+                let storage = RedisStorage::default();
+                storage.clear().unwrap();
+                let rate_limiter = RateLimiter::new_with_storage(
+                    Box::new(storage)
+                );
+                $function(&mut TestsLimiter::new_from_blocking_impl(rate_limiter)).await;
+            }
+
+            #[cfg(feature = "redis_storage")]
+            #[tokio::test]
+            #[serial]
+            async fn [<$function _with_async_redis>]() {
+                let storage = AsyncRedisStorage::new("redis://127.0.0.1:6379").await.expect("We need a Redis running locally");
+                storage.clear().await.unwrap();
+                let rate_limiter = AsyncRateLimiter::new_with_storage(
+                    Box::new(storage)
+                );
+                $function(&mut TestsLimiter::new_from_async_impl(rate_limiter)).await;
+            }
+
+            #[cfg(feature = "redis_storage")]
+            #[tokio::test]
+            #[serial]
+            async fn [<$function _with_async_redis_and_local_cache>]() {
+                let storage_builder = CachedRedisStorageBuilder::new("redis://127.0.0.1:6379").
+                    flushing_period(Duration::from_millis(2)).
+                    max_cached_counters(10000);
+                let storage = storage_builder.build().await.expect("We need a Redis running locally");
+                storage.clear().await.unwrap();
+                let rate_limiter = AsyncRateLimiter::new_with_storage(
+                    Box::new(storage)
+                );
+                $function(&mut TestsLimiter::new_from_async_impl(rate_limiter)).await;
+            }
+        }
+    };
+}
+
 #[cfg(feature = "distributed_storage")]
 async fn distributed_storage_factory(
     count: usize,
@@ -159,7 +226,7 @@ mod test {
     use self::limitador::counter::Counter;
     use self::limitador::RateLimiter;
     use crate::helpers::tests_limiter::*;
-    use limitador::limit::Limit;
+    use limitador::limit::{Context, Expression, Limit};
     #[cfg(feature = "disk_storage")]
     use limitador::storage::disk::{DiskStorage, OptimizeFor};
     #[cfg(feature = "distributed_storage")]
@@ -208,6 +275,13 @@ mod test {
     test_with_all_storage_impls!(configure_with_deletes_all_except_the_limits_given);
     test_with_all_storage_impls!(configure_with_updates_the_limits);
     test_with_all_storage_impls!(add_limit_only_adds_if_not_present);
+
+    test_with_reservation_capable_storage_impls!(reserve_accounts_for_outstanding_reservations);
+    test_with_reservation_capable_storage_impls!(
+        commit_reservation_applies_actual_amount_and_releases_hold
+    );
+    test_with_reservation_capable_storage_impls!(reserve_without_matching_limits_is_a_noop);
+    test_with_reservation_capable_storage_impls!(expired_reservations_do_not_count_as_outstanding);
 
     test_with_distributed_storage_impls!(distributed_rate_limited);
 
@@ -1280,6 +1354,118 @@ mod test {
         let known_limit = limits.iter().next().unwrap();
         assert_eq!(known_limit.max_value(), 10);
         assert_eq!(known_limit.name(), None);
+    }
+
+    async fn reserve_accounts_for_outstanding_reservations(rate_limiter: &mut TestsLimiter) {
+        let namespace = "reservations";
+        let limit = Limit::new(namespace, 10, 60, vec![], Vec::<Expression>::default());
+        rate_limiter.add_limit(&limit).await;
+
+        let ctx = Context::default();
+
+        let first = rate_limiter
+            .reserve(namespace, &ctx, 6, Duration::from_secs(30), false)
+            .await
+            .unwrap();
+        assert!(!first.limited);
+        assert!(first.reservation_id.is_some());
+
+        // value(0) + outstanding(6) + 6 = 12 > 10: rejected
+        let second = rate_limiter
+            .reserve(namespace, &ctx, 6, Duration::from_secs(30), false)
+            .await
+            .unwrap();
+        assert!(second.limited);
+        assert!(second.reservation_id.is_none());
+
+        // value(0) + outstanding(6) + 4 = 10 <= 10: admitted
+        let third = rate_limiter
+            .reserve(namespace, &ctx, 4, Duration::from_secs(30), false)
+            .await
+            .unwrap();
+        assert!(!third.limited);
+    }
+
+    async fn commit_reservation_applies_actual_amount_and_releases_hold(
+        rate_limiter: &mut TestsLimiter,
+    ) {
+        let namespace = "commit";
+        let limit = Limit::new(namespace, 10, 60, vec![], Vec::<Expression>::default());
+        rate_limiter.add_limit(&limit).await;
+
+        let ctx = Context::default();
+
+        let reserved = rate_limiter
+            .reserve(namespace, &ctx, 6, Duration::from_secs(30), false)
+            .await
+            .unwrap();
+        let reservation_id = reserved.reservation_id.expect("should be admitted");
+
+        // Still held: 0 + outstanding(6) + 6 = 12 > 10
+        let blocked = rate_limiter
+            .reserve(namespace, &ctx, 6, Duration::from_secs(30), false)
+            .await
+            .unwrap();
+        assert!(blocked.limited);
+
+        // Real usage turned out lower than the estimate
+        let commit = rate_limiter
+            .commit_reservation(namespace, &ctx, &reservation_id, 2)
+            .await
+            .unwrap();
+        assert!(commit.reservation_released);
+
+        // Committing again is a no-op release, but still applies actual_amount unconditionally
+        let second_commit = rate_limiter
+            .commit_reservation(namespace, &ctx, &reservation_id, 2)
+            .await
+            .unwrap();
+        assert!(!second_commit.reservation_released);
+
+        // Counter is now at 4 (2 + 2) with no outstanding reservations: 4 + 6 = 10 <= 10
+        let after = rate_limiter
+            .reserve(namespace, &ctx, 6, Duration::from_secs(30), false)
+            .await
+            .unwrap();
+        assert!(!after.limited);
+    }
+
+    async fn reserve_without_matching_limits_is_a_noop(rate_limiter: &mut TestsLimiter) {
+        let result = rate_limiter
+            .reserve(
+                "empty",
+                &Context::default(),
+                5,
+                Duration::from_secs(10),
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(!result.limited);
+        assert!(result.reservation_id.is_none());
+    }
+
+    async fn expired_reservations_do_not_count_as_outstanding(rate_limiter: &mut TestsLimiter) {
+        let namespace = "expiry";
+        let limit = Limit::new(namespace, 10, 60, vec![], Vec::<Expression>::default());
+        rate_limiter.add_limit(&limit).await;
+
+        let ctx = Context::default();
+
+        // A zero ttl means this reservation is already expired by the time we look at it
+        // again.
+        let first = rate_limiter
+            .reserve(namespace, &ctx, 8, Duration::ZERO, false)
+            .await
+            .unwrap();
+        assert!(!first.limited);
+
+        // The first reservation is already expired, so another 8 fits again: 0 + 0 + 8 <= 10
+        let second = rate_limiter
+            .reserve(namespace, &ctx, 8, Duration::from_secs(30), false)
+            .await
+            .unwrap();
+        assert!(!second.limited);
     }
 
     #[allow(dead_code)]

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -1621,14 +1621,8 @@ mod test {
             .await
             .unwrap();
         assert!(!result.limited);
-        let reservation_id = result.reservation_id.expect("should be admitted");
-
-        // Nothing was actually held, so there's nothing to release.
-        let commit = rate_limiter
-            .commit_reservation(namespace, &ctx, &reservation_id, 0)
-            .await
-            .unwrap();
-        assert!(!commit.reservation_released);
+        // Nothing was actually held, so there's no `reservation_id` to later release.
+        assert!(result.reservation_id.is_none());
     }
 
     async fn reserve_denies_amount_zero_when_already_over_limit(rate_limiter: &mut TestsLimiter) {

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -1482,14 +1482,14 @@ mod test {
 
         // Real usage turned out lower than the estimate
         let commit = rate_limiter
-            .commit_reservation(namespace, &ctx, &reservation_id, 2)
+            .commit_reservation(namespace, &ctx, Some(&reservation_id), 2)
             .await
             .unwrap();
         assert!(commit.reservation_released);
 
         // Committing again is a no-op release, but still applies actual_amount unconditionally
         let second_commit = rate_limiter
-            .commit_reservation(namespace, &ctx, &reservation_id, 2)
+            .commit_reservation(namespace, &ctx, Some(&reservation_id), 2)
             .await
             .unwrap();
         assert!(!second_commit.reservation_released);
@@ -1524,7 +1524,7 @@ mod test {
         let reservation_id = reserved.reservation_id.expect("should be admitted");
 
         let commit = rate_limiter
-            .commit_reservation(namespace, &ctx, &reservation_id, 9)
+            .commit_reservation(namespace, &ctx, Some(&reservation_id), 9)
             .await
             .unwrap();
         assert!(commit.reservation_released);

--- a/limitador/tests/integration_tests.rs
+++ b/limitador/tests/integration_tests.rs
@@ -1468,6 +1468,113 @@ mod test {
         assert!(!second.limited);
     }
 
+    // RFC 0021's motivating scenario against the shared, Redis-backed path: N concurrent
+    // in-flight requests racing to reserve capacity against one limit. Unlike the local
+    // (in-memory) path, this is expected to already be safe regardless of threading, since
+    // the entire check-and-write happens inside one atomic Lua script executed by Redis.
+    #[cfg(feature = "redis_storage")]
+    #[test]
+    #[serial]
+    fn concurrent_reserve_calls_never_exceed_the_limit_with_sync_redis() {
+        use limitador::storage::redis::RedisStorage;
+        use limitador::RateLimiter;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        const MAX_VALUE: u64 = 50;
+        const AMOUNT: u64 = 5;
+        const CONCURRENT_REQUESTS: usize = 20;
+
+        let storage = RedisStorage::default();
+        storage.clear().unwrap();
+        let rl = Arc::new(RateLimiter::new_with_storage(Box::new(storage)));
+        let namespace = "sync_redis_race";
+        let limit = Limit::new(
+            namespace,
+            MAX_VALUE,
+            60,
+            vec![],
+            Vec::<Expression>::default(),
+        );
+        rl.add_limit(limit);
+        let ns: limitador::limit::Namespace = namespace.into();
+
+        let admitted_count = Arc::new(AtomicUsize::new(0));
+        std::thread::scope(|s| {
+            for _ in 0..CONCURRENT_REQUESTS {
+                let rl = rl.clone();
+                let ns = ns.clone();
+                let admitted_count = admitted_count.clone();
+                s.spawn(move || {
+                    let ctx = Context::default();
+                    let res = rl
+                        .reserve(&ns, &ctx, AMOUNT, Duration::from_secs(30), false)
+                        .unwrap();
+                    if !res.limited {
+                        admitted_count.fetch_add(1, Ordering::SeqCst);
+                    }
+                });
+            }
+        });
+
+        let expected = (MAX_VALUE / AMOUNT) as usize;
+        assert_eq!(admitted_count.load(Ordering::SeqCst), expected);
+    }
+
+    #[cfg(feature = "redis_storage")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[serial]
+    async fn concurrent_reserve_calls_never_exceed_the_limit_with_async_redis() {
+        use limitador::storage::redis::AsyncRedisStorage;
+        use limitador::AsyncRateLimiter;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        const MAX_VALUE: u64 = 50;
+        const AMOUNT: u64 = 5;
+        const CONCURRENT_REQUESTS: usize = 20;
+
+        let storage = AsyncRedisStorage::new("redis://127.0.0.1:6379")
+            .await
+            .expect("We need a Redis running locally");
+        storage.clear().await.unwrap();
+        let rl = Arc::new(AsyncRateLimiter::new_with_storage(Box::new(storage)));
+        let namespace = "async_redis_race";
+        let limit = Limit::new(
+            namespace,
+            MAX_VALUE,
+            60,
+            vec![],
+            Vec::<Expression>::default(),
+        );
+        rl.add_limit(limit);
+        let ns: limitador::limit::Namespace = namespace.into();
+
+        let admitted_count = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::with_capacity(CONCURRENT_REQUESTS);
+        for _ in 0..CONCURRENT_REQUESTS {
+            let rl = rl.clone();
+            let ns = ns.clone();
+            let admitted_count = admitted_count.clone();
+            handles.push(tokio::spawn(async move {
+                let ctx = Context::default();
+                let res = rl
+                    .reserve(&ns, &ctx, AMOUNT, Duration::from_secs(30), false)
+                    .await
+                    .unwrap();
+                if !res.limited {
+                    admitted_count.fetch_add(1, Ordering::SeqCst);
+                }
+            }));
+        }
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        let expected = (MAX_VALUE / AMOUNT) as usize;
+        assert_eq!(admitted_count.load(Ordering::SeqCst), expected);
+    }
+
     #[allow(dead_code)]
     async fn distributed_rate_limited<Fut>(create_distributed_limiters: fn(count: usize) -> Fut)
     where


### PR DESCRIPTION
Fixes #506

### Verification steps

Run the `sandbox` dev environment:

```bash
cd limitador-server/sandbox
docker rmi limitador-testing:latest
make build
make deploy-in-memory
```

In a separate shell, install [grpcurl](https://github.com/fullstorydev/grpcurl) (needs [Go SDK 1.18+](https://golang.org/doc/install)):

```bash
make grpcurl
```

Inspect the `RateLimitService` GRPC service — it should now list `Reserve` and `Commit` alongside `CheckRateLimit`/`Report`:

```bash
bin/grpcurl -plaintext 127.0.0.1:18081 describe kuadrant.service.ratelimit.v1.RateLimitService
```
```
kuadrant.service.ratelimit.v1.RateLimitService is a service:
service RateLimitService {
  rpc CheckRateLimit ( .envoy.service.ratelimit.v3.RateLimitRequest ) returns ( .envoy.service.ratelimit.v3.RateLimitResponse );
  rpc Report ( .envoy.service.ratelimit.v3.RateLimitRequest ) returns ( .envoy.service.ratelimit.v3.RateLimitResponse );
  rpc Reserve ( .kuadrant.service.ratelimit.v1.ReserveRequest ) returns ( .kuadrant.service.ratelimit.v1.ReserveResponse );
  rpc Commit ( .kuadrant.service.ratelimit.v1.CommitRequest ) returns ( .kuadrant.service.ratelimit.v1.CommitResponse );
}
```

The sandbox's `limits.yaml` has a `GET`/`req.path: /` limit of max 10 req in a 60s window. Reserve 1 unit of estimated capacity against it:

```bash
bin/grpcurl -plaintext -d @ 127.0.0.1:18081 kuadrant.service.ratelimit.v1.RateLimitService.Reserve <<EOM
{
    "domain": "test_namespace",
    "amount": 1,
    "ttl": "60s",
    "descriptors": [
        {"entries": [
            {"key": "req.method", "value": "GET"},
            {"key": "req.path", "value": "/"}
        ]}
    ]
}
EOM
```

Expected response — `OK`, with a `reservationId` to keep for later:

```json
{
  "code": "OK",
  "reservationId": "<uuid>"
}
```

Note the counter itself is untouched by the reservation alone — `remaining` still shows 10, since the hold lives separately from the counter's own value until `Commit` applies it:

```bash
curl -s http://127.0.0.1:18080/counters/test_namespace | yq e -P
```

Reserve 1 more unit, 9 more times. Even though the counter's own value is still 0, the outstanding holds from these (plus the one above) fill the limit of 10 - the 10th call in this loop is the last one that should still be `OK`:

```bash
for i in $(seq 1 9); do
  bin/grpcurl -plaintext -d @ 127.0.0.1:18081 kuadrant.service.ratelimit.v1.RateLimitService.Reserve <<EOM
{
    "domain": "test_namespace",
    "amount": 1,
    "ttl": "60s",
    "descriptors": [{"entries": [{"key": "req.method", "value": "GET"}, {"key": "req.path", "value": "/"}]}]
}
EOM
done
```

One more `Reserve` call now returns `OVER_LIMIT`, since outstanding reservations already total 10:

```bash
bin/grpcurl -plaintext -d @ 127.0.0.1:18081 kuadrant.service.ratelimit.v1.RateLimitService.Reserve <<EOM
{
    "domain": "test_namespace",
    "amount": 1,
    "ttl": "60s",
    "descriptors": [
        {"entries": [
            {"key": "req.method", "value": "GET"},
            {"key": "req.path", "value": "/"}
        ]}
    ]
}
EOM
```
```json
{
  "code": "OVER_LIMIT"
}
```

Resolve the first reservation with `Commit`, reporting real usage:

```bash
bin/grpcurl -plaintext -d @ 127.0.0.1:18081 kuadrant.service.ratelimit.v1.RateLimitService.Commit <<EOM
{
    "domain": "test_namespace",
    "reservationId": "<paste the reservation_id here>",
    "actualAmount": 1,
    "descriptors": [
        {"entries": [
            {"key": "req.method", "value": "GET"},
            {"key": "req.path", "value": "/"}
        ]}
    ]
}
EOM
```

Expected response, and the reservation's hold is now released:

```json
{
  "reservationReleased": true
}
```

Committing the *same* `reservationId` again (already released) degrades gracefully: `actualAmount` is still applied to the counter unconditionally, but nothing is released this time. The expected response is an **empty object**, not `{"reservationReleased": false}`:

```bash
bin/grpcurl -plaintext -d @ 127.0.0.1:18081 kuadrant.service.ratelimit.v1.RateLimitService.Commit <<EOM
{
    "domain": "test_namespace",
    "reservationId": "<the same reservation_id again>",
    "actualAmount": 1,
    "descriptors": [
        {"entries": [
            {"key": "req.method", "value": "GET"},
            {"key": "req.path", "value": "/"}
        ]}
    ]
}
EOM
```
```json
{}
```

The counter now reflects the committed usage:

```bash
curl -s http://127.0.0.1:18080/counters/test_namespace | yq e -P
```
```yaml
- limit:
    namespace: test_namespace
    max_value: 10
    seconds: 60
    conditions:
      - descriptors[0]['req.method'] == 'GET'
      - descriptors[0]['req.path'] != '/json'
    variables: []
  set_variables: {}
  remaining: 8
  expires_in_seconds: <=60
```

### Clean up
```
make clean
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rate-limit reservations, allowing estimated capacity to be held and later committed using actual usage.
  * Added Reserve and Commit gRPC operations with reservation identifiers, expiry handling, and configurable limits.
  * Added command-line options to disable reservations and configure reservation fraction and TTL.
  * Added reservation support across in-memory, disk, Redis, and cached Redis storage.

* **Documentation**
  * Added sandbox examples for reserving and committing capacity.
  * Clarified that testing requires Redis 7.0 or newer.

* **Chores**
  * Updated sandbox Redis images to Redis 7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->